### PR TITLE
fix: Velopack 자동 업데이트 다운로드 실패 해결 (2.4.17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ first number changes, something has broken and you need to check your commands a
 changes there are only new features available and nothing old has broken and when the last number changes, old bugs have
 been fixed and old features improved.
 
+## 2.4.17 - 2026-05-03
+### 🐛 스탠드얼론 자동 업데이트 다운로드 실패 해결
+
+#### 🐛 버그 수정
+- **Velopack 자동 업데이트 다운로드 실패 (#82)**: 스탠드얼론 빌드의 GUI에서 "지금 업데이트" 클릭 시 "업데이트 다운로드 실패. 나중에 다시 시도해주세요." 오류로 항상 실패하던 회귀 수정
+  - **근본 원인**: 코드는 `Update.exe download <feed_url>` 서브커맨드로 다운로드를 위임했지만, Velopack v0.0.x에서 `download` 서브커맨드가 완전히 제거되었고 다운로드 책임이 SDK 측(lib-csharp/lib-rust/...)으로 이동. 현 Velopack의 `Update.exe`는 `apply`/`start`/`patch`/`uninstall`/`update-self`만 인식하므로 호출이 "Unknown subcommand 'download'"로 즉시 실패하고 GUI가 일반 오류 다이얼로그를 띄움
+  - **수정**: `VelopackUpdater.check_and_download()`을 Python urllib 기반으로 재구현. `releases.<channel>.json` 매니페스트(`win`/`osx`/`linux`)를 파싱하여 최신 full nupkg를 찾고, 청크 단위 스트리밍으로 Velopack의 packages 디렉터리(`<root>/packages` 또는 LOCALAPPDATA fallback)에 `.partial` 임시 파일로 저장. SHA256(우선) 또는 SHA1로 무결성 검증 후 최종 경로로 rename. 캐시된 동일 크기/체크섬 패키지가 이미 있으면 재다운로드 생략
+  - **`apply_and_restart()` 강화**: `Update.exe apply --package <downloaded_path>`로 명시 인자를 전달해 Velopack의 `find_latest_full_package` 휴리스틱에 의존하지 않도록 함. `--restart`는 Velopack v0.0.x apply의 기본 동작이라 별도 플래그 불필요
+  - **에러 메시지 개선**: 다운로드 실패 시 GUI에 “release feed 도달 불가 / 패키지 누락 / 체크섬 검증 실패” 가능 원인과 GitHub에서 수동 다운로드하라는 fallback 안내를 함께 표시
+- **회귀 방지 테스트 추가** (`tests/test_velopack_updater.py`, 13개): 실제 localhost HTTP 서버 + 가짜 `Update.exe` 스크립트 + 가짜 Velopack 설치 레이아웃(`<root>/Update.exe`, `<root>/current/app.exe`, `<root>/sq.version`, `<root>/packages/`)을 tempdir에 구성하여 스탠드얼론 빌드를 띄우지 않고도 업데이트 경로를 end-to-end로 검증. Linux/macOS/Windows 어디서든 실행 가능
+  - 행복 경로(매니페스트 → nupkg → 체크섬 검증 → packages 디렉터리에 저장)
+  - `Update.exe download` 서브커맨드가 절대 호출되지 않음을 가짜 스크립트의 invocation log로 검증
+  - 캐시된 패키지 재다운로드 생략 / 크기 불일치 시 재다운로드
+  - 체크섬 불일치 / 매니페스트 누락 / 서버 도달 불가 시 깨끗하게 False 반환 (예외로 누설되지 않음)
+  - 진행률 콜백이 `(downloaded, total)` 바이트 쌍을 받음
+  - `apply_and_restart()`가 `Update.exe apply --package <path>`를 호출하고 `download`를 절대 포함하지 않음
+  - 읽기 전용 root → LOCALAPPDATA fallback / `sq.version`에서 packId 읽기 / Update.exe 부재 시 안전한 False 반환
+
 ## 2.4.16 - 2026-05-03
 ### ⚡ 플롯 메모리 잔류 해소와 FFmpeg lazy setup
 

--- a/impulcifer.py
+++ b/impulcifer.py
@@ -44,7 +44,7 @@ def _get_version() -> str:
         pass
 
     # Fallback
-    return "2.4.16"
+    return "2.4.17"
 
 __version__ = _get_version()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "impulcifer-py313"
-version = "2.4.16"
+version = "2.4.17"
 authors = [
   { name="원본 저자: Jaakko Pasanen", email="" },
   { name="Python 3.13/3.14 호환 버전: 115dkk", email="" },

--- a/tests/test_velopack_updater.py
+++ b/tests/test_velopack_updater.py
@@ -1,0 +1,488 @@
+# -*- coding: utf-8 -*-
+"""End-to-end regression tests for the Velopack standalone update path.
+
+These tests reproduce the failure observed in the 2.4.13 standalone build —
+``Update.exe download <url>`` returning "Unknown subcommand 'download'" — by
+running the actual ``VelopackUpdater.check_and_download()`` flow against:
+
+  * A real localhost HTTP server serving a ``releases.win.json`` manifest and
+    a fake ``.nupkg`` payload, and
+  * A real fake ``Update.exe`` script in a tempdir laid out exactly like a
+    Velopack-installed app (``<root>/Update.exe`` + ``<root>/current/`` +
+    ``<root>/packages/``).
+
+The tests verify the BUG-FIX contract:
+
+  1. Velopack's ``download`` subcommand is **never** invoked. The fake
+     ``Update.exe`` records every invocation; only ``apply`` is allowed and
+     any ``download`` call fails the test.
+  2. Successful downloads land in ``<root>/packages/<filename>.nupkg`` with
+     the right size and checksum.
+  3. Manifest-fetch / network / checksum failures all return ``False``
+     (instead of raising), so the GUI surfaces the localized error.
+  4. ``VelopackUpdater.apply_and_restart()`` invokes ``Update.exe apply
+     --package <path>`` on success — confirming the apply path picks up the
+     downloaded ``.nupkg`` directly rather than relying on Velopack's
+     packages-directory heuristic.
+
+If the ``download``-subcommand regression returns, test 1 fails immediately.
+If the URL pattern or feed schema drifts, tests 2-3 fail with a precise
+mismatch message. The tests run on every platform — they don't require an
+actual standalone build, so CI catches breakage before ship.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import http.server
+import json
+import os
+import socket
+import socketserver
+import stat
+import sys
+import tempfile
+import threading
+import unittest
+import unittest.mock as mock
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator, List, Tuple
+
+import updater.updater_core as updater_core
+from updater.updater_core import (
+    UpdateExecutionError,
+    VelopackExecutor,
+    VelopackUpdater,
+)
+
+
+PACK_ID = "Impulcifer"
+LATEST_VERSION = "2.4.99"
+PACKAGE_BYTES = b"FAKE-NUPKG-CONTENTS-FOR-REGRESSION-TEST" * 16
+
+
+def _free_port() -> int:
+    """Return a free TCP port on localhost so parallel tests don't collide."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+class _ManifestHandler(http.server.BaseHTTPRequestHandler):
+    """Serves a Velopack release feed — manifest + nupkg + 404 for the rest.
+
+    Routes (relative to ``/``):
+      * ``/releases.win.json`` — the JSON release index Velopack now uses
+      * ``/releases.osx.json`` / ``/releases.linux.json`` — same for unit
+        tests that exercise alternate channels
+      * ``/Impulcifer-2.4.99-full.nupkg`` — the binary payload
+      * Anything else → 404
+    """
+
+    # Filled in by the harness before requests start arriving.
+    server_payload: bytes = b""
+    server_manifest: dict = {}
+    request_log: List[str] = []
+
+    def log_message(self, format, *args):  # noqa: A002 — http.server signature
+        # Silence the default stderr access log for clean test output.
+        return
+
+    def do_GET(self):  # noqa: N802 — http.server signature
+        type(self).request_log.append(self.path)
+        if self.path.startswith("/releases.") and self.path.endswith(".json"):
+            payload = json.dumps(type(self).server_manifest).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+            return
+
+        if self.path.endswith(".nupkg"):
+            payload = type(self).server_payload
+            self.send_response(200)
+            self.send_header("Content-Type", "application/octet-stream")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+            return
+
+        self.send_response(404)
+        self.end_headers()
+
+
+@contextmanager
+def _release_server(payload: bytes, manifest: dict) -> Iterator[Tuple[str, List[str]]]:
+    """Spin up a localhost server with the given payload + manifest."""
+    handler = _ManifestHandler
+    handler.server_payload = payload
+    handler.server_manifest = manifest
+    handler.request_log = []
+
+    port = _free_port()
+    server = socketserver.TCPServer(("127.0.0.1", port), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    try:
+        yield f"http://127.0.0.1:{port}", handler.request_log
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def _build_manifest(payload: bytes, version: str = LATEST_VERSION) -> dict:
+    """Return a Velopack-format release manifest for ``payload``.
+
+    Mirrors the schema produced by ``vpk pack`` in CI — ``Assets`` is a list
+    of full / delta entries with checksums, sizes, and filenames.
+    """
+    return {
+        "Assets": [
+            {
+                "PackageId": PACK_ID,
+                "Version": version,
+                "Type": "Full",
+                "FileName": f"{PACK_ID}-{version}-full.nupkg",
+                "SHA1": hashlib.sha1(payload).hexdigest().upper(),
+                "SHA256": hashlib.sha256(payload).hexdigest().upper(),
+                "Size": len(payload),
+            }
+        ]
+    }
+
+
+def _make_fake_update_exe(target: Path, log_path: Path) -> None:
+    """Write a fake ``Update.exe`` script that logs args + exit code.
+
+    The script accepts the ``apply`` subcommand (and writes its argv to
+    ``log_path``) and rejects ``download`` outright — exactly mirroring the
+    behaviour of the real Velopack ``Update.exe`` v0.0.1298+. If the
+    Python-side download path ever falls back to invoking ``Update.exe
+    download``, the regression test fails with a clear message.
+
+    On Windows we still emit a ``.cmd`` despite the ``.exe`` filename — the
+    test never executes ``apply_and_restart``, only inspects the script
+    contents. (Velopack's apply path is exercised separately via mock_apply.)
+    """
+    if sys.platform == "win32":
+        # Use a .cmd-style batch so the file is at least syntactically valid
+        # if a future test does shell-execute it; the assertion logic never
+        # actually runs it though.
+        script = (
+            "@echo off\r\n"
+            f"echo %* >> \"{log_path}\"\r\n"
+            "if /I \"%1\"==\"download\" exit /b 1\r\n"
+            "exit /b 0\r\n"
+        )
+    else:
+        script = (
+            "#!/bin/sh\n"
+            f"echo \"$@\" >> \"{log_path}\"\n"
+            "if [ \"$1\" = \"download\" ]; then exit 1; fi\n"
+            "exit 0\n"
+        )
+    target.write_text(script, encoding="utf-8")
+    if sys.platform != "win32":
+        target.chmod(target.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+@contextmanager
+def _fake_velopack_install() -> Iterator[Tuple[Path, Path, Path]]:
+    """Yield ``(root, update_exe, packages_dir)`` for a fake install layout.
+
+    Layout matches what Velopack's installer produces on Windows:
+      * ``<root>/Update.exe``
+      * ``<root>/current/app.exe`` (we don't actually execute it)
+      * ``<root>/packages/`` (created on demand)
+      * ``<root>/sq.version`` with ``id=Impulcifer`` so the pack-ID lookup hits
+
+    A lightweight ``Update.exe.log`` next to ``Update.exe`` records every
+    invocation so tests can assert which subcommands were run.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        root = Path(tmpdir) / PACK_ID
+        root.mkdir()
+        (root / "current").mkdir()
+        (root / "current" / "app.exe").write_bytes(b"")
+        (root / "sq.version").write_text(f"id={PACK_ID}\nversion=2.4.13\n", encoding="utf-8")
+
+        update_exe = root / "Update.exe"
+        log_path = root / "Update.exe.log"
+        _make_fake_update_exe(update_exe, log_path)
+
+        packages_dir = root / "packages"
+
+        yield root, update_exe, packages_dir
+
+
+class VelopackUpdaterDownloadTest(unittest.TestCase):
+    """Regression tests for the Python-driven download path."""
+
+    def test_download_fetches_manifest_and_writes_package(self) -> None:
+        """Happy path: manifest → nupkg → checksum-verified file on disk."""
+        manifest = _build_manifest(PACKAGE_BYTES)
+
+        with _fake_velopack_install() as (root, update_exe, packages_dir), \
+             _release_server(PACKAGE_BYTES, manifest) as (base_url, log):
+
+            with mock.patch.object(updater_core, "get_velopack_update_exe",
+                                   return_value=update_exe):
+                u = VelopackUpdater(base_url, LATEST_VERSION)
+                self.assertTrue(u.check_and_download(),
+                                "Happy path must return True")
+
+            # The fixed implementation must NOT touch the legacy
+            # ``Update.exe download`` subcommand. (That's the whole bug.)
+            self.assertNotIn("download", str((root / "Update.exe.log").read_text("utf-8"))
+                             if (root / "Update.exe.log").exists() else "",
+                             "Update.exe must never receive the 'download' subcommand")
+
+            # Manifest fetch + nupkg fetch should both have happened.
+            self.assertIn(f"/releases.{u._detect_channel()}.json", log)
+            expected_filename = manifest["Assets"][0]["FileName"]
+            self.assertIn(f"/{expected_filename}", log)
+
+            # Package landed in the packages dir with the right contents.
+            target = packages_dir / expected_filename
+            self.assertTrue(target.exists(),
+                            f"Expected downloaded package at {target}")
+            self.assertEqual(target.read_bytes(), PACKAGE_BYTES)
+            self.assertEqual(u.downloaded_package, target)
+
+    def test_download_skips_when_package_already_present(self) -> None:
+        """Re-running the download must short-circuit on a cached package."""
+        manifest = _build_manifest(PACKAGE_BYTES)
+
+        with _fake_velopack_install() as (root, update_exe, packages_dir), \
+             _release_server(PACKAGE_BYTES, manifest) as (base_url, log):
+
+            packages_dir.mkdir(parents=True, exist_ok=True)
+            cached = packages_dir / manifest["Assets"][0]["FileName"]
+            cached.write_bytes(PACKAGE_BYTES)
+
+            with mock.patch.object(updater_core, "get_velopack_update_exe",
+                                   return_value=update_exe):
+                u = VelopackUpdater(base_url, LATEST_VERSION)
+                self.assertTrue(u.check_and_download())
+
+            nupkg_requests = [p for p in log if p.endswith(".nupkg")]
+            self.assertEqual(nupkg_requests, [],
+                             "Cached package present — must not refetch nupkg")
+
+    def test_download_redownloads_on_size_mismatch(self) -> None:
+        """A stale cached package with the wrong size must be replaced."""
+        manifest = _build_manifest(PACKAGE_BYTES)
+
+        with _fake_velopack_install() as (root, update_exe, packages_dir), \
+             _release_server(PACKAGE_BYTES, manifest) as (base_url, log):
+
+            packages_dir.mkdir(parents=True, exist_ok=True)
+            cached = packages_dir / manifest["Assets"][0]["FileName"]
+            cached.write_bytes(b"wrong-size")  # length 10, manifest expects 624
+
+            with mock.patch.object(updater_core, "get_velopack_update_exe",
+                                   return_value=update_exe):
+                u = VelopackUpdater(base_url, LATEST_VERSION)
+                self.assertTrue(u.check_and_download())
+
+            self.assertEqual(cached.read_bytes(), PACKAGE_BYTES,
+                             "Stale cached package must be replaced")
+
+    def test_download_fails_clean_on_checksum_mismatch(self) -> None:
+        """Tampered payload must fail download (returns False, no crash)."""
+        # Manifest claims one checksum, but the server returns different bytes.
+        manifest = _build_manifest(PACKAGE_BYTES)
+        with _fake_velopack_install() as (root, update_exe, packages_dir), \
+             _release_server(b"TAMPERED-PAYLOAD", manifest) as (base_url, _):
+
+            with mock.patch.object(updater_core, "get_velopack_update_exe",
+                                   return_value=update_exe):
+                u = VelopackUpdater(base_url, LATEST_VERSION)
+                self.assertFalse(u.check_and_download(),
+                                 "Checksum mismatch must return False")
+                self.assertIsNone(u.downloaded_package)
+
+            # The .partial file must be cleaned up so a retry starts fresh.
+            partials = list(packages_dir.glob("*.partial"))
+            self.assertEqual(partials, [],
+                             "Failed download must not leave .partial files behind")
+
+    def test_download_fails_clean_on_missing_manifest(self) -> None:
+        """No releases.<channel>.json on the server → False, no exception."""
+        # Server returns 404 for everything (no manifest registered).
+        with _fake_velopack_install() as (root, update_exe, _), \
+             _release_server(b"", {}) as (base_url, _):
+
+            class _EmptyHandler(_ManifestHandler):
+                pass
+
+            with mock.patch.object(updater_core, "get_velopack_update_exe",
+                                   return_value=update_exe):
+                u = VelopackUpdater(base_url, LATEST_VERSION)
+                # Empty manifest has no full assets → returns False
+                self.assertFalse(u.check_and_download())
+
+    def test_download_fails_clean_on_unreachable_server(self) -> None:
+        """Connection refused (port not listening) → False, no exception."""
+        with _fake_velopack_install() as (_, update_exe, _):
+            unreachable = f"http://127.0.0.1:{_free_port()}"
+            with mock.patch.object(updater_core, "get_velopack_update_exe",
+                                   return_value=update_exe):
+                u = VelopackUpdater(unreachable, LATEST_VERSION)
+                self.assertFalse(u.check_and_download())
+
+    def test_progress_callback_receives_byte_pairs(self) -> None:
+        """Progress callback gets ``(downloaded, total)`` pairs during stream."""
+        manifest = _build_manifest(PACKAGE_BYTES)
+        progress_log: List[Tuple[int, int]] = []
+
+        with _fake_velopack_install() as (_, update_exe, _), \
+             _release_server(PACKAGE_BYTES, manifest) as (base_url, _):
+
+            with mock.patch.object(updater_core, "get_velopack_update_exe",
+                                   return_value=update_exe):
+                u = VelopackUpdater(base_url, LATEST_VERSION)
+                self.assertTrue(u.check_and_download(progress_callback=lambda d, t: progress_log.append((d, t))))
+
+        self.assertGreater(len(progress_log), 0,
+                           "Progress callback must fire at least once")
+        last = progress_log[-1]
+        self.assertEqual(last[0], len(PACKAGE_BYTES),
+                         "Final downloaded byte count must equal package size")
+        self.assertEqual(last[1], len(PACKAGE_BYTES),
+                         "Final total must equal package size (matches Content-Length)")
+
+
+class VelopackUpdaterApplyTest(unittest.TestCase):
+    """Apply-and-restart tests — verify Update.exe args and exit semantics."""
+
+    def test_apply_passes_downloaded_package_to_update_exe(self) -> None:
+        """``apply --package <downloaded>`` is the exact subprocess invocation."""
+        manifest = _build_manifest(PACKAGE_BYTES)
+
+        with _fake_velopack_install() as (_, update_exe, packages_dir), \
+             _release_server(PACKAGE_BYTES, manifest) as (base_url, _):
+
+            with mock.patch.object(updater_core, "get_velopack_update_exe",
+                                   return_value=update_exe):
+                u = VelopackUpdater(base_url, LATEST_VERSION)
+                self.assertTrue(u.check_and_download())
+                expected_pkg = packages_dir / manifest["Assets"][0]["FileName"]
+                self.assertEqual(u.downloaded_package, expected_pkg)
+
+                # Stub Popen + sys.exit so apply_and_restart returns to the
+                # test harness instead of terminating the interpreter.
+                with mock.patch.object(updater_core.subprocess, "Popen") as popen_mock, \
+                     mock.patch.object(updater_core.sys, "exit",
+                                       side_effect=SystemExit(0)) as exit_mock:
+                    with self.assertRaises(SystemExit):
+                        u.apply_and_restart()
+
+                # The single Popen call must include "apply" (NOT "download")
+                # plus the explicit --package path.
+                self.assertEqual(popen_mock.call_count, 1)
+                args, _kwargs = popen_mock.call_args
+                cmd = args[0]
+                self.assertEqual(cmd[0], str(update_exe))
+                self.assertEqual(cmd[1], "apply")
+                self.assertNotIn("download", cmd,
+                                 "Apply command must never contain the 'download' subcommand")
+                self.assertIn("--package", cmd)
+                self.assertIn(str(expected_pkg), cmd)
+                exit_mock.assert_called_once_with(0)
+
+
+class VelopackExecutorTest(unittest.TestCase):
+    """End-to-end executor tests covering the GUI-facing surface."""
+
+    def test_executor_surfaces_actionable_error_on_download_failure(self) -> None:
+        """Failed download → UpdateExecutionError with manual-download hint."""
+        with _fake_velopack_install() as (_, update_exe, _):
+            unreachable = f"http://127.0.0.1:{_free_port()}"
+            with mock.patch.object(updater_core, "GITHUB_RELEASES_URL", unreachable), \
+                 mock.patch.object(updater_core, "get_velopack_update_exe",
+                                   return_value=update_exe):
+                executor = VelopackExecutor(LATEST_VERSION)
+                progress_calls: List[Tuple[float, str]] = []
+                with self.assertRaises(UpdateExecutionError) as cm:
+                    executor.execute(lambda p, m: progress_calls.append((p, m)))
+
+                msg = str(cm.exception).lower()
+                self.assertIn("download", msg,
+                              "Error must mention download for triage")
+                # Must hint at the manual-download fallback so the user is
+                # never blocked when auto-update fails.
+                self.assertIn("github", msg,
+                              "Error must point users at the GitHub fallback")
+
+    def test_executor_progress_is_normalized_to_unit_interval(self) -> None:
+        """Progress reported to the GUI must stay within [0.0, 1.0]."""
+        manifest = _build_manifest(PACKAGE_BYTES)
+        with _fake_velopack_install() as (_, update_exe, _), \
+             _release_server(PACKAGE_BYTES, manifest) as (base_url, _):
+
+            with mock.patch.object(updater_core, "GITHUB_RELEASES_URL", base_url), \
+                 mock.patch.object(updater_core, "get_velopack_update_exe",
+                                   return_value=update_exe):
+                executor = VelopackExecutor(LATEST_VERSION)
+                progress_calls: List[Tuple[float, str]] = []
+                executor.execute(lambda p, m: progress_calls.append((p, m)))
+
+                self.assertGreater(len(progress_calls), 0)
+                for p, _ in progress_calls:
+                    self.assertGreaterEqual(p, 0.0)
+                    self.assertLessEqual(p, 1.0)
+
+
+class VelopackUpdaterEnvironmentTest(unittest.TestCase):
+    """Sanity tests on the Velopack-environment helpers."""
+
+    def test_packages_dir_falls_back_when_root_not_writable(self) -> None:
+        """Read-only root → LOCALAPPDATA fallback (Windows-style behavior)."""
+        with _fake_velopack_install() as (root, update_exe, _), \
+             tempfile.TemporaryDirectory() as appdata:
+            packages_dir = root / "packages"
+
+            # Force the writability test inside _get_packages_dir to fail.
+            original_mkdir = Path.mkdir
+
+            def _failing_mkdir(self, *args, **kwargs):
+                if str(self) == str(packages_dir):
+                    raise PermissionError("simulated read-only install")
+                return original_mkdir(self, *args, **kwargs)
+
+            with mock.patch.object(updater_core, "get_velopack_update_exe",
+                                   return_value=update_exe), \
+                 mock.patch.dict(os.environ, {"LOCALAPPDATA": appdata}, clear=False), \
+                 mock.patch.object(Path, "mkdir", _failing_mkdir):
+
+                u = VelopackUpdater("http://example.invalid", LATEST_VERSION)
+                fallback = u._get_packages_dir()
+
+            self.assertEqual(fallback, Path(appdata) / PACK_ID / "packages")
+            self.assertTrue(fallback.exists(),
+                            "Fallback packages dir must be created")
+
+    def test_pack_id_read_from_sq_version(self) -> None:
+        """``sq.version`` ``id=`` line is the source of truth for pack ID."""
+        with _fake_velopack_install() as (_, update_exe, _):
+            with mock.patch.object(updater_core, "get_velopack_update_exe",
+                                   return_value=update_exe):
+                u = VelopackUpdater("http://example.invalid", LATEST_VERSION)
+                self.assertEqual(u._get_pack_id(), PACK_ID)
+
+    def test_no_update_exe_returns_false_immediately(self) -> None:
+        """Missing Update.exe must not crash — return False with a log line."""
+        with mock.patch.object(updater_core, "get_velopack_update_exe",
+                               return_value=None):
+            u = VelopackUpdater("http://example.invalid", LATEST_VERSION)
+            self.assertFalse(u.check_and_download())
+            self.assertFalse(u.apply_and_restart())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/updater/updater_core.py
+++ b/updater/updater_core.py
@@ -5,16 +5,21 @@ Automatic updater for Impulcifer
 Supports both Velopack (standalone) and pip (development/pip install) environments
 """
 
+import hashlib
+import json
 import os
 import sys
 import subprocess
+import urllib.error
 import urllib.request
 import tempfile
 import platform
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, Callable
+from typing import Callable, Dict, Optional
+
+from packaging import version as _version
 
 
 def _is_standalone_build() -> bool:
@@ -88,83 +93,321 @@ def is_pip_environment() -> bool:
         return False
 
 
+class VelopackDownloadError(RuntimeError):
+    """Raised when the Python-side Velopack download cannot complete.
+
+    Carries a short stable :attr:`reason` (e.g. ``"manifest_fetch_failed"``,
+    ``"checksum_mismatch"``) that can be surfaced to the user / regression
+    tests, plus an optional underlying detail string.
+    """
+
+    def __init__(self, reason: str, detail: str = ""):
+        self.reason = reason
+        self.detail = detail
+        super().__init__(f"{reason}: {detail}" if detail else reason)
+
+
 class VelopackUpdater:
-    """Updater for Velopack-installed standalone executables."""
+    """Updater for Velopack-installed standalone executables.
+
+    Important — Velopack v0.0.x removed the ``Update.exe download`` subcommand;
+    only ``apply`` / ``start`` / ``patch`` / ``uninstall`` / ``update-self``
+    remain, and the download path was moved entirely into the Velopack SDKs
+    (lib-csharp/lib-rust/...). Calling ``Update.exe download <url>`` against a
+    Velopack-installed app therefore fails with "Unknown subcommand 'download'"
+    on every modern build.
+
+    To stay compatible we drive the download from Python: fetch
+    ``releases.<channel>.json``, locate the latest full ``.nupkg``, stream it
+    into Velopack's packages directory with a SHA256/SHA1 verification, and
+    then call ``Update.exe apply --restart`` (which is still supported and
+    will auto-locate the package via ``find_latest_full_package``).
+    """
+
+    # Chunk size matched to typical TCP window — large enough to amortise
+    # syscall overhead, small enough that progress callbacks fire often.
+    _CHUNK_SIZE = 65536
 
     def __init__(self, releases_url: str, version: str):
-        """
-        Initialize Velopack updater.
+        """Initialize Velopack updater.
 
         Args:
-            releases_url: Base URL for releases (e.g., GitHub releases URL)
-            version: Target version string
+            releases_url: Base URL for releases. The trailing slash is
+                stripped; ``releases.<channel>.json`` and the resolved
+                ``.nupkg`` are appended at request time.
+            version: Target version string (used for diagnostic messages).
         """
-        self.releases_url = releases_url
+        self.releases_url = releases_url.rstrip('/')
         self.version = version
         self.update_exe = get_velopack_update_exe()
+        # Populated by :meth:`check_and_download` on success.
+        self.downloaded_package: Optional[Path] = None
+        # Last subprocess stderr for diagnostic surfacing in apply().
+        self.last_apply_stderr: Optional[str] = None
 
-    def check_and_download(self, progress_callback: Optional[Callable[[int, int], None]] = None) -> bool:
+    # ------------------------------------------------------------------
+    # Velopack environment discovery
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _detect_channel() -> str:
+        """Return the Velopack release-feed channel for this platform.
+
+        Velopack's CoreUtil.GetVeloReleaseIndexName uses ``win`` for Windows,
+        ``osx`` (with arch suffix in some pipelines) for macOS, and ``linux``
+        for Linux. We mirror that to find the right release index file.
         """
-        Check for updates and download if available.
+        system = platform.system()
+        if system == 'Windows':
+            return 'win'
+        if system == 'Darwin':
+            return 'osx'
+        if system == 'Linux':
+            return 'linux'
+        return 'win'
+
+    def _get_packages_dir(self) -> Path:
+        """Return Velopack's packages directory for this install.
+
+        Default: ``<update_exe_dir>/packages``. If that directory cannot be
+        created or written to (UAC-protected ProgramFiles install), Velopack
+        falls back to ``%LOCALAPPDATA%\\<packId>\\packages`` — we mirror that.
+        """
+        if not self.update_exe:
+            raise VelopackDownloadError("update_exe_missing")
+
+        root = self.update_exe.parent
+        packages_dir = root / "packages"
+
+        try:
+            packages_dir.mkdir(parents=True, exist_ok=True)
+            test_file = packages_dir / ".write_test"
+            test_file.write_text("ok", encoding='utf-8')
+            test_file.unlink()
+            return packages_dir
+        except (OSError, PermissionError):
+            local_app_data = os.environ.get('LOCALAPPDATA')
+            if local_app_data:
+                pack_id = self._get_pack_id() or "Impulcifer"
+                fallback = Path(local_app_data) / pack_id / "packages"
+                fallback.mkdir(parents=True, exist_ok=True)
+                return fallback
+            raise VelopackDownloadError(
+                "packages_dir_not_writable",
+                f"Cannot write to {packages_dir} and LOCALAPPDATA is unset.",
+            )
+
+    def _get_pack_id(self) -> Optional[str]:
+        """Read the Velopack pack ID from ``sq.version`` next to Update.exe.
+
+        The format is a simple ``key=value`` text file written by ``vpk pack``;
+        ``id`` carries the pack identifier (e.g. ``Impulcifer``). If the file
+        is missing we fall back to the directory name, which is the install
+        layout's pack folder for default Velopack installs.
+        """
+        if not self.update_exe:
+            return None
+        sq_version = self.update_exe.parent / "sq.version"
+        if sq_version.exists():
+            try:
+                for raw_line in sq_version.read_text(encoding='utf-8', errors='replace').splitlines():
+                    line = raw_line.strip()
+                    if line.lower().startswith("id="):
+                        return line.split("=", 1)[1].strip()
+            except (OSError, ValueError):
+                pass
+        return self.update_exe.parent.name
+
+    # ------------------------------------------------------------------
+    # Manifest + download
+    # ------------------------------------------------------------------
+
+    def _open_url(self, url: str, timeout: int):
+        """Open a URL with the standard Impulcifer-Updater UA + 30s timeout."""
+        req = urllib.request.Request(
+            url,
+            headers={'User-Agent': 'Impulcifer-Updater', 'Accept': 'application/json, */*'},
+        )
+        return urllib.request.urlopen(req, timeout=timeout)
+
+    def _fetch_release_manifest(self, channel: str) -> Optional[Dict]:
+        """Fetch ``releases.<channel>.json`` and return the latest full asset."""
+        url = f"{self.releases_url}/releases.{channel}.json"
+        try:
+            with self._open_url(url, timeout=30) as response:
+                data = json.loads(response.read().decode('utf-8'))
+        except (urllib.error.HTTPError, urllib.error.URLError, json.JSONDecodeError, OSError) as exc:
+            print(f"Failed to fetch {url}: {exc}")
+            return None
+
+        assets = data.get('Assets') or []
+        full_assets = [a for a in assets if str(a.get('Type', '')).lower() == 'full']
+        if not full_assets:
+            return None
+
+        def _key(asset: Dict):
+            try:
+                return _version.parse(str(asset.get('Version', '0')))
+            except Exception:
+                return _version.parse('0')
+
+        return max(full_assets, key=_key)
+
+    def _verify_checksum(self, path: Path, asset_info: Dict) -> bool:
+        """Verify SHA256 (preferred) / SHA1 against ``asset_info``.
+
+        Velopack's ``releases.<channel>.json`` carries both fields when
+        produced by recent ``vpk pack`` versions. Older feeds may carry only
+        SHA1 — we accept either, preferring SHA256 when both are present.
+        """
+        expected_sha256 = asset_info.get('SHA256')
+        expected_sha1 = asset_info.get('SHA1')
+        if not expected_sha256 and not expected_sha1:
+            # Velopack's own SDK enforces a checksum; missing-by-design is
+            # unexpected, but we choose to accept rather than block here so
+            # we don't regress feeds that were intentionally unsigned.
+            return True
+
+        sha256_hasher = hashlib.sha256()
+        sha1_hasher = hashlib.sha1()
+        with open(path, 'rb') as f:
+            for chunk in iter(lambda: f.read(self._CHUNK_SIZE), b''):
+                sha256_hasher.update(chunk)
+                sha1_hasher.update(chunk)
+
+        if expected_sha256:
+            return sha256_hasher.hexdigest().lower() == expected_sha256.lower()
+        return sha1_hasher.hexdigest().lower() == expected_sha1.lower()
+
+    def check_and_download(
+        self, progress_callback: Optional[Callable[[int, int], None]] = None
+    ) -> bool:
+        """Fetch the release manifest and download the latest full ``.nupkg``.
 
         Args:
-            progress_callback: Optional callback for progress updates
+            progress_callback: Optional ``(downloaded_bytes, total_bytes)``
+                callback invoked while the package streams to disk.
 
         Returns:
-            True if update is downloaded and ready to apply
+            ``True`` if a complete, checksum-verified ``.nupkg`` is staged in
+            the packages directory. ``False`` otherwise; diagnostic detail is
+            printed to stdout (and recoverable via ``last_apply_stderr`` for
+            apply errors).
         """
         if not self.update_exe:
             print("Velopack Update.exe not found")
             return False
 
         try:
-            # Velopack CLI로 업데이트 확인 및 다운로드
-            result = subprocess.run(
-                [str(self.update_exe), "download", self.releases_url],
-                capture_output=True,
-                text=True,
-                timeout=120
-            )
+            channel = self._detect_channel()
+            packages_dir = self._get_packages_dir()
+            asset_info = self._fetch_release_manifest(channel)
 
-            if result.returncode == 0:
-                print(f"Update downloaded successfully: {result.stdout}")
-                return True
-            else:
-                print(f"Update download failed: {result.stderr}")
+            if not asset_info:
+                print(
+                    f"No usable release manifest at {self.releases_url}/releases.{channel}.json. "
+                    "Server may be missing the Velopack release index."
+                )
                 return False
 
-        except subprocess.TimeoutExpired:
-            print("Update download timed out")
+            filename = asset_info.get('FileName')
+            if not filename:
+                print("Release manifest entry has no FileName.")
+                return False
+
+            target_path = packages_dir / filename
+            partial_path = packages_dir / f"{filename}.partial"
+            expected_size = int(asset_info.get('Size') or 0)
+
+            # If the package is already on disk and matches the expected size,
+            # skip the download — Velopack itself does the same.
+            if target_path.exists() and (
+                expected_size == 0 or target_path.stat().st_size == expected_size
+            ):
+                if self._verify_checksum(target_path, asset_info):
+                    print(f"Update package already present: {target_path}")
+                    self.downloaded_package = target_path
+                    return True
+                # Stale/corrupt — fall through to redownload.
+                target_path.unlink(missing_ok=True)
+
+            download_url = f"{self.releases_url}/{filename}"
+            print(f"Downloading update from {download_url}")
+
+            if partial_path.exists():
+                partial_path.unlink()
+
+            with self._open_url(download_url, timeout=120) as response:
+                total_size = int(response.headers.get('Content-Length') or expected_size)
+                downloaded = 0
+                with open(partial_path, 'wb') as f:
+                    while True:
+                        chunk = response.read(self._CHUNK_SIZE)
+                        if not chunk:
+                            break
+                        f.write(chunk)
+                        downloaded += len(chunk)
+                        if progress_callback and total_size > 0:
+                            progress_callback(downloaded, total_size)
+
+            if not self._verify_checksum(partial_path, asset_info):
+                partial_path.unlink(missing_ok=True)
+                print("Downloaded package failed checksum verification.")
+                return False
+
+            if target_path.exists():
+                target_path.unlink()
+            partial_path.rename(target_path)
+            self.downloaded_package = target_path
+
+            print(f"Update downloaded successfully: {target_path}")
+            return True
+
+        except VelopackDownloadError as exc:
+            print(f"Velopack environment error: {exc}")
             return False
-        except Exception as e:
-            print(f"Update download error: {e}")
+        except urllib.error.HTTPError as exc:
+            print(f"HTTP error during update download: {exc}")
+            return False
+        except urllib.error.URLError as exc:
+            print(f"Network error during update download: {exc}")
+            return False
+        except OSError as exc:
+            print(f"I/O error during update download: {exc}")
+            return False
+        except Exception as exc:  # noqa: BLE001 — last-line safety
+            print(f"Unexpected error during update download: {exc}")
             return False
 
     def apply_and_restart(self) -> bool:
-        """
-        Apply downloaded update and restart the application.
-        This method does not return if successful.
+        """Apply the staged update via ``Update.exe apply`` and restart.
 
-        Returns:
-            False if application failed (method returns only on failure)
+        ``Update.exe apply`` (without ``--norestart``) restarts by default.
+        We pass the explicit downloaded-package path when available so the
+        applier doesn't depend on ``find_latest_full_package`` heuristics.
         """
         if not self.update_exe:
             print("Velopack Update.exe not found")
             return False
 
-        try:
-            # Velopack이 앱을 종료하고 업데이트 적용 후 재시작함
-            subprocess.Popen(
-                [str(self.update_exe), "apply", "--restart"],
-                creationflags=subprocess.DETACHED_PROCESS | subprocess.CREATE_NEW_PROCESS_GROUP
-                if platform.system() == 'Windows' else 0
-            )
+        cmd = [str(self.update_exe), "apply"]
+        if self.downloaded_package and self.downloaded_package.exists():
+            cmd.extend(["--package", str(self.downloaded_package)])
 
-            # 현재 프로세스 종료
+        try:
+            kwargs: Dict = {}
+            if platform.system() == 'Windows':
+                kwargs['creationflags'] = (
+                    subprocess.DETACHED_PROCESS | subprocess.CREATE_NEW_PROCESS_GROUP
+                )
+            subprocess.Popen(cmd, **kwargs)
+
+            # 현재 프로세스 종료 — Velopack이 인계받아 적용 후 재시작
             sys.exit(0)
 
-        except Exception as e:
-            print(f"Update apply error: {e}")
+        except Exception as exc:  # noqa: BLE001 — surface at GUI layer
+            self.last_apply_stderr = str(exc)
+            print(f"Update apply error: {exc}")
             return False
 
 
@@ -400,9 +643,23 @@ class VelopackExecutor(UpdateExecutor):
     def execute(self, progress_callback: Callable[[float, str], None]) -> UpdateExecutionResult:
         """Download the Velopack update and prepare the apply action."""
         updater = VelopackUpdater(GITHUB_RELEASES_URL, self.latest_version)
-        progress_callback(0.3, "update_downloading")
-        if not updater.check_and_download():
-            raise UpdateExecutionError("Failed to download update")
+
+        # Progress for the .nupkg download streams from 0.1 → 0.8 of the
+        # overall bar; the remaining 0.8 → 1.0 covers checksum verify + apply.
+        def _download_progress(downloaded: int, total: int) -> None:
+            if total <= 0:
+                return
+            percent = int((downloaded / total) * 100)
+            progress_callback(0.1 + (downloaded / total) * 0.7, f"Downloading: {percent}%")
+
+        progress_callback(0.1, "update_downloading")
+        if not updater.check_and_download(progress_callback=_download_progress):
+            raise UpdateExecutionError(
+                "Failed to download update. The release feed may be unreachable, "
+                "the package may be missing from the release, or the file failed "
+                "checksum verification. Please check your internet connection and "
+                "try again, or download the latest installer manually from GitHub."
+            )
 
         progress_callback(0.8, "update_installing")
         return UpdateExecutionResult(


### PR DESCRIPTION
스탠드얼론 빌드 GUI에서 "지금 업데이트" 클릭 시 항상 "업데이트
다운로드 실패. 나중에 다시 시도해주세요." 오류로 실패하던 회귀 수정.

근본 원인
---------
Velopack v0.0.x에서 `Update.exe download <feed_url>` 서브커맨드가 완전히 제거되었고, 다운로드 책임이 Velopack SDK(lib-csharp/lib-rust/ ...) 측으로 이동했다. 현재 Velopack의 Update.exe는 apply/start/ patch/uninstall/update-self만 인식하므로 기존 Python 코드의 호출이 "Unknown subcommand 'download'"로 즉시 실패하고 GUI가 일반 오류 다이얼로그를 띄웠다.

수정
----
`VelopackUpdater.check_and_download()`을 Python urllib 기반으로 재구 현. `releases.<channel>.json` 매니페스트(win/osx/linux)를 파싱하여 최신 full nupkg를 찾고, 청크 스트리밍으로 Velopack의 packages 디렉 터리(<root>/packages 또는 LOCALAPPDATA fallback)에 `.partial` 임시 파일로 저장. SHA256(우선) 또는 SHA1로 무결성 검증 후 최종 경로로
rename. 캐시된 동일 크기/체크섬 패키지가 이미 있으면 재다운로드
생략.

`apply_and_restart()`은 `Update.exe apply --package <downloaded_path>` 로 명시 인자를 전달해 Velopack의 find_latest_full_package 휴리스틱 에 의존하지 않도록 함. --restart는 Velopack v0.0.x apply의 기본 동작이라 별도 플래그 불필요.

다운로드 실패 시 GUI에 "release feed 도달 불가 / 패키지 누락 / 체크
섬 검증 실패" 가능 원인과 GitHub에서 수동 다운로드하라는 fallback
안내를 함께 표시.

회귀 방지 테스트 (tests/test_velopack_updater.py, 13개)
------------------------------------------------------- 실제 localhost HTTP 서버 + 가짜 Update.exe 스크립트 + 가짜 Velopack 설치 레이아웃(<root>/Update.exe, <root>/current/app.exe, <root>/ sq.version, <root>/packages/)을 tempdir에 구성하여 스탠드얼론 빌드 없이도 업데이트 경로를 end-to-end로 검증. Linux/macOS/Windows 모두 에서 실행 가능.

검증 항목:
- 행복 경로(매니페스트 → nupkg → 체크섬 검증 → packages 디렉터리 저장)
- Update.exe `download` 서브커맨드가 절대 호출되지 않음을 가짜 스크립트의 invocation log로 검증
- 캐시된 패키지 재다운로드 생략 / 크기 불일치 시 재다운로드
- 체크섬 불일치 / 매니페스트 누락 / 서버 도달 불가 시 깨끗하게 False 반환 (예외 누설 X)
- 진행률 콜백이 (downloaded, total) 바이트 쌍을 받음
- apply_and_restart()이 `apply --package <path>`를 호출하고 `download`를 절대 포함하지 않음
- 읽기 전용 root → LOCALAPPDATA fallback
- sq.version에서 packId 읽기
- Update.exe 부재 시 안전한 False 반환

실제 GitHub 릴리스 피드(`releases.win.json`)에 대해서도 매니페스트
파싱이 정상 동작함을 확인 (Impulcifer-2.4.15-full.nupkg, 182MB, SHA256 일치).

검증 결과
---------
- Tier 1: py_compile + ruff check 통과
- Tier 2: 84 passed, 1 skipped (parity test는 numpy 2.3.5/scipy 1.16.3 round-off로 master에서도 사전 실패, 본 PR과 무관)

배포 영향
---------
이 수정은 2.4.17 이후 빌드부터 자동 업데이트가 정상 작동하도록 함.
2.4.13/2.4.15 등 기존 사용자는 한 번은 GitHub releases에서 수동으 로 2.4.17을 설치해야 하며, 이후부터는 GUI에서 자동 업데이트가 작
동함.