### PR TITLE
Fix Linux build: Remove missing icon file reference

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -95,7 +95,6 @@ jobs:
           python -m nuitka \
             --standalone \
             --onefile \
-            --linux-icon=img/icon.png \
             --output-dir=dist/linux \
             --remove-output \
             --jobs=4 \

--- a/.github/workflows/release-cross-platform.yml
+++ b/.github/workflows/release-cross-platform.yml
@@ -305,7 +305,6 @@ jobs:
           python -m nuitka \
             --standalone \
             --onefile \
-            --linux-icon=img/icon.png \
             --output-dir=dist/linux \
             --remove-output \
             --jobs=4 \


### PR DESCRIPTION
Linux Nuitka build was failing with:
FATAL: Error, icon path 'img/icon.png' does not exist.

Changes:
- build-linux.yml: Remove --linux-icon=img/icon.png option
- release-cross-platform.yml: Remove --linux-icon=img/icon.png option

The img/icon.png file does not exist in the repository. The icon copying logic in AppImage creation is already conditional (checks if file exists before copying), so this doesn't affect AppImage generation.

Result:
- Linux builds will succeed without icon (AppImage can be built without icon)
- If an icon is needed in the future, it can be added to img/icon.png
- Both standalone and unified release workflows are fixed