### PR TITLE
Improve inverse filter generation for external WAV files

### DIFF
--- a/impulse_response_estimator.py
+++ b/impulse_response_estimator.py
@@ -259,9 +259,16 @@ class ImpulseResponseEstimator(object):
             ire = cls(min_duration=1.0, fs=fs)  # Minimal duration
             ire.test_signal = data_for_comparison
             ire.duration = len(data_for_comparison) / fs
-            # For non-sweep signals, we can't generate a proper inverse filter
-            # Use a simple approach
-            ire.inverse_filter = np.flip(data_for_comparison) / np.sum(data_for_comparison**2)
+
+            # Try to generate proper inverse filter for log sweep signals
+            # using the class's generate_inverse_filter() method
+            try:
+                ire.inverse_filter = ire.generate_inverse_filter()
+            except Exception:
+                # If that fails, fall back to simple linear inversion
+                # This works for non-sweep signals but may be inaccurate for log sweeps
+                print("Warning: Using fallback linear inversion. Result may be inaccurate for Log Sweeps.")
+                ire.inverse_filter = np.flip(data_for_comparison) / np.sum(data_for_comparison**2)
             
         return ire
 


### PR DESCRIPTION
When loading external WAV files (like TrueHD conversions), try to use the proper log sweep inverse filter formula (generate_inverse_filter) before falling back to simple linear inversion.

The generate_inverse_filter() method uses the mathematically correct formula for log sweeps from Angelo Farina's paper, which produces more accurate impulse response estimates compared to simple time-reversal with energy normalization.

If generate_inverse_filter() fails (e.g., for non-sweep signals), fall back to the simple linear inversion with a warning message.