### PR TITLE
[review-of-#62] Modernize Lion-parity baseline (rfft, isnan, dead-code, logger glyphs)

### DIFF
--- a/autoeq/__init__.py
+++ b/autoeq/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+"""Vendored AutoEQ package (forked from autoeq-pkg 1.2.5).
+
+Kept inside this repository to preserve Lion-style numerical parity for the
+BRIR pipeline while modernising the surrounding code (NumPy/SciPy idioms,
+no pandas/TF dependency, Pillow >= 9.1 palette, etc.).
+"""
+
+__version__ = "1.2.5+impulcifer"

--- a/autoeq/biquad.py
+++ b/autoeq/biquad.py
@@ -3,7 +3,6 @@
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.ticker as ticker
-from scipy import signal
 
 
 def numpyfy(fc, Q, gain, fs):
@@ -133,11 +132,6 @@ def digital_coeffs(f, fs, a0, a1, a2, b0, b1, b2):
 
 def impulse_response(a0, a1, a2, b0, b1, b2, n=250):
     raise NotImplementedError('biquad.impulse_response is not correctly implemented!')
-    ir = signal.unit_impulse(n)
-    for _a0, _a1, _a2, _b0, _b1, _b2 in zip(a0, a1, a2, b0, b1, b2):
-        ir = signal.lfilter(np.concatenate([_b0, _b1, _b2]), np.concatenate([_a0, _a1, _a2]), ir)
-    ir = np.concatenate(([0.0], ir))
-    return ir
 
 
 def main():

--- a/autoeq/frequency_response.py
+++ b/autoeq/frequency_response.py
@@ -165,8 +165,8 @@ class FrequencyResponse:
         name = '.'.join(os.path.split(file_path)[1].split('.')[:-1])
 
         # Read file
-        f = open(file_path, 'r', encoding='utf-8')
-        s = f.read()
+        with open(file_path, 'r', encoding='utf-8') as f:
+            s = f.read()
 
         # Regex for AutoEq style CSV
         header_pattern = r'frequency(,(raw|smoothed|error|error_smoothed|equalization|parametric_eq|fixed_band_eq|equalized_raw|equalized_smoothed|target))+'
@@ -478,7 +478,6 @@ class FrequencyResponse:
         _fc, _Q, _gain = unpack(result.x)
         rmse = np.sqrt(np.mean(np.square(residual(result.x))))
 
-        _fc = np.abs(np.round(_fc / fs) * fs - _fc)
         _Q = np.abs(_Q)
 
         if parametric:
@@ -840,14 +839,15 @@ class FrequencyResponse:
 
     def interpolate(self, f=None, f_step=DEFAULT_STEP, pol_order=1, f_min=DEFAULT_F_MIN, f_max=DEFAULT_F_MAX):
         """Interpolates missing values from previous and next value. Resets all but raw data."""
-        # Remove None values
-        i = 0
-        while i < len(self.raw):
-            if self.raw[i] is None:
-                self.raw = np.delete(self.raw, i)
-                self.frequency = np.delete(self.frequency, i)
-            else:
-                i += 1
+        # Drop NaN entries (originally Nones turned into NaNs by ``_init_data``).
+        # ``self.raw`` is a float ndarray here, so ``is None`` would never match
+        # and the original Python loop was dead code.
+        if len(self.raw):
+            raw_arr = np.asarray(self.raw, dtype=float)
+            valid = ~np.isnan(raw_arr)
+            if not valid.all():
+                self.raw = raw_arr[valid]
+                self.frequency = self.frequency[valid]
 
         # Interpolation functions
         keys = 'raw error error_smoothed equalization equalized_raw equalized_smoothed target'.split()
@@ -1059,9 +1059,11 @@ class FrequencyResponse:
             treble_f_upper: Upper boundary of transition frequency reqion. In the transition region normal filter is \
                         switched to treble filter with sigmoid weighting function.
         """
-        if None in self.frequency or None in data:
-            # Must not contain None values
-            raise ValueError('None values present, cannot smoothen!')
+        # Reject NaN-bearing arrays. After ``_init_data`` Nones are stored as
+        # NaN floats, so ``np.isnan`` is the appropriate gate.
+        if np.any(np.isnan(np.asarray(self.frequency, dtype=float))) \
+                or np.any(np.isnan(np.asarray(data, dtype=float))):
+            raise ValueError('NaN values present, cannot smoothen!')
 
         # Normal filter
         y_normal = data
@@ -1241,9 +1243,12 @@ class FrequencyResponse:
         else:
             raise ValueError('Error data is missing. Call FrequencyResponse.compensate().')
 
-        if None in error or None in self.equalization or None in self.equalized_raw:
-            # Must not contain None values
-            raise ValueError('None values detected during equalization, interpolating data with default parameters.')
+        # ``equalization`` and ``equalized_raw`` were just reset to empty lists,
+        # so only ``error`` (an ndarray of floats with NaN replacing None) needs
+        # checking here. ``np.any(np.isnan(...))`` works whether ``error`` is a
+        # list or an ndarray.
+        if np.any(np.isnan(np.asarray(error, dtype=float))):
+            raise ValueError('NaN values detected during equalization, interpolating data with default parameters.')
 
         # Invert with max gain clipping
         max_gain = self._sigmoid(treble_f_lower, treble_f_upper, a_normal=max_gain, a_treble=treble_max_gain)

--- a/core/parallel_workers.py
+++ b/core/parallel_workers.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 """경량 병렬 처리 워커 함수 모듈.
 
-ProcessPoolExecutor 워커 프로세스가 이 모듈만 import하면 됨.
-impulcifer.py의 무거운 import 체인(matplotlib, bokeh, autoeq 등)을 피함.
-
-워커 프로세스 메모리: ~50-80 MB (scipy + numpy) vs ~200-400 MB (impulcifer 전체)
+ProcessPoolExecutor 워커 프로세스가 이 모듈만 import하면 됨. 그러면 impulcifer.py
+나 GUI 트리(bokeh, customtkinter, seaborn 등)는 워커 측에서 로드되지 않는다.
+플롯/decay 워커는 scipy + numpy만 끌어오고, EQ 워커는 lazy import로
+``autoeq.frequency_response``를 통해 matplotlib + Pillow + tabulate까지 끌어온다.
 """
 def process_plot_worker(args):
     """플롯용 컨볼루션 워커. scipy.signal.convolve만 사용.

--- a/core/utils.py
+++ b/core/utils.py
@@ -6,7 +6,6 @@ import tempfile
 import json
 import numpy as np
 import soundfile as sf
-from scipy.fftpack import fft
 from scipy import signal
 from PIL import Image
 import matplotlib.ticker as ticker
@@ -590,22 +589,19 @@ def write_wav(file_path, fs, data, bit_depth=32):
 
 
 def magnitude_response(x, fs):
-    """Calculates frequency magnitude response
+    """Calculates frequency magnitude response.
 
-    Args:
-        x: Input signal
-        fs: Sampling rate
-
-    Returns:
-        - Frequency values as numpy array
-        - Frequency magnitudes as numpy array
+    Returns the same first ``ceil(N/2)`` bins as Lion's full-FFT implementation
+    while only computing the one-sided real spectrum (``rfft`` is ~2x faster on
+    real input). For real ``x`` we have ``fft(x)[k] == rfft(x)[k]`` for
+    ``0 <= k <= N/2``, so the slice we expose here is bit-identical to Lion.
     """
     nfft = len(x)
-    df = fs / nfft
-    f = np.arange(0, fs - df, df)
-    X = fft(x)
-    X_mag = 20 * np.log10(np.abs(X))
-    return f[0:int(np.ceil(nfft / 2))], X_mag[0:int(np.ceil(nfft / 2))]
+    half = int(np.ceil(nfft / 2))
+    X = np.fft.rfft(x)
+    X_mag = 20 * np.log10(np.abs(X[:half]))
+    f = np.arange(half) * (fs / nfft)
+    return f, X_mag
 
 
 def sync_axes(axes, sync_x=True, sync_y=True):

--- a/infra/logger.py
+++ b/infra/logger.py
@@ -5,11 +5,28 @@ Unified logging system for Impulcifer
 Supports both CLI output and GUI callbacks with localization
 """
 
+import sys
 from typing import Callable, Optional, TYPE_CHECKING
 from enum import Enum
 
 if TYPE_CHECKING:
     from i18n.localization import LocalizationManager
+
+
+def _ensure_utf8_console() -> None:
+    """Best-effort UTF-8 reconfiguration so console glyphs survive on Windows cp949."""
+    for stream_name in ("stdout", "stderr"):
+        stream = getattr(sys, stream_name, None)
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        try:
+            reconfigure(encoding="utf-8", errors="replace")
+        except Exception:
+            pass
+
+
+_ensure_utf8_console()
 
 
 class LogLevel(Enum):
@@ -117,11 +134,11 @@ class ImpulciferLogger:
         if level == LogLevel.PROGRESS:
             console_msg = f"[{progress_value}%] {translated_msg}"
         elif level == LogLevel.SUCCESS:
-            console_msg = f"OK: {translated_msg}"
+            console_msg = f"✓ {translated_msg}"
         elif level == LogLevel.ERROR:
-            console_msg = f"ERROR: {translated_msg}"
+            console_msg = f"✗ {translated_msg}"
         elif level == LogLevel.WARNING:
-            console_msg = f"WARNING: {translated_msg}"
+            console_msg = f"⚠ {translated_msg}"
         else:
             console_msg = translated_msg
 

--- a/tests/test_magnitude_response_parity.py
+++ b/tests/test_magnitude_response_parity.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+"""Regression test pinning Lion-equivalent behaviour for ``magnitude_response``.
+
+The current implementation uses ``np.fft.rfft`` for speed, but it must return
+exactly the same first ``ceil(N/2)`` magnitude bins as Lion's full-FFT path
+(``scipy.fftpack.fft`` followed by a ``[:ceil(N/2)]`` slice). For real inputs
+those two FFT paths agree bit-for-bit on the bins we expose, so this test
+fails the moment someone introduces an epsilon, a windowed FFT, or a different
+bin layout.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+from scipy.fftpack import fft
+
+from core.utils import magnitude_response
+
+
+def _lion_magnitude_response(x: np.ndarray, fs: int):
+    nfft = len(x)
+    df = fs / nfft
+    f = np.arange(0, fs - df, df)
+    X = fft(x)
+    X_mag = 20 * np.log10(np.abs(X))
+    half = int(np.ceil(nfft / 2))
+    return f[:half], X_mag[:half]
+
+
+class MagnitudeResponseLionParity(unittest.TestCase):
+    def _assert_bit_identical(self, x: np.ndarray, fs: int):
+        f_lion, m_lion = _lion_magnitude_response(x, fs)
+        f_modern, m_modern = magnitude_response(x, fs)
+        self.assertEqual(f_lion.shape, f_modern.shape)
+        self.assertTrue(np.array_equal(f_lion, f_modern))
+        self.assertEqual(m_lion.shape, m_modern.shape)
+        self.assertTrue(np.array_equal(m_lion, m_modern))
+
+    def test_even_length(self):
+        rng = np.random.default_rng(0xA110)
+        for nfft in (8, 1024, 48000):
+            with self.subTest(nfft=nfft):
+                self._assert_bit_identical(rng.standard_normal(nfft), 48000)
+
+    def test_odd_length(self):
+        rng = np.random.default_rng(0xA111)
+        for nfft in (9, 1025, 48001):
+            with self.subTest(nfft=nfft):
+                self._assert_bit_identical(rng.standard_normal(nfft), 48000)
+
+    def test_impulse(self):
+        x = np.zeros(2048)
+        x[0] = 1.0
+        self._assert_bit_identical(x, 48000)
+
+    def test_sweep_like(self):
+        # Smooth, broadband signal that exercises every FFT bin.
+        n = 4096
+        t = np.arange(n) / 48000
+        x = np.sin(2 * np.pi * np.linspace(20, 20000, n) * t)
+        self._assert_bit_identical(x, 48000)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Builds on top of #62. Output stays bit-identical to PR #62's tested baseline (hesuvi.wav md5 unchanged for the demo run with `--vbass --vbass_freq 250`), while the implementation drops Lion-style slow paths in favour of modern NumPy/SciPy idioms.

The premise: even non-parity-risky changes should be modern and fast — but every change is **verified against Lion's hesuvi.wav** before landing. PR #62 over-corrected toward Lion's literal Python loops; this PR walks them back where the math is genuinely identical.

## Modernizations (each verified parity-safe)

- **`core/utils.py:magnitude_response`**: `scipy.fftpack.fft` + half-slice → `np.fft.rfft` on the same first `ceil(N/2)` bins. Real-input `fft(x)[k] == rfft(x)[k]` for `0 ≤ k ≤ N/2`, so output is **bit-identical** to Lion. ~2x faster.
- **`autoeq/frequency_response.py`**:
  - `_smoothen_fractional_octave` / `equalize`: `None in ndarray` → `np.any(np.isnan(...))`. Avoids future NumPy deprecation, dtype-agnostic.
  - `interpolate`: dead `while ... self.raw[i] is None` loop → vectorized `~np.isnan` boolean mask.
  - `read_from_csv`: leaked file handle → `with open(...)`.
  - `_optimize_biquad_filters_scipy`: removed no-op `_fc = np.abs(np.round(_fc / fs) * fs - _fc)` (always identity given `least_squares` bounds).
- **`autoeq/biquad.py`**: removed unreachable code after `raise NotImplementedError` and now-unused `scipy.signal` import.
- **`autoeq/__init__.py`**: added module docstring + `__version__ = "1.2.5+impulcifer"` so `--info` and tooling can identify the vendored fork.
- **`infra/logger.py`**: restored `✓ / ✗ / ⚠` console glyphs and added a one-shot `sys.stdout.reconfigure(encoding="utf-8", errors="replace")` so Windows cp949 consoles no longer crash on Unicode (PR #62 had stripped the glyphs to side-step the encoding error rather than fix it).
- **`core/parallel_workers.py`**: corrected the misleading "scipy + numpy only" docstring — the EQ worker really does pull autoeq + matplotlib + Pillow via lazy import.

## New tests

- **`tests/test_magnitude_response_parity.py`**: 4-case regression test pinning bit-equivalence of `magnitude_response` against Lion's full-FFT reference for even/odd lengths, an impulse, and a sweep-like signal. Catches anyone reintroducing an epsilon, a windowed FFT, or a different bin layout.

## What I deliberately did NOT change (parity-risk too high for marginal speedup)

- `FrequencyResponse._window_size`'s left-to-right Python sum vs `np.mean(freq[1:]/freq[:-1])`: the two differ by ~7e-15 due to associativity of float summation. Below ULP, but still a non-zero parity risk on `round()` boundaries — left as-is.
- `smoothen_heavy_light` parameters, `equalize` clipping/transition logic, `minimum_phase_impulse_response`, virtual-bass synthesis: PR #62 already pinned these to the Lion code path for parity; modernizing them would require adding compensating logic and a much larger verification matrix.

## Verification

Demo input: `jaakkopasanen/Impulcifer/data/demo` + sweep pkl, `--vbass --vbass_freq 250`.

Candidate (this branch, Python 3.13) vs Lion control (Python 3.10 + autoeq-pkg 1.2.5 source, with `signal.hanning` → `signal.windows.hann` patched):

```
exact_equal             : False   (cross-Python BLAS noise floor)
max_abs_sample_diff     : 6.519258e-09   (~ -106 dBFS rel-peak)
rms_sample_diff         : 6.894194e-11
all_freq_mean_abs_db    : 0.000025
all_freq_max_abs_db     : 0.026503   (12419 Hz on C-l, at -80 dB notch)
low15_200_mean_abs_db   : 0.000026
high10k_20k_mean_abs_db : 0.000076
```

These deltas exactly match what PR #62 reported between Lion 3.13 control and Lion 3.8 control (`max_abs_sample_diff=7.45e-09`, `mean_abs_db=0.000023`) — i.e. the BLAS/LAPACK rounding floor across Python versions.

**hesuvi.wav md5 = `d295982d021a6d16ab2c194c3517c162` — identical to PR #62's pre-modernization run.** That is, this PR did not move the output by a single sample; it only modernized the code that produces it.

## Test plan

- [x] `python -m unittest tests.test_magnitude_response_parity` (4 tests pass)
- [x] `python -m unittest tests.test_parallel_processing` (12 tests pass)
- [x] `python -m pytest tests/test_virtual_bass.py` (24 tests pass)
- [x] `python -m compileall autoeq core impulcifer.py` clean
- [x] Demo BRIR generation (`--vbass --vbass_freq 250`) bit-identical to PR #62 baseline
- [ ] Reviewer to confirm Windows console no longer needs the ASCII workaround on cp949

https://claude.ai/code/session_01QmuFaJyE7iC362EX3pdENs

---
_Generated by [Claude Code](https://claude.ai/code/session_01QmuFaJyE7iC362EX3pdENs)_