### PR TITLE
feat: add ITD preservation to virtual bass synthesis, bump to v2.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ first number changes, something has broken and you need to check your commands a
 changes there are only new features available and nothing old has broken and when the last number changes, old bugs have
 been fixed and old features improved.
 
+## 2.4.4 - 2026-02-28
+### Virtual Bass ITD 반영
+- Virtual Bass: ITD(Interaural Time Difference) 반영 로직 추가. 합성된 bass IR에 원본 HRIR의 좌우 귀 도달 시간차를 보존하도록 개선.
+
+### Import 정리
+- `impulcifer.py`: 누락된 `importlib.resources`, `matplotlib.font_manager` import 추가
+- `core/channel_generation.py`: ImpulseResponse를 올바른 소스 모듈에서 import하도록 수정
+- `research/` 전체(10개 파일 + 1 notebook): `sys.path` 경로 수정 및 패키지 접두사 적용
+
+## 2.4.3 - 2026-02-28
+### Import 정리 및 경로 수정 (중간 릴리스)
+
 ## 2.4.2 - 2026-02-27
 ### 📁 프로젝트 구조 재편
 루트에 평면적으로 나열되어 있던 모듈들을 논리적 패키지 구조로 재편했습니다.

--- a/gui/modern_gui.py
+++ b/gui/modern_gui.py
@@ -1863,7 +1863,7 @@ class ModernImpulciferGUI:
 
         # Fallback: Unknown version
         print("Warning: Could not determine version, using fallback")
-        return "2.4.3"  # Current known version as last resort
+        return "2.4.4"  # Current known version as last resort
 
     def check_for_updates_background(self):
         """Check for updates in background thread"""

--- a/impulcifer.py
+++ b/impulcifer.py
@@ -36,7 +36,7 @@ def _get_version() -> str:
             pass
 
     # Fallback
-    return "2.4.3"
+    return "2.4.4"
 
 __version__ = _get_version()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "impulcifer-py313"
-version = "2.4.3"
+version = "2.4.4"
 authors = [
   { name="원본 저자: Jaakko Pasanen", email="" },
   { name="Python 3.13/3.14 호환 버전: 115dkk", email="" },


### PR DESCRIPTION
The synthesized bass IR now preserves the interaural time difference (ITD) from the original HRIR. Previously, both ears were aligned to the same head_ms position, losing spatial localization cues in the low frequencies.

Changes to core/virtual_bass.py:
- Compute ITD from original left/right IR peak positions before the per-side processing loop
- Replace uniform head_samples alignment (Step 9) with differential delay: ipsilateral ear gets base delay, contralateral ear gets base delay + |ITD|
- Center speakers get equal delay on both ears (no ITD)
- Gracefully handle missing ear (ITD defaults to 0)

Version bump: 2.4.3 → 2.4.4

https://claude.ai/code/session_01X8sRpfCKK7HzBcQxT7XM2V