### PR TITLE
Fix linter errors (F541, F841)

### DIFF
--- a/impulcifer.py
+++ b/impulcifer.py
@@ -1055,7 +1055,7 @@ def headphone_compensation(estimator, dir_path, headphone_file_path=None):
         # Check if it's a directory or a file
         if os.path.isdir(normalized_path):
             # It's a directory - search for common headphone file names
-            logger.info(f"Path is a directory, searching for headphone compensation file inside...")
+            logger.info("Path is a directory, searching for headphone compensation file inside...")
             possible_names = ["headphones.wav", "headphone.wav", "hp.wav", "compensation.wav"]
             actual_hp_file = None
 

--- a/modern_gui.py
+++ b/modern_gui.py
@@ -485,7 +485,7 @@ class UpdateDialog(ctk.CTkToplevel):
                 )
             else:
                 # On Unix-like systems, capture output
-                process = subprocess.Popen(
+                _process = subprocess.Popen(
                     upgrade_cmd,
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "impulcifer-py313"
-version = "2.2.7"
+version = "2.2.8"
 authors = [
   { name="원본 저자: Jaakko Pasanen", email="" },
   { name="Python 3.13/3.14 호환 버전: 115dkk", email="" },


### PR DESCRIPTION
- impulcifer.py:1058 - Remove unnecessary f-string prefix (no placeholders)
- modern_gui.py:488 - Prefix unused variable with underscore

Version bump: 2.2.7 -> 2.2.8