### PR TITLE
fix: v2.4.9 - correct Velopack hook arg prefix + update UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ first number changes, something has broken and you need to check your commands a
 changes there are only new features available and nothing old has broken and when the last number changes, old bugs have
 been fixed and old features improved.
 
+## 2.4.9 - 2026-03-19
+### 🐛 Velopack 훅 인자명 수정 + 업데이트 UX 개선
+
+#### 🐛 버그 수정
+- **Velopack 라이프사이클 훅 인자명 수정**: Velopack은 `--veloapp-*` prefix를 사용하지만 코드가 `--velopack-*`을 검색하고 있어 모든 훅(설치/업데이트/제거)이 감지 실패
+  - `gui_main.py`: `--velopack-` → `--veloapp-` (공식 문서: https://docs.velopack.io/integrating/hooks)
+  - `build_nuitka.py`: 폴백 엔트리포인트에도 올바른 Velopack 훅 핸들러 추가
+
+#### ⭐ 개선
+- **업데이트 후 재시작 알림**: `VELOPACK_RESTART` 환경 변수 감지하여 업데이트 완료 메시지 표시
+- **업데이트 전 메시지 개선**: "앱이 종료됩니다. 잠시 후 자동으로 다시 시작됩니다." 안내 추가
+
 ## 2.4.8 - 2026-03-08
 ### 🐛 Velopack 설치 훅 + 메모리 회수
 

--- a/build_scripts/build_nuitka.py
+++ b/build_scripts/build_nuitka.py
@@ -266,8 +266,13 @@ def main():
             f.write("""#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 \"\"\"Impulcifer Modern GUI 엔트리 포인트\"\"\"
+import sys
 
 if __name__ == "__main__":
+    # Velopack lifecycle hooks (https://docs.velopack.io/integrating/hooks)
+    for arg in sys.argv[1:]:
+        if arg.startswith('--veloapp-'):
+            sys.exit(0)
     from gui.modern_gui import main_gui
     main_gui()
 """)

--- a/gui/modern_gui.py
+++ b/gui/modern_gui.py
@@ -592,7 +592,9 @@ class UpdateDialog(ctk.CTkToplevel):
                 # Show message before restart
                 self.after(0, lambda: messagebox.showinfo(
                     self.loc.get('update_complete_title', default="Update Ready"),
-                    self.loc.get('update_restart_message', default="The application will now restart to complete the update.")
+                    self.loc.get('update_restart_message',
+                                 default="The application will close to apply the update.\n"
+                                         "It will restart automatically in a few seconds.")
                 ))
 
                 updater.apply_and_restart()
@@ -705,6 +707,13 @@ class ModernImpulciferGUI:
 
         # Check for updates in background (after 2 seconds)
         self.root.after(2000, self.check_for_updates_background)
+
+        # Velopack 업데이트 후 재시작 감지 — 사용자에게 완료 알림
+        if os.environ.get('VELOPACK_RESTART'):
+            self.root.after(1000, lambda: messagebox.showinfo(
+                self.loc.get('update_complete_title', default="Update Complete"),
+                self.loc.get('update_restart_done', default="The new version has been installed successfully.")
+            ))
 
         # Set window size and position
         window_width = 1000
@@ -1847,7 +1856,7 @@ class ModernImpulciferGUI:
             pass
 
         # Fallback
-        return "2.4.8"
+        return "2.4.9"
 
     def check_for_updates_background(self):
         """Check for updates in background thread"""

--- a/gui_main.py
+++ b/gui_main.py
@@ -8,13 +8,14 @@ import sys
 def _handle_velopack_lifecycle():
     """Velopack 설치/업데이트/제거 훅 처리.
 
-    Velopack은 설치/업데이트/제거 시 실행 파일에 특수 인자를 전달합니다.
-    형식: --velopack-install <version>, --velopack-install=<version> 등
-    이 인자가 감지되면 GUI를 실행하지 않고 즉시 종료합니다.
+    Velopack 공식 문서: https://docs.velopack.io/integrating/hooks
+    인자 형식: --veloapp-install, --veloapp-updated, --veloapp-obsolete, --veloapp-uninstall
+    각 인자 뒤에 버전 문자열이 따라옴 (예: --veloapp-install 2.4.9)
+    타임아웃: install/uninstall 30초, updated/obsolete 15초
     """
     for arg in sys.argv[1:]:
-        if arg.startswith('--velopack-'):
-            if arg.startswith('--velopack-uninstall'):
+        if arg.startswith('--veloapp-'):
+            if arg.startswith('--veloapp-uninstall'):
                 _cleanup_on_uninstall()
             sys.exit(0)
 

--- a/impulcifer.py
+++ b/impulcifer.py
@@ -44,7 +44,7 @@ def _get_version() -> str:
         pass
 
     # Fallback
-    return "2.4.8"
+    return "2.4.9"
 
 __version__ = _get_version()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "impulcifer-py313"
-version = "2.4.8"
+version = "2.4.9"
 authors = [
   { name="원본 저자: Jaakko Pasanen", email="" },
   { name="Python 3.13/3.14 호환 버전: 115dkk", email="" },


### PR DESCRIPTION
Root cause: Velopack uses --veloapp-* args (not --velopack-*). All lifecycle hooks (install/update/uninstall) were undetected, causing GUI to launch during installation.

Ref: https://docs.velopack.io/integrating/hooks

Changes:
- gui_main.py: --velopack- → --veloapp- prefix matching
- build_nuitka.py: fallback entry point also gets hook handler
- modern_gui.py: VELOPACK_RESTART env var detection for post-update notification + improved pre-restart message

https://claude.ai/code/session_01NUZkamahFbmeSjqKCp8nJw