### PR TITLE
Fix ImpulseResponse instantiation error in parallel workers

### DIFF
--- a/benchmark_parallel.py
+++ b/benchmark_parallel.py
@@ -57,8 +57,8 @@ def benchmark_normalize():
         for speaker in speakers[:12]:  # 12채널 테스트
             data = np.random.randn(48000)  # 1초 길이 랜덤 데이터
             hrir.irs[speaker] = {
-                'left': ImpulseResponse(name=f'{speaker}-left', fs=48000, data=data.copy()),
-                'right': ImpulseResponse(name=f'{speaker}-right', fs=48000, data=data.copy())
+                'left': ImpulseResponse(data=data.copy(), fs=48000),
+                'right': ImpulseResponse(data=data.copy(), fs=48000)
             }
 
         print(f"  채널 수: {len(hrir.irs)} (좌우 합계 {len(hrir.irs)*2})")

--- a/impulcifer.py
+++ b/impulcifer.py
@@ -395,7 +395,7 @@ def _process_decay_worker(args):
     from impulse_response import ImpulseResponse
 
     # Create temporary IR object
-    temp_ir = ImpulseResponse(name=f'{speaker}-{side}', data=ir_data.copy(), fs=fs)
+    temp_ir = ImpulseResponse(data=ir_data.copy(), fs=fs)
     temp_ir.adjust_decay(decay_value)
 
     return (speaker, side, temp_ir.data)
@@ -417,7 +417,7 @@ def _process_plot_worker(args):
     from impulse_response import ImpulseResponse
 
     # Create temporary IR object
-    temp_ir = ImpulseResponse(name=f'{speaker}-{side}', data=ir_data.copy(), fs=fs)
+    temp_ir = ImpulseResponse(data=ir_data.copy(), fs=fs)
     recording = temp_ir.convolve(test_signal)
 
     return (speaker, side, recording)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "impulcifer-py313"
-version = "2.2.5"
+version = "2.2.6"
 authors = [
   { name="원본 저자: Jaakko Pasanen", email="" },
   { name="Python 3.13/3.14 호환 버전: 115dkk", email="" },


### PR DESCRIPTION
Remove incorrect 'name' keyword argument from ImpulseResponse() calls in _process_decay_worker and _process_plot_worker functions. The ImpulseResponse class only accepts (data, fs, recording=None).

This fixes the error:
"ImpulseResponse.__init__() got an unexpected keyword argument 'name'" that occurred during "Plotting BRIR graphs after processing".

Also fixes the same issue in benchmark_parallel.py.

Bumps version to 2.2.6.