### PR TITLE
fix: add vbass_ prefix to logger translation and bump to v2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ first number changes, something has broken and you need to check your commands a
 changes there are only new features available and nothing old has broken and when the last number changes, old bugs have
 been fixed and old features improved.
 
+## 2.4.1 - 2026-02-27
+### 🔧 Virtual Bass 로거 번역 수정
+- `vbass_` 접두사가 로거 자동 번역 시스템에서 누락되어 번역 키가 그대로 출력되던 문제 수정
+- `logger.py`의 `_translate()` 접두사 목록에 `vbass_` 추가
+
+---
+
 ## 2.4.0 - 2026-02-27
 ### 🎵 가상 베이스 (Virtual Bass) 합성 기능 추가
 저주파 대역을 합성된 미니멈 페이즈 베이스로 교체하여 서브베이스 응답을 개선하는 기능을 추가했습니다.

--- a/impulcifer.py
+++ b/impulcifer.py
@@ -36,7 +36,7 @@ def _get_version() -> str:
             pass
 
     # Fallback
-    return "2.4.0"
+    return "2.4.1"
 
 __version__ = _get_version()
 

--- a/logger.py
+++ b/logger.py
@@ -69,7 +69,7 @@ class ImpulciferLogger:
             return message
 
         # If message starts with common prefixes, treat as translation key
-        if message.startswith(('cli_', 'message_', 'error_', 'warning_', 'success_', 'info_')):
+        if message.startswith(('cli_', 'message_', 'error_', 'warning_', 'success_', 'info_', 'vbass_')):
             return self.localization.get(message, **kwargs)
 
         # Otherwise return as-is (allows mixing translated and non-translated messages)

--- a/modern_gui.py
+++ b/modern_gui.py
@@ -1863,7 +1863,7 @@ class ModernImpulciferGUI:
 
         # Fallback: Unknown version
         print("Warning: Could not determine version, using fallback")
-        return "2.4.0"  # Current known version as last resort
+        return "2.4.1"  # Current known version as last resort
 
     def check_for_updates_background(self):
         """Check for updates in background thread"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "impulcifer-py313"
-version = "2.4.0"
+version = "2.4.1"
 authors = [
   { name="원본 저자: Jaakko Pasanen", email="" },
   { name="Python 3.13/3.14 호환 버전: 115dkk", email="" },


### PR DESCRIPTION
The logger's _translate() only recognized cli_, message_, error_, warning_, success_, info_ prefixes for auto-translation. vbass_ keys were output as raw strings instead of translated text.

https://claude.ai/code/session_01X8sRpfCKK7HzBcQxT7XM2V