### PR TITLE
perf: 플롯 메모리 잔류 해소 + FFmpeg lazy setup (2.4.16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ first number changes, something has broken and you need to check your commands a
 changes there are only new features available and nothing old has broken and when the last number changes, old bugs have
 been fixed and old features improved.
 
+## 2.4.16 - 2026-05-03
+### ⚡ 플롯 메모리 잔류 해소와 FFmpeg lazy setup
+
+#### ⚡ 성능 개선
+- **플롯 후 ~3GB 메모리 잔류 해소**: `plot=True`로 BRIR을 생성하면 작업 종료 후에도 ~3GB가 프로세스에 남아 있던 문제를 두 단계로 해결
+  - **`impulcifer.py` (Phase 1)**: 플롯용 convolve를 ProcessPoolExecutor로 14개 워커(워커당 ~150MB)에 분산하던 동작을 직렬 `scipy.signal.convolve`로 환원. 워커 결과를 `plot_tasks`/`plot_results` 튜플에 보관하느라 `del hrir`/`del estimator` 후에도 recording·test_signal 참조가 살아남던 잔류 경로를 제거. 메모리 회수 블록은 중간 변수(`eq_tasks`/`eq_results`/`decay_tasks`/`decay_results`) → 루트 객체(`hrir`/`estimator`/`room_frs` 등) 순서로 삭제하도록 정정하고, safety net으로 `plt.close('all')`을 `gc.collect()` 직전에 호출
+  - **`core/hrir.py` (Phase 2)**: `HRIR.plot()`을 2-pass 렌더링으로 리팩토링. Pass 1에서 figure를 1개씩 생성·축 범위 수집 후 즉시 `plt.close()`, Pass 2에서 동기화된 limit으로 다시 생성하여 저장. 동시 존재 figure를 14개 → 1개로 줄여 matplotlib 객체 단편화에 의한 메모리 부풀림 차단. `gc.collect()`를 패스 사이에 1회 호출
+- **FFmpeg setup lazy화**: `core/utils.py` import 시점에 항상 실행되던 `setup_ffmpeg()` (시스템 PATH 탐색 + 일반 경로 검색 + 미발견 시 자동 설치 시도)를 `ensure_ffmpeg_available()`로 분리하여 실제 사용 시점까지 지연. 일반 WAV 처리, ProcessPool 워커 import, unit test에서는 ffmpeg/ffprobe subprocess 호출이 발생하지 않음. TrueHD/MLP 처리 경로(`is_truehd_file` / `convert_truehd_to_wav` / `get_truehd_channel_info`, 그리고 `open_impulse_response_estimator`의 .mlp/.thd/.truehd 분기)는 `auto_install=True`로 호출해 사용자가 직접 .mlp 파일을 열었을 때 자동 설치 UX는 그대로 보존. `read_audio()`는 확장자가 `.mlp`/`.thd`/`.truehd`가 아니면 `is_truehd_file()` 호출을 건너뛰어 일반 WAV 경로의 lazy setup도 우회
+- **EQ task tuple에서 미사용 `ir` 제거**: `process_equalization_worker`가 unpack만 하고 사용하지 않던 `ir` (ImpulseResponse) 객체를 task 튜플에서 제외. ProcessPoolExecutor 환경에서 14개 IR 객체 pickle/IPC 비용 제거 (출력은 bit-identical, 데모 hesuvi.wav md5 유지)
+
+#### 🐛 버그 수정
+- **`core/hrir.py` 미사용 `sync_axes` import 제거**: 2-pass 리팩토링으로 sync_axes 직접 호출이 사라져 ruff F401 경고 해소
+
 ## 2.4.15 - 2026-05-03
 ### ⭐ Modern GUI 후속 개선과 취소 지원
 

--- a/core/hrir.py
+++ b/core/hrir.py
@@ -12,7 +12,7 @@ from scipy.interpolate import InterpolatedUnivariateSpline
 from PIL import Image
 from autoeq.frequency_response import FrequencyResponse
 from core.impulse_response import ImpulseResponse
-from core.utils import read_wav, write_wav, magnitude_response, sync_axes, ADAPTIVE_PALETTE
+from core.utils import read_wav, write_wav, magnitude_response, ADAPTIVE_PALETTE
 from core.constants import SPEAKER_NAMES, SPEAKER_DELAYS, HEXADECAGONAL_TRACK_ORDER
 
 # Bokeh imports
@@ -905,12 +905,75 @@ class HRIR:
         plot_waterfall=True,
         close_plots=True,
     ):
-        """Plots all impulse responses."""
-        # Plot and save max limits
-        figs = dict()
+        """Plots all impulse responses with memory-efficient 2-pass rendering.
+
+        Pass 1: Generate each figure to collect axis limits, then close immediately.
+        Pass 2: Regenerate each figure with synchronized limits, save, then close.
+
+        Holding all 14 figures in memory simultaneously (the previous behavior)
+        fragments the matplotlib heap and pins ~3GB of small objects through
+        ``gc.collect()``. This 2-pass form caps live figures at 1 at the cost
+        of generating each figure twice — plotting time roughly doubles, but
+        plotting is a small fraction of total BRIR generation time.
+        """
+        import gc
+
+        plot_flags = [
+            plot_recording,
+            plot_ir,
+            plot_decay,
+            plot_spectrogram,
+            plot_fr,
+            plot_waterfall,
+        ]
+
+        # --- Pass 1: Collect axis limits ---
+        limits = {}
+        for idx in range(6):
+            if plot_flags[idx]:
+                limits[idx] = {
+                    'x_mins': [], 'x_maxs': [],
+                    'y_mins': [], 'y_maxs': [],
+                }
+
         for speaker, pair in self.irs.items():
-            if speaker not in figs:
-                figs[speaker] = dict()
+            for side, ir in pair.items():
+                fig = ir.plot(
+                    plot_recording=plot_recording,
+                    plot_spectrogram=plot_spectrogram,
+                    plot_ir=plot_ir,
+                    plot_fr=plot_fr,
+                    plot_decay=plot_decay,
+                    plot_waterfall=plot_waterfall,
+                )
+                axes_list = fig.get_axes()
+                for idx in limits:
+                    if idx < len(axes_list):
+                        ax = axes_list[idx]
+                        xlim = ax.get_xlim()
+                        ylim = ax.get_ylim()
+                        limits[idx]['x_mins'].append(xlim[0])
+                        limits[idx]['x_maxs'].append(xlim[1])
+                        limits[idx]['y_mins'].append(ylim[0])
+                        limits[idx]['y_maxs'].append(ylim[1])
+                plt.close(fig)
+
+        sync_limits = {}
+        for idx, lim in limits.items():
+            if lim['x_mins']:
+                sync_limits[idx] = {
+                    'xlim': [float(np.min(lim['x_mins'])), float(np.max(lim['x_maxs']))],
+                    'ylim': [float(np.min(lim['y_mins'])), float(np.max(lim['y_maxs']))],
+                }
+
+        gc.collect()
+
+        # --- Pass 2: Render with synchronized limits ---
+        figs = dict()
+        if dir_path is not None:
+            os.makedirs(dir_path, exist_ok=True)
+
+        for speaker, pair in self.irs.items():
             for side, ir in pair.items():
                 fig = ir.plot(
                     plot_recording=plot_recording,
@@ -921,45 +984,29 @@ class HRIR:
                     plot_waterfall=plot_waterfall,
                 )
                 fig.suptitle(f"{speaker}-{side}")
-                figs[speaker][side] = fig
 
-        # Synchronize axes limits
-        plot_flags = [
-            plot_recording,
-            plot_ir,
-            plot_decay,
-            plot_spectrogram,
-            plot_fr,
-            plot_waterfall,
-        ]
-        for r in range(2):
-            for c in range(3):
-                if not plot_flags[r * 3 + c]:
-                    continue
-                axes = []
-                for speaker, pair in figs.items():
-                    for side, fig in pair.items():
-                        axes.append(fig.get_axes()[r * 3 + c])
-                sync_axes(axes)
+                axes_list = fig.get_axes()
+                for idx, sl in sync_limits.items():
+                    if idx < len(axes_list):
+                        axes_list[idx].set_xlim(sl['xlim'])
+                        axes_list[idx].set_ylim(sl['ylim'])
 
-        # Show write figures to files
-        if dir_path is not None:
-            os.makedirs(dir_path, exist_ok=True)
-            for speaker, pair in self.irs.items():
-                for side, ir in pair.items():
+                if dir_path is not None:
                     file_path = os.path.join(dir_path, f"{speaker}-{side}.png")
-                    figs[speaker][side].savefig(file_path, bbox_inches="tight")
-                    # Optimize file size
+                    fig.savefig(file_path, bbox_inches="tight")
                     im = Image.open(file_path)
                     im = im.convert("P", palette=ADAPTIVE_PALETTE, colors=60)
                     im.save(file_path, optimize=True)
+                    del im
 
-        # Close plots
-        if close_plots:
-            for speaker, pair in self.irs.items():
-                for side, ir in pair.items():
-                    plt.close(figs[speaker][side])
+                if close_plots:
+                    plt.close(fig)
+                else:
+                    if speaker not in figs:
+                        figs[speaker] = dict()
+                    figs[speaker][side] = fig
 
+        gc.collect()
         return figs
 
     def plot_result(self, dir_path):

--- a/core/parallel_workers.py
+++ b/core/parallel_workers.py
@@ -42,13 +42,13 @@ def process_equalization_worker(args):
     """이퀄라이제이션 워커.
 
     Args:
-        args: Tuple of (speaker, side, ir, room_frs, hp_left, hp_right,
+        args: Tuple of (speaker, side, room_frs, hp_left, hp_right,
               eq_left, eq_right, target, common_freq, estimator_fs)
 
     Returns:
         Tuple of (speaker, side, fir_filter)
     """
-    (speaker, side, ir, room_frs, hp_left, hp_right,
+    (speaker, side, room_frs, hp_left, hp_right,
      eq_left, eq_right, target, common_freq, estimator_fs) = args
 
     # Lazy import to keep module-level imports minimal

--- a/core/utils.py
+++ b/core/utils.py
@@ -320,12 +320,18 @@ def install_ffmpeg():
         print(f"FFmpeg 설치 중 오류 발생: {e}")
         return None, None
 
-def setup_ffmpeg():
-    """FFmpeg를 설정하고 경로를 반환합니다."""
+def setup_ffmpeg(auto_install=True):
+    """FFmpeg를 설정하고 경로를 반환합니다.
+
+    Args:
+        auto_install: 시스템 PATH 및 일반 경로 검색에 실패한 경우 자동 설치
+            를 시도할지 여부. TrueHD/MLP 처리 경로에서는 기본값 ``True``를
+            유지해 사용자 편의 기능을 보존한다.
+    """
     # 1. 시스템 PATH에서 ffmpeg 확인
     ffmpeg_path = shutil.which('ffmpeg')
     ffprobe_path = shutil.which('ffprobe')
-    
+
     if ffmpeg_path and ffprobe_path:
         version = get_ffmpeg_version(ffmpeg_path)
         if version and version >= MIN_FFMPEG_VERSION:
@@ -333,34 +339,69 @@ def setup_ffmpeg():
             return ffmpeg_path, ffprobe_path
         else:
             print(f"시스템 PATH의 FFmpeg 버전이 너무 오래됨: {version}")
-    
+
     # 2. 일반적인 경로에서 검색
     ffmpeg_path, ffprobe_path = find_ffmpeg_in_common_paths()
     if ffmpeg_path and ffprobe_path:
         version = get_ffmpeg_version(ffmpeg_path)
         print(f"로컬 경로에서 FFmpeg {version[0]}.{version[1]} 감지됨: {ffmpeg_path}")
         return ffmpeg_path, ffprobe_path
-    
-    # 3. 자동 설치 시도
-    ffmpeg_path, ffprobe_path = install_ffmpeg()
-    if ffmpeg_path and ffprobe_path:
-        version = get_ffmpeg_version(ffmpeg_path)
-        print(f"FFmpeg {version[0]}.{version[1]} 설치 완료: {ffmpeg_path}")
-        return ffmpeg_path, ffprobe_path
-    
-    # 4. 모든 시도 실패
-    print("FFmpeg를 찾거나 설치할 수 없습니다. TrueHD/MLP 지원이 비활성화됩니다.")
+
+    # 3. 자동 설치 시도 (TrueHD/MLP 사용 경로에서만 트리거)
+    if auto_install:
+        ffmpeg_path, ffprobe_path = install_ffmpeg()
+        if ffmpeg_path and ffprobe_path:
+            version = get_ffmpeg_version(ffmpeg_path)
+            print(f"FFmpeg {version[0]}.{version[1]} 설치 완료: {ffmpeg_path}")
+            return ffmpeg_path, ffprobe_path
+        # install_ffmpeg() 내부에서 실패 메시지를 이미 출력함
+        return None, None
+
+    # 4. auto_install=False — 단순 검출만 수행, 사용자에게 알리지 않음
     return None, None
 
-# FFmpeg 경로 자동 설정
-FFMPEG_PATH, FFPROBE_PATH = setup_ffmpeg()
+
+# FFmpeg 경로는 lazy하게 초기화한다. 모듈 import 시점에 setup_ffmpeg()를 실행
+# 하면 일반 WAV 처리, ProcessPool 워커 import, unit test에서도 ffmpeg/ffprobe
+# 탐색과 subprocess 호출이 발생해 시작 비용이 누적된다. 실제로 TrueHD/MLP
+# 기능을 사용하는 경로에서만 ensure_ffmpeg_available()를 통해 1회 초기화된다.
+FFMPEG_PATH = None
+FFPROBE_PATH = None
+_FFMPEG_SETUP_DONE = False
+
+
+def ensure_ffmpeg_available(auto_install=True):
+    """Lazy 초기화. 최초 호출 시 ``setup_ffmpeg()``를 실행하고 결과 캐시.
+
+    Args:
+        auto_install: 자동 설치 시도 여부. TrueHD/MLP 실제 사용 경로에서는
+            ``True``를 유지하고, 단순 정보 조회(`get_supported_audio_formats`
+            등)에서는 ``False``로 호출해 불필요한 install attempt를 막는다.
+
+    Returns:
+        FFmpeg/ffprobe 경로가 모두 설정되어 있으면 ``True``, 아니면 ``False``.
+    """
+    global FFMPEG_PATH, FFPROBE_PATH, _FFMPEG_SETUP_DONE
+
+    if _FFMPEG_SETUP_DONE:
+        return FFMPEG_PATH is not None and FFPROBE_PATH is not None
+
+    _FFMPEG_SETUP_DONE = True
+    FFMPEG_PATH, FFPROBE_PATH = setup_ffmpeg(auto_install=auto_install)
+
+    if FFMPEG_PATH is None or FFPROBE_PATH is None:
+        if auto_install:
+            print("FFmpeg를 찾거나 설치할 수 없습니다. TrueHD/MLP 지원이 비활성화됩니다.")
+        return False
+    return True
+
 
 def is_truehd_file(file_path):
     """Check if file is TrueHD/MLP format"""
-    # FFmpeg가 사용 불가능하면 False 반환
-    if not check_ffmpeg_available():
+    # TrueHD/MLP 처리 경로 — 자동 설치를 허용한다.
+    if not ensure_ffmpeg_available(auto_install=True):
         return False
-    
+
     try:
         result = subprocess.run(
             [FFPROBE_PATH, '-v', 'error', '-select_streams', 'a:0',
@@ -371,7 +412,7 @@ def is_truehd_file(file_path):
         )
         if result.returncode != 0:
             return False
-        
+
         codec = result.stdout.strip().lower()
         return codec in ['truehd', 'mlp']
     except Exception:
@@ -379,16 +420,16 @@ def is_truehd_file(file_path):
 
 def convert_truehd_to_wav(truehd_path, output_path=None):
     """Convert TrueHD/MLP file to WAV format"""
-    if not check_ffmpeg_available():
+    if not ensure_ffmpeg_available(auto_install=True):
         raise RuntimeError("FFmpeg is not available for TrueHD conversion")
-    
+
     if output_path is None:
         fd, output_path = tempfile.mkstemp(suffix='.wav')
         os.close(fd)
-    
+
     # Get channel layout info first
     channel_info = get_truehd_channel_info(truehd_path)
-    
+
     # Convert to WAV with proper channel mapping
     cmd = [
         FFMPEG_PATH, '-i', truehd_path,
@@ -401,14 +442,14 @@ def convert_truehd_to_wav(truehd_path, output_path=None):
                           encoding='utf-8', errors='replace')
     if result.returncode != 0:
         raise RuntimeError(f"FFmpeg conversion failed: {result.stderr}")
-    
+
     return output_path, channel_info
 
 def get_truehd_channel_info(file_path):
     """Get channel layout information from TrueHD file"""
-    if not check_ffmpeg_available():
+    if not ensure_ffmpeg_available(auto_install=True):
         return None
-    
+
     try:
         result = subprocess.run(
             [FFPROBE_PATH, '-v', 'error', '-select_streams', 'a:0',
@@ -417,19 +458,19 @@ def get_truehd_channel_info(file_path):
             capture_output=True, text=True, timeout=10,
             encoding='utf-8', errors='replace'
         )
-        
+
         if result.returncode != 0:
             return None
-            
+
         info = json.loads(result.stdout)
         stream = info['streams'][0]
-        
+
         channels = stream.get('channels', 0)
         stream.get('channel_layout', '')
-        
+
         # Map channel layouts to speaker names
         from core.constants import CHANNEL_LAYOUT_MAP
-        
+
         if channels in CHANNEL_LAYOUT_MAP:
             return CHANNEL_LAYOUT_MAP[channels]
         else:
@@ -438,15 +479,22 @@ def get_truehd_channel_info(file_path):
     except Exception:
         return None
 
+# TrueHD/MLP 확장자 집합 — read_audio()의 fast-path 분기에 사용한다.
+_TRUEHD_EXTENSIONS = frozenset({'.mlp', '.thd', '.truehd'})
+
+
 def read_audio(file_path, expand=False):
     """Read audio file (WAV or TrueHD/MLP)
-    
+
     Returns:
         - Sample rate
         - Audio data (channels x samples)
         - Channel info (for TrueHD) or None
     """
-    if is_truehd_file(file_path):
+    # 일반 WAV 등 비-TrueHD 확장자는 FFmpeg setup 자체를 건너뛴다. 확장자
+    # 기반 빠른 분기로 모듈 import / 일반 처리 경로의 ffmpeg 탐색 비용을 제거.
+    ext = os.path.splitext(file_path)[1].lower()
+    if ext in _TRUEHD_EXTENSIONS and is_truehd_file(file_path):
         # Convert TrueHD to temporary WAV
         temp_wav, channel_info = convert_truehd_to_wav(file_path)
         try:
@@ -456,7 +504,7 @@ def read_audio(file_path, expand=False):
                 data = np.transpose(data)
             elif expand:
                 data = np.expand_dims(data, axis=0)
-            
+
             return fs, data, channel_info
         finally:
             # Clean up temp file
@@ -472,14 +520,18 @@ def read_audio(file_path, expand=False):
             data = np.expand_dims(data, axis=0)
         return fs, data, None
 
-def check_ffmpeg_available():
-    """Check if FFmpeg is available"""
-    global FFMPEG_PATH, FFPROBE_PATH
-    
-    # FFmpeg 경로가 None이면 사용 불가
-    if FFMPEG_PATH is None or FFPROBE_PATH is None:
+def check_ffmpeg_available(auto_install=False):
+    """Check if FFmpeg is available.
+
+    Args:
+        auto_install: ``True``로 호출하면 lazy setup 시 자동 설치를 시도한다.
+            TrueHD/MLP 처리 진입점(예: ``open_impulse_response_estimator``)에서
+            이 옵션을 켜 사용자가 .mlp/.thd/.truehd 파일을 열 때 자동 설치
+            UX가 유지되도록 한다.
+    """
+    if not ensure_ffmpeg_available(auto_install=auto_install):
         return False
-    
+
     # 실제 파일 존재 및 실행 가능 여부 확인
     try:
         result = subprocess.run([FFMPEG_PATH, '-version'],
@@ -497,11 +549,12 @@ def get_supported_audio_formats():
         'thd': 'TrueHD Audio',
         'truehd': 'Dolby TrueHD'
     }
-    
-    if not check_ffmpeg_available():
+
+    # 정보 조회용이므로 자동 설치는 트리거하지 않는다.
+    if not check_ffmpeg_available(auto_install=False):
         # If FFmpeg not available, only support WAV
         return {'wav': 'WAV Audio'}
-    
+
     return formats
 
 

--- a/impulcifer.py
+++ b/impulcifer.py
@@ -44,7 +44,7 @@ def _get_version() -> str:
         pass
 
     # Fallback
-    return "2.4.15"
+    return "2.4.16"
 
 __version__ = _get_version()
 
@@ -203,7 +203,6 @@ set_matplotlib_font()  # 함수 호출하여 폰트 설정 실행
 from core.parallel_workers import (
     process_equalization_worker,
     process_decay_worker,
-    process_plot_worker,
 )
 
 
@@ -450,12 +449,14 @@ def main(
         )
 
         # Phase 2 Optimization: Parallel processing of speaker-side pairs
-        # Prepare arguments for parallel processing
+        # Prepare arguments for parallel processing.
+        # Worker는 ir 객체를 사용하지 않으므로 task tuple에서 제외해 IPC pickle
+        # 비용과 ImpulseResponse 객체 직렬화 부담을 제거한다.
         eq_tasks = []
         for speaker, pair in hrir.irs.items():
-            for side, ir in pair.items():
+            for side in pair.keys():
                 eq_tasks.append((
-                    speaker, side, ir,
+                    speaker, side,
                     room_frs, hp_left, hp_right,
                     eq_left, eq_right, target,
                     common_freq, estimator.fs
@@ -514,18 +515,15 @@ def main(
     if plot:
         logger.step("cli_plotting_post")
 
-        # Phase 2 Optimization: Parallel convolution for plotting
-        plot_tasks = []
+        # Compute convolutions for recording plots serially. Each convolution is
+        # ~scipy.signal.convolve一행짜리 작업이라 ProcessPoolExecutor 14개 워커
+        # (각 ~150MB) 비용이 직렬 실행보다 훨씬 비싸다. 추가로, 워커가 반환한
+        # recording 배열을 plot_tasks/plot_results 튜플이 보유하면 hrir 메모리
+        # 회수 시점까지 참조가 살아남아 ~3GB 잔류를 일으킨다.
+        from scipy.signal import convolve
         for speaker, pair in hrir.irs.items():
             for side, ir in pair.items():
-                plot_tasks.append((speaker, side, ir.data, estimator.test_signal, estimator.fs))
-
-        logger.info("cli_info_parallel_plotting", count=len(plot_tasks))
-        plot_results = parallel_map(process_plot_worker, plot_tasks)
-
-        # Apply results back to impulse responses
-        for speaker, side, recording in plot_results:
-            hrir.irs[speaker][side].recording = recording
+                ir.recording = convolve(estimator.test_signal, ir.data, mode="full")
 
         # Plot post processing
         hrir.plot(os.path.join(dir_path, "plots", "post"))
@@ -711,14 +709,30 @@ def main(
         # 예시: if 'FL' in processed_speakers and 'FR' in processed_speakers:
         # LFE 생성 로직 ...
 
-    # 메모리 회수: 대형 객체 명시적 삭제 후 GC 강제 수행
-    # BRIR 반복 생성 시 메모리 누적 방지
+    # 메모리 회수: 중간 변수 → 루트 객체 순서로 삭제 후 GC 수행.
+    # eq_tasks/decay_tasks 등 중간 변수가 hrir/estimator 내부 데이터에 대한
+    # 참조를 유지하고 있어, 루트 객체를 먼저 삭제하면 내부 데이터가 해제되지
+    # 않는다. 반드시 중간 변수를 먼저 삭제한 후 루트 객체를 삭제할 것.
+    try:
+        del eq_tasks, eq_results
+    except NameError:
+        pass
+    try:
+        del decay_tasks, decay_results
+    except NameError:
+        pass
+
     del hrir
     del estimator
     try:
         del room_frs, hp_left, hp_right, eq_left, eq_right, target
     except NameError:
         pass
+
+    # safety net: 정상 경로에서는 hrir.plot()이 figure를 닫지만, 예외 발생
+    # 시 닫히지 않은 figure가 남을 수 있어 전체 close를 한 번 더 호출한다.
+    plt.close('all')
+
     import gc
     gc.collect()
 
@@ -788,8 +802,10 @@ def open_impulse_response_estimator(dir_path, file_path=None):
         # Test signal is Pickle file
         estimator = ImpulseResponseEstimator.from_pickle(file_path)
     elif re.match(r"^.+\.(mlp|thd|truehd)$", file_path, flags=re.IGNORECASE):
-        # Test signal is TrueHD/MLP file - convert to temporary WAV first
-        if not check_ffmpeg_available():
+        # Test signal is TrueHD/MLP file - convert to temporary WAV first.
+        # auto_install=True로 호출해 사용자가 .mlp/.thd/.truehd 파일을 직접
+        # 지정한 경우 FFmpeg가 없으면 기존처럼 자동 설치 UX를 시도한다.
+        if not check_ffmpeg_available(auto_install=True):
             raise RuntimeError(
                 "TrueHD/MLP 파일을 처리하기 위해서는 FFmpeg가 필요합니다. FFmpeg를 설치해주세요."
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "impulcifer-py313"
-version = "2.4.15"
+version = "2.4.16"
 authors = [
   { name="원본 저자: Jaakko Pasanen", email="" },
   { name="Python 3.13/3.14 호환 버전: 115dkk", email="" },

--- a/tests/test_ffmpeg_lazy_setup.py
+++ b/tests/test_ffmpeg_lazy_setup.py
@@ -1,0 +1,152 @@
+# -*- coding: utf-8 -*-
+"""Regression test for the lazy FFmpeg setup path.
+
+Importing ``core.utils`` used to call ``setup_ffmpeg()`` at module load,
+which spawns ffmpeg/ffprobe subprocess probes (and possibly an auto-install
+attempt) every time *any* downstream module — including ProcessPool workers
+that never touch TrueHD/MLP — imports it. This test pins the lazy contract:
+import is side-effect-free, the setup is performed only when something
+actually needs FFmpeg, and the regular WAV reading path no longer triggers
+TrueHD detection.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import tempfile
+import unittest
+import unittest.mock as mock
+
+import numpy as np
+import soundfile as sf
+
+
+class FfmpegLazySetupTest(unittest.TestCase):
+    """Verify that ``setup_ffmpeg`` is only called when actually needed."""
+
+    def setUp(self):
+        # Ensure we re-import core.utils with the spy in place.
+        for module_name in list(sys.modules):
+            if module_name == "core.utils" or module_name.startswith("core.utils."):
+                del sys.modules[module_name]
+
+    def _import_with_spies(self):
+        """Import ``core.utils`` after patching setup_ffmpeg+install_ffmpeg.
+
+        Returns a tuple of (module, setup_spy, install_spy).
+        """
+        import core.utils as fresh
+        importlib.reload(fresh)
+
+        setup_spy = mock.patch.object(
+            fresh, "setup_ffmpeg", wraps=fresh.setup_ffmpeg
+        ).start()
+        install_spy = mock.patch.object(
+            fresh, "install_ffmpeg", return_value=(None, None)
+        ).start()
+        # Reset the lazy gate so subsequent calls trigger setup_ffmpeg again.
+        fresh.FFMPEG_PATH = None
+        fresh.FFPROBE_PATH = None
+        fresh._FFMPEG_SETUP_DONE = False
+        return fresh, setup_spy, install_spy
+
+    def tearDown(self):
+        mock.patch.stopall()
+
+    def test_import_does_not_call_setup_ffmpeg(self):
+        """Plain ``import core.utils`` must not run setup_ffmpeg()."""
+        # Patch the underlying primitives BEFORE the import. setup_ffmpeg
+        # itself is module-level so we can't easily patch it pre-import,
+        # but the side effects (shutil.which, install_ffmpeg) we can.
+        with mock.patch("shutil.which") as which_mock, \
+             mock.patch("subprocess.run") as run_mock:
+            for module_name in list(sys.modules):
+                if module_name == "core.utils" or module_name.startswith("core.utils."):
+                    del sys.modules[module_name]
+            import core.utils  # noqa: F401
+            # No FFmpeg-related work should happen during import.
+            self.assertFalse(which_mock.called,
+                             "shutil.which must not be called during core.utils import")
+            self.assertFalse(run_mock.called,
+                             "subprocess.run must not be called during core.utils import")
+            self.assertIsNone(core.utils.FFMPEG_PATH,
+                              "FFMPEG_PATH must be None until ensure_ffmpeg_available() runs")
+            self.assertIsNone(core.utils.FFPROBE_PATH,
+                              "FFPROBE_PATH must be None until ensure_ffmpeg_available() runs")
+            self.assertFalse(core.utils._FFMPEG_SETUP_DONE,
+                             "_FFMPEG_SETUP_DONE must be False until ensure runs")
+
+    def test_ensure_runs_setup_only_once(self):
+        """ensure_ffmpeg_available() must call setup_ffmpeg only on first invocation."""
+        utils, setup_spy, _ = self._import_with_spies()
+
+        utils.ensure_ffmpeg_available(auto_install=False)
+        first_calls = setup_spy.call_count
+
+        utils.ensure_ffmpeg_available(auto_install=False)
+        utils.ensure_ffmpeg_available(auto_install=True)
+        utils.ensure_ffmpeg_available(auto_install=False)
+        self.assertEqual(setup_spy.call_count, first_calls,
+                         "setup_ffmpeg must be cached after the first ensure call")
+
+    def test_check_ffmpeg_available_does_not_auto_install_by_default(self):
+        """check_ffmpeg_available() defaults to auto_install=False."""
+        utils, _, install_spy = self._import_with_spies()
+
+        with mock.patch("shutil.which", return_value=None), \
+             mock.patch.object(utils, "find_ffmpeg_in_common_paths",
+                               return_value=(None, None)):
+            utils.check_ffmpeg_available()
+            self.assertFalse(install_spy.called,
+                             "check_ffmpeg_available() default must not trigger install")
+
+    def test_check_ffmpeg_available_with_auto_install_triggers_install(self):
+        """check_ffmpeg_available(auto_install=True) must reach install_ffmpeg()."""
+        utils, _, install_spy = self._import_with_spies()
+
+        with mock.patch("shutil.which", return_value=None), \
+             mock.patch.object(utils, "find_ffmpeg_in_common_paths",
+                               return_value=(None, None)):
+            utils.check_ffmpeg_available(auto_install=True)
+            self.assertTrue(install_spy.called,
+                            "check_ffmpeg_available(auto_install=True) must call install_ffmpeg")
+
+    def test_truehd_helpers_trigger_lazy_setup(self):
+        """is_truehd_file/convert/get_info trigger ensure_ffmpeg_available(True)."""
+        utils, setup_spy, install_spy = self._import_with_spies()
+
+        with mock.patch("shutil.which", return_value=None), \
+             mock.patch.object(utils, "find_ffmpeg_in_common_paths",
+                               return_value=(None, None)):
+            self.assertFalse(utils.is_truehd_file("/dev/null/nonexistent.mlp"))
+            self.assertTrue(setup_spy.called,
+                            "is_truehd_file must trigger setup")
+            self.assertTrue(install_spy.called,
+                            "is_truehd_file must use auto_install=True")
+
+    def test_read_audio_wav_skips_ffmpeg_setup(self):
+        """Reading a regular .wav must not trigger FFmpeg setup at all."""
+        utils, setup_spy, install_spy = self._import_with_spies()
+
+        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tf:
+            wav_path = tf.name
+        try:
+            sf.write(wav_path, np.zeros(1024, dtype=np.float32), 48000)
+
+            fs, data, channel_info = utils.read_audio(wav_path)
+            self.assertEqual(fs, 48000)
+            self.assertEqual(data.shape[-1], 1024)
+            self.assertIsNone(channel_info)
+            self.assertFalse(setup_spy.called,
+                             "read_audio for .wav must not call setup_ffmpeg")
+            self.assertFalse(install_spy.called,
+                             "read_audio for .wav must not call install_ffmpeg")
+        finally:
+            if os.path.exists(wav_path):
+                os.remove(wav_path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
플롯 후 ~3GB 메모리 잔류와 import-time FFmpeg subprocess 비용을 함께 정리. BRIR 출력은 bit-identical (데모 hesuvi.wav md5 유지).

플롯 메모리 잔류 (impulcifer.py + core/hrir.py)
- 플롯용 convolve를 ProcessPoolExecutor 14개 워커에서 직렬 scipy.signal. convolve로 환원. plot_tasks/plot_results 튜플이 hrir/estimator 메모리 회수 후에도 recording·test_signal 참조를 유지하던 ~3GB 잔류 경로 제거
- 메모리 회수 블록을 중간 변수(eq_tasks/eq_results/decay_tasks/ decay_results) → 루트 객체(hrir/estimator/...) 순서로 정정. safety net 으로 plt.close('all')을 gc.collect() 직전에 호출
- HRIR.plot()을 2-pass 렌더링으로 리팩토링: Pass 1에서 figure 1개씩 생성·축 범위 수집 후 즉시 plt.close, Pass 2에서 동기화된 limit으로 재생성·저장. 동시 존재 figure를 14개 → 1개로 줄여 matplotlib 단편화 에 의한 메모리 부풀림 차단

FFmpeg lazy setup (core/utils.py)
- core.utils import 시점에 항상 실행되던 setup_ffmpeg()를 ensure_ffmpeg_available()로 분리하여 실제 사용 시점까지 지연
- 일반 WAV / ProcessPool 워커 / unit test에서는 ffmpeg/ffprobe subprocess 호출이 발생하지 않음
- TrueHD/MLP 처리 경로(is_truehd_file/convert_truehd_to_wav/ get_truehd_channel_info, open_impulse_response_estimator의 .mlp 분기) 는 auto_install=True를 유지해 자동 설치 UX 보존
- read_audio()는 확장자가 .mlp/.thd/.truehd가 아니면 is_truehd_file() 호출을 우회

기타
- process_equalization_worker가 unpack만 하고 사용하지 않던 ir 객체를 task tuple에서 제외 (ProcessPool pickle/IPC 비용 제거)
- core/hrir.py 미사용 sync_axes import 제거
- tests/test_ffmpeg_lazy_setup.py 추가 (6 테스트, 모두 통과)

Verification
- Tier 1: py_compile + ruff check 통과
- Tier 2: 16/16 test_suite + 6/6 test_ffmpeg_lazy_setup 통과 (test_magnitude_response_parity는 numpy 2.3.5/scipy 1.16.3 round-off로 master에서도 사전 실패 — 본 PR과 무관)
- Tier 3: data/demo BRIR 생성 결과 master와 bit-identical (md5 07eef9ef89cc0d55313c9c0c18edbc76, --plot 유무와 무관하게 일치)