### PR TITLE
fix: correct all CI/CD path references for get_version.py and build_n…

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -77,8 +77,7 @@ jobs:
 
       - name: Read project version and set APP_VERSION
         run: |
-          python get_version.py
-          APP_VERSION=$(python get_version.py)
+          APP_VERSION=$(python infra/get_version.py)
           echo "APP_VERSION=$APP_VERSION" >> $GITHUB_ENV
           echo "Building version: $APP_VERSION"
 

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -58,8 +58,7 @@ jobs:
 
       - name: Read project version and set APP_VERSION
         run: |
-          python get_version.py
-          APP_VERSION=$(python get_version.py)
+          APP_VERSION=$(python infra/get_version.py)
           echo "APP_VERSION=$APP_VERSION" >> $GITHUB_ENV
           echo "Building version: $APP_VERSION"
 

--- a/.github/workflows/release-cross-platform.yml
+++ b/.github/workflows/release-cross-platform.yml
@@ -63,8 +63,7 @@ jobs:
 
       - name: Read project version and set APP_VERSION
         run: |
-          python get_version.py
-          APP_VERSION=$(python get_version.py)
+          APP_VERSION=$(python infra/get_version.py)
           echo "APP_VERSION=$APP_VERSION" >> $GITHUB_ENV
           echo "Building version: $APP_VERSION"
         shell: bash
@@ -72,7 +71,7 @@ jobs:
       - name: Run Nuitka build using build_nuitka.py
         run: |
           echo "[2/3] Starting optimized Nuitka build for Windows..."
-          python build_nuitka.py
+          python build_scripts/build_nuitka.py
           echo "NUITKA_OUTPUT_DIR=${{ github.workspace }}\dist\Impulcifer_Distribution\ImpulciferGUI" >> $GITHUB_ENV
           echo "PROJECT_ROOT_FOR_ISS=${{ github.workspace }}" >> $GITHUB_ENV
           echo "ISS_PATH=${{ github.workspace }}\.github\workflows\Output" >> $GITHUB_ENV
@@ -167,7 +166,7 @@ jobs:
 
       - name: Read project version
         run: |
-          APP_VERSION=$(python get_version.py)
+          APP_VERSION=$(python infra/get_version.py)
           echo "APP_VERSION=$APP_VERSION" >> $GITHUB_ENV
 
       - name: Run Nuitka build for macOS
@@ -348,7 +347,7 @@ jobs:
 
       - name: Read project version
         run: |
-          APP_VERSION=$(python get_version.py)
+          APP_VERSION=$(python infra/get_version.py)
           echo "APP_VERSION=$APP_VERSION" >> $GITHUB_ENV
 
       - name: Run Nuitka build for Linux
@@ -604,7 +603,7 @@ jobs:
 
       - name: Get version
         run: |
-          APP_VERSION=$(python get_version.py)
+          APP_VERSION=$(python infra/get_version.py)
           echo "APP_VERSION=$APP_VERSION" >> $GITHUB_ENV
           echo "Version: $APP_VERSION"
 

--- a/infra/get_version.py
+++ b/infra/get_version.py
@@ -1,40 +1,25 @@
+"""Read project version from pyproject.toml and print to stdout."""
 import os
 import sys
 
-try:
-    # Python 3.11+
-    import tomllib
-
-    def load_toml_config(file_path):
-        with open(file_path, 'rb') as f:
-            return tomllib.load(f)
-
-except ImportError:
-    # Python < 3.11
-    import toml
-
-    def load_toml_config(file_path):
-        with open(file_path, 'r', encoding='utf-8') as f:
-            return toml.load(f)
-
+# pyproject.toml is always at the project root
+script_dir = os.path.dirname(os.path.abspath(__file__))
+project_root = os.path.dirname(script_dir)
+toml_path = os.path.join(project_root, "pyproject.toml")
 
 try:
-    config = load_toml_config('pyproject.toml')
-    app_version = config['project']['version']
+    try:
+        # Python 3.11+
+        import tomllib
+        with open(toml_path, "rb") as f:
+            config = tomllib.load(f)
+    except ImportError:
+        # Python < 3.11
+        import toml
+        with open(toml_path, "r", encoding="utf-8") as f:
+            config = toml.load(f)
 
-    # 표준 출력으로는 버전 정보만 출력
-    print(app_version)
-
-    # GITHUB_ENV 파일에 APP_VERSION 설정 (기존 로직 유지)
-    github_env_file = os.getenv('GITHUB_ENV')
-    if github_env_file:
-        with open(github_env_file, 'a', encoding='utf-8') as env_f:
-            env_f.write(f"APP_VERSION={app_version}\n")
-        # 정보성 메시지는 stderr로 출력하거나 로깅 시스템 사용 (또는 제거)
-        print(f"Info: APP_VERSION set to {app_version} in GITHUB_ENV", file=sys.stderr)
-    else:
-        print("Error: GITHUB_ENV not found.", file=sys.stderr)
-        sys.exit(1)
+    print(config["project"]["version"])
 except Exception as e:
-    print(f"Error in get_version.py: {e}", file=sys.stderr)
+    print(f"Error reading version: {e}", file=sys.stderr)
     sys.exit(1)


### PR DESCRIPTION
…uitka.py

- get_version.py is at infra/get_version.py, not root — fixed in all 4 workflow files (build-linux, build-macos, release-cross-platform)
- build_nuitka.py is at build_scripts/build_nuitka.py — fixed in release-cross-platform.yml
- Removed redundant double invocations of get_version.py
- Simplified get_version.py: uses absolute path to pyproject.toml so it works from any CWD, removed GITHUB_ENV writing (workflows handle it), no longer fails when GITHUB_ENV is unset (works locally)

https://claude.ai/code/session_01X8sRpfCKK7HzBcQxT7XM2V