### PR TITLE
fix: update all imports for restructured package layout, bump to v2.4.3

### DIFF
--- a/core/channel_generation.py
+++ b/core/channel_generation.py
@@ -38,7 +38,7 @@ def generate_missing_channels(hrir, auto_generate_config):
                             mixed_data += src_data
                     
                     # 새 IR 객체 생성
-                    from core.hrir import ImpulseResponse
+                    from core.impulse_response import ImpulseResponse
                     new_ir = ImpulseResponse(mixed_data, hrir.fs)
                     hrir.irs[channel_name][side] = new_ir
                 

--- a/gui/modern_gui.py
+++ b/gui/modern_gui.py
@@ -1863,7 +1863,7 @@ class ModernImpulciferGUI:
 
         # Fallback: Unknown version
         print("Warning: Could not determine version, using fallback")
-        return "2.4.2"  # Current known version as last resort
+        return "2.4.3"  # Current known version as last resort
 
     def check_for_updates_background(self):
         """Check for updates in background thread"""

--- a/impulcifer.py
+++ b/impulcifer.py
@@ -36,7 +36,7 @@ def _get_version() -> str:
             pass
 
     # Fallback
-    return "2.4.2"
+    return "2.4.3"
 
 __version__ = _get_version()
 
@@ -48,6 +48,8 @@ from datetime import datetime
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.ticker as ticker
+import matplotlib.font_manager as fm
+import importlib.resources
 from autoeq.frequency_response import FrequencyResponse
 from core.impulse_response_estimator import ImpulseResponseEstimator
 from core.hrir import HRIR, _get_center_value

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "impulcifer-py313"
-version = "2.4.2"
+version = "2.4.3"
 authors = [
   { name="원본 저자: Jaakko Pasanen", email="" },
   { name="Python 3.13/3.14 호환 버전: 115dkk", email="" },

--- a/research/headphone-feedback-compensation/compare_headphone_compensation_methods.py
+++ b/research/headphone-feedback-compensation/compare_headphone_compensation_methods.py
@@ -5,11 +5,11 @@ import sys
 import numpy as np
 import matplotlib.pyplot as plt
 from autoeq.frequency_response import FrequencyResponse
-sys.path.insert(1, os.path.realpath(os.path.join(sys.path[0], os.pardir)))
-from impulse_response_estimator import ImpulseResponseEstimator
-from hrir import HRIR
-from utils import sync_axes, save_fig_as_png, config_fr_axis
-from constants import COLORS
+sys.path.insert(1, os.path.realpath(os.path.join(sys.path[0], os.pardir, os.pardir)))
+from core.impulse_response_estimator import ImpulseResponseEstimator
+from core.hrir import HRIR
+from core.utils import sync_axes, save_fig_as_png, config_fr_axis
+from core.constants import COLORS
 
 DIR_PATH = os.path.abspath(os.path.join(__file__, os.pardir))
 TEST_SIGNAL = os.path.join(DIR_PATH, 'sweep-6.15s-48000Hz-32bit-2.93Hz-24000Hz.pkl')

--- a/research/headphone-feedback-compensation/generate_headphone_sweep_sequence.py
+++ b/research/headphone-feedback-compensation/generate_headphone_sweep_sequence.py
@@ -4,10 +4,10 @@ import os
 import sys
 import numpy as np
 import matplotlib.pyplot as plt
-sys.path.insert(1, os.path.realpath(os.path.join(sys.path[0], os.pardir)))
-from utils import write_wav
-from impulse_response_estimator import ImpulseResponseEstimator
-from hrir import HRIR
+sys.path.insert(1, os.path.realpath(os.path.join(sys.path[0], os.pardir, os.pardir)))
+from core.utils import write_wav
+from core.impulse_response_estimator import ImpulseResponseEstimator
+from core.hrir import HRIR
 
 DIR_PATH = os.path.abspath(os.path.join(__file__, os.pardir))
 TEST_SIGNAL = os.path.join(DIR_PATH, 'sweep-6.15s-48000Hz-32bit-2.93Hz-24000Hz.pkl')

--- a/research/headphone-reseat-repeatability/headphone_reseat_repeatability.py
+++ b/research/headphone-reseat-repeatability/headphone_reseat_repeatability.py
@@ -5,11 +5,11 @@ import sys
 from glob import glob
 import matplotlib.pyplot as plt
 import matplotlib.ticker as ticker
-sys.path.insert(1, os.path.realpath(os.path.join(sys.path[0], os.pardir)))
+sys.path.insert(1, os.path.realpath(os.path.join(sys.path[0], os.pardir, os.pardir)))
 from impulcifer import headphone_compensation
-from impulse_response_estimator import ImpulseResponseEstimator
-from impulse_response import ImpulseResponse
-from utils import read_wav, optimize_png_size, sync_axes
+from core.impulse_response_estimator import ImpulseResponseEstimator
+from core.impulse_response import ImpulseResponse
+from core.utils import read_wav, optimize_png_size, sync_axes
 
 DIR_PATH = os.path.abspath(os.path.join(__file__, os.pardir))
 

--- a/research/level-vs-balance/level_vs_balance.py
+++ b/research/level-vs-balance/level_vs_balance.py
@@ -9,10 +9,10 @@ import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.ticker as ticker
 from autoeq.frequency_response import FrequencyResponse
-sys.path.insert(1, os.path.realpath(os.path.join(sys.path[0], os.pardir)))
-from impulse_response_estimator import ImpulseResponseEstimator
-from hrir import HRIR
-from utils import save_fig_as_png, config_fr_axis
+sys.path.insert(1, os.path.realpath(os.path.join(sys.path[0], os.pardir, os.pardir)))
+from core.impulse_response_estimator import ImpulseResponseEstimator
+from core.hrir import HRIR
+from core.utils import save_fig_as_png, config_fr_axis
 
 DIR_PATH = os.path.abspath(os.path.join(__file__, os.pardir))
 

--- a/research/mic-calibration/mic_calibration.py
+++ b/research/mic-calibration/mic_calibration.py
@@ -8,10 +8,10 @@ import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.ticker as ticker
 from autoeq.frequency_response import FrequencyResponse
-sys.path.insert(1, os.path.realpath(os.path.join(sys.path[0], os.pardir)))
-from impulse_response_estimator import ImpulseResponseEstimator
-from hrir import HRIR
-from utils import optimize_png_size
+sys.path.insert(1, os.path.realpath(os.path.join(sys.path[0], os.pardir, os.pardir)))
+from core.impulse_response_estimator import ImpulseResponseEstimator
+from core.hrir import HRIR
+from core.utils import optimize_png_size
 
 
 DIR_PATH = os.path.abspath(os.path.join(__file__, os.pardir))

--- a/research/open-vs-closed-ear-canal/open_vs_closed_ear_canal.py
+++ b/research/open-vs-closed-ear-canal/open_vs_closed_ear_canal.py
@@ -5,11 +5,11 @@ import sys
 from glob import glob
 import matplotlib.pyplot as plt
 import matplotlib.ticker as ticker
-sys.path.insert(1, os.path.realpath(os.path.join(sys.path[0], os.pardir)))
+sys.path.insert(1, os.path.realpath(os.path.join(sys.path[0], os.pardir, os.pardir)))
 from impulcifer import headphone_compensation
-from impulse_response_estimator import ImpulseResponseEstimator
-from impulse_response import ImpulseResponse
-from utils import read_wav, optimize_png_size
+from core.impulse_response_estimator import ImpulseResponseEstimator
+from core.impulse_response import ImpulseResponse
+from core.utils import read_wav, optimize_png_size
 
 DIR_PATH = os.path.abspath(os.path.join(__file__, os.pardir))
 TEST_SIGNAL = os.path.join(DIR_PATH, 'sweep-6.15s-48000Hz-32bit-2.93Hz-24000Hz.pkl')

--- a/research/reverberation-management/lundeby.ipynb
+++ b/research/reverberation-management/lundeby.ipynb
@@ -27,20 +27,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from time import time\n",
-    "import numpy as np\n",
-    "from scipy import signal, stats\n",
-    "import matplotlib.pyplot as plt\n",
-    "from utils import read_wav, write_wav\n",
-    "from constants import HEXADECAGONAL_TRACK_ORDER, HESUVI_TRACK_ORDER, SPEAKER_NAMES\n",
-    "from impulse_response import ImpulseResponse\n",
-    "from impulse_response_estimator import ImpulseResponseEstimator\n",
-    "from hrir import HRIR"
-   ]
+   "source": "from time import time\nimport numpy as np\nfrom scipy import signal, stats\nimport matplotlib.pyplot as plt\nfrom core.utils import read_wav, write_wav\nfrom core.constants import HEXADECAGONAL_TRACK_ORDER, HESUVI_TRACK_ORDER, SPEAKER_NAMES\nfrom core.impulse_response import ImpulseResponse\nfrom core.impulse_response_estimator import ImpulseResponseEstimator\nfrom core.hrir import HRIR"
   },
   {
    "cell_type": "markdown",

--- a/research/reverberation-management/reverberation_management.py
+++ b/research/reverberation-management/reverberation_management.py
@@ -8,8 +8,8 @@ from scipy import signal
 from scipy.signal.windows import hann
 import matplotlib.pyplot as plt
 sys.path.insert(1, os.path.realpath(os.path.join(sys.path[0], os.pardir, os.pardir)))
-from utils import read_wav, write_wav
-from constants import HEXADECAGONAL_TRACK_ORDER, HESUVI_TRACK_ORDER, SPEAKER_NAMES
+from core.utils import read_wav, write_wav
+from core.constants import HEXADECAGONAL_TRACK_ORDER, HESUVI_TRACK_ORDER, SPEAKER_NAMES
 
 DIR_PATH = os.path.abspath(os.path.join(__file__, os.pardir))
 

--- a/research/room-targets/room_targets.py
+++ b/research/room-targets/room_targets.py
@@ -5,8 +5,8 @@ import sys
 import matplotlib.pyplot as plt
 import numpy as np
 from autoeq.frequency_response import FrequencyResponse
-sys.path.insert(1, os.path.realpath(os.path.join(sys.path[0], os.pardir)))
-from utils import optimize_png_size
+sys.path.insert(1, os.path.realpath(os.path.join(sys.path[0], os.pardir, os.pardir)))
+from core.utils import optimize_png_size
 
 DIR_PATH = os.path.abspath(os.path.join(__file__, os.pardir))
 

--- a/research/speaker-balance-graphs/speaker_balance_graphs.py
+++ b/research/speaker-balance-graphs/speaker_balance_graphs.py
@@ -3,10 +3,10 @@
 import os
 import sys
 import matplotlib.pyplot as plt
-sys.path.insert(1, os.path.realpath(os.path.join(sys.path[0], os.pardir)))
-from utils import read_wav, config_fr_axis, optimize_png_size
-from constants import COLORS
-from impulse_response import ImpulseResponse
+sys.path.insert(1, os.path.realpath(os.path.join(sys.path[0], os.pardir, os.pardir)))
+from core.utils import read_wav, config_fr_axis, optimize_png_size
+from core.constants import COLORS
+from core.impulse_response import ImpulseResponse
 
 DIR_PATH = os.path.abspath(os.path.join(__file__, os.pardir))
 TEST_SIGNAL = os.path.join(DIR_PATH, 'sweep-6.15s-48000Hz-32bit-2.93Hz-24000Hz.pkl')

--- a/research/virtual-room-target/virtual_room_target.py
+++ b/research/virtual-room-target/virtual_room_target.py
@@ -4,8 +4,8 @@ import os
 import sys
 import matplotlib.pyplot as plt
 from autoeq.frequency_response import FrequencyResponse
-sys.path.insert(1, os.path.realpath(os.path.join(sys.path[0], os.pardir)))
-from utils import optimize_png_size
+sys.path.insert(1, os.path.realpath(os.path.join(sys.path[0], os.pardir, os.pardir)))
+from core.utils import optimize_png_size
 
 DIR_PATH = os.path.abspath(os.path.join(__file__, os.pardir))
 


### PR DESCRIPTION
Production code:
- impulcifer.py: add missing `import importlib.resources` and `import matplotlib.font_manager as fm` (runtime NameError fix)
- core/channel_generation.py: import ImpulseResponse from core.impulse_response instead of core.hrir (correct source module)
- gui/modern_gui.py: update fallback version to 2.4.3

Research scripts (10 files + 1 notebook):
- Fix sys.path to go up 2 levels (project root), not 1 (research/)
- Update all bare imports to use package prefixes: utils → core.utils, constants → core.constants, impulse_response → core.impulse_response, impulse_response_estimator → core.impulse_response_estimator, hrir → core.hrir

Version bump: 2.4.2 → 2.4.3

https://claude.ai/code/session_01X8sRpfCKK7HzBcQxT7XM2V