### PR TITLE
Fix Linux build failure: Remove non-existent icon file reference

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -95,7 +95,6 @@ jobs:
           python -m nuitka \
             --standalone \
             --onefile \
-            --linux-icon=img/icon.png \
             --output-dir=dist/linux \
             --remove-output \
             --jobs=4 \


### PR DESCRIPTION
리눅스 빌드 실패 원인 수정:
- .github/workflows/build-linux.yml: --linux-icon=img/icon.png 옵션 제거
- img/icon.png 파일이 존재하지 않아 빌드가 실패했음
- 아이콘은 AppImage 생성 단계에서 별도로 처리됨

오류:
FATAL: Error, icon path 'img/icon.png' does not exist.

수정 후:
- Nuitka 빌드는 아이콘 없이 진행
- AppImage에서는 기존 이미지 파일을 사용하거나 없으면 스킵