### PR TITLE
fix: 한국어 로케일 mojibake 복구 + update_restart_done 누락 키 (2.4.19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ first number changes, something has broken and you need to check your commands a
 changes there are only new features available and nothing old has broken and when the last number changes, old bugs have
 been fixed and old features improved.
 
+## 2.4.19 - 2026-05-04
+### 🐛 한국어 로케일 mojibake 복구 + 업데이트 재시작 알림 누락 키 추가
+
+#### 🐛 버그 수정
+- **`update_restart_done` 키 누락(전 언어)**: Velopack 자동 업데이트로 앱이 재시작된 직후 띄우는 정보 다이얼로그(`gui/modern_gui.py:67-69`)가 코드에서 `loc.get('update_restart_done', default=...)`를 호출하지만 9개 로케일 어디에도 키가 없어 본문이 키 이름 그대로 `update_restart_done`으로 표시되던 회귀
+  - **수정**: 9개 캐노니컬 로케일(`en, ko, de, es, fr, ja, ru, zh_CN, zh_TW`) 전부에 키 추가. ko는 자연스러운 한국어 번역(`새 버전이 정상적으로 설치되었습니다.`), 나머지 7개 비-en 언어는 영어 fallback(`The new version has been installed successfully.`)으로 동기화. 키 총수 273→274
+- **ko.json 3개 키 mojibake 복구**: 한글이 `?`로 망가져 있어 사용자에게 `??? 한국어(?)? ???????.` 같은 텍스트가 노출되던 문제. CP949↔UTF-8 인코딩 사고로 추정
+  - `message_language_changed` (ko.json:97): `??? {language}(?)? ???????.` → `언어가 {language}(으)로 변경되었습니다.` (조사 자동 처리 형태로 복구)
+  - `message_processing_cancelling` (ko.json:273): `?? ??? ??? ?? ?????...` → `현재 단계가 끝나면 취소됩니다...`
+  - `message_processing_cancelled` (ko.json:274): `??? ???????.` → `처리가 취소되었습니다.`
+
 ## 2.4.18 - 2026-05-04
 ### 🔧 데모 데이터 raw binary 전환 (LFS 포기)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ been fixed and old features improved.
   - **수정**: 9개 캐노니컬 로케일(`en, ko, de, es, fr, ja, ru, zh_CN, zh_TW`) 전부에 키 추가. ko는 자연스러운 한국어 번역(`새 버전이 정상적으로 설치되었습니다.`), 나머지 7개 비-en 언어는 영어 fallback(`The new version has been installed successfully.`)으로 동기화. 키 총수 273→274
 - **ko.json 3개 키 mojibake 복구**: 한글이 `?`로 망가져 있어 사용자에게 `??? 한국어(?)? ???????.` 같은 텍스트가 노출되던 문제. CP949↔UTF-8 인코딩 사고로 추정
   - `message_language_changed` (ko.json:97): `??? {language}(?)? ???????.` → `언어가 {language}(으)로 변경되었습니다.` (조사 자동 처리 형태로 복구)
-  - `message_processing_cancelling` (ko.json:273): `?? ??? ??? ?? ?????...` → `현재 단계가 끝나면 취소됩니다...`
+  - `message_processing_cancelling` (ko.json:273): `?? ??? ??? ?? ?????...` → `이 작업을 마치고 취소하겠습니다...`
   - `message_processing_cancelled` (ko.json:274): `??? ???????.` → `처리가 취소되었습니다.`
 
 ## 2.4.18 - 2026-05-04

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -215,6 +215,7 @@
   "update_complete_message": "Das Update wurde im Hintergrund gestartet.\nBitte starten Sie die Anwendung neu, um die neue Version zu verwenden.",
   "update_error_no_installer": "Installationsprogramm nicht verfügbar. Bitte laden Sie manuell von GitHub herunter:\nhttps://github.com/115dkk/Impulcifer-pip313/releases/latest",
   "update_restart_message": "Die Anwendung wird jetzt neu gestartet, um das Update abzuschließen.",
+  "update_restart_done": "The new version has been installed successfully.",
   "update_error_apply": "Update konnte nicht angewendet werden",
   "update_manual_complete": "Bitte folgen Sie den Anweisungen des Installationsprogramms, um das Update abzuschließen.",
   "section_data_access": "Datenzugriff",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -222,6 +222,7 @@
   "update_complete_message": "The update has been started in the background.\nPlease restart the application to use the new version.",
   "update_error_no_installer": "No installer available. Please download manually from GitHub:\nhttps://github.com/115dkk/Impulcifer-pip313/releases/latest",
   "update_restart_message": "The application will now restart to complete the update.",
+  "update_restart_done": "The new version has been installed successfully.",
   "update_error_apply": "Failed to apply update",
   "update_manual_complete": "Please follow the installer prompts to complete the update.",
   "section_data_access": "Data Access",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -215,6 +215,7 @@
   "update_complete_message": "La actualización ha comenzado en segundo plano.\nPor favor, reinicie la aplicación para usar la nueva versión.",
   "update_error_no_installer": "Instalador no disponible. Por favor, descargue manualmente desde GitHub:\nhttps://github.com/115dkk/Impulcifer-pip313/releases/latest",
   "update_restart_message": "La aplicación se reiniciará ahora para completar la actualización.",
+  "update_restart_done": "The new version has been installed successfully.",
   "update_error_apply": "Error al aplicar la actualización",
   "update_manual_complete": "Por favor, siga las instrucciones del instalador para completar la actualización.",
   "section_data_access": "Acceso a datos",

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -215,6 +215,7 @@
   "update_complete_message": "La mise à jour a été lancée en arrière-plan.\nVeuillez redémarrer l'application pour utiliser la nouvelle version.",
   "update_error_no_installer": "Installateur non disponible. Veuillez télécharger manuellement depuis GitHub :\nhttps://github.com/115dkk/Impulcifer-pip313/releases/latest",
   "update_restart_message": "L'application va maintenant redémarrer pour terminer la mise à jour.",
+  "update_restart_done": "The new version has been installed successfully.",
   "update_error_apply": "Échec de l'application de la mise à jour",
   "update_manual_complete": "Veuillez suivre les instructions de l'installateur pour terminer la mise à jour.",
   "section_data_access": "Accès aux données",

--- a/i18n/locales/ja.json
+++ b/i18n/locales/ja.json
@@ -215,6 +215,7 @@
   "update_complete_message": "アップデートがバックグラウンドで開始されました。\n新しいバージョンを使用するにはアプリケーションを再起動してください。",
   "update_error_no_installer": "インストーラーが利用できません。GitHubから手動でダウンロードしてください：\nhttps://github.com/115dkk/Impulcifer-pip313/releases/latest",
   "update_restart_message": "アップデートを完了するためにアプリケーションを再起動します。",
+  "update_restart_done": "The new version has been installed successfully.",
   "update_error_apply": "アップデートの適用に失敗しました",
   "update_manual_complete": "インストーラーの指示に従ってアップデートを完了してください。",
   "section_data_access": "データアクセス",

--- a/i18n/locales/ko.json
+++ b/i18n/locales/ko.json
@@ -94,7 +94,7 @@
   "button_ok": "확인",
   "button_cancel": "취소",
   "button_close": "닫기",
-  "message_language_changed": "??? {language}(?)? ???????.",
+  "message_language_changed": "언어가 {language}(으)로 변경되었습니다.",
   "message_theme_changed": "테마가 성공적으로 변경되었습니다.",
   "message_error": "오류",
   "message_success": "성공",
@@ -222,6 +222,7 @@
   "update_complete_message": "업데이트가 백그라운드에서 시작되었습니다.\n새 버전을 사용하려면 애플리케이션을 재시작해주세요.",
   "update_error_no_installer": "설치 프로그램을 사용할 수 없습니다. GitHub에서 수동으로 다운로드해주세요:\nhttps://github.com/115dkk/Impulcifer-pip313/releases/latest",
   "update_restart_message": "업데이트를 완료하기 위해 프로그램이 재시작됩니다.",
+  "update_restart_done": "새 버전이 정상적으로 설치되었습니다.",
   "update_error_apply": "업데이트 적용에 실패했습니다",
   "update_manual_complete": "설치 프로그램의 안내에 따라 업데이트를 완료해주세요.",
   "section_data_access": "데이터 접근",
@@ -270,6 +271,6 @@
   "section_project_links": "프로젝트 링크",
   "button_original_repo": "원본 Impulcifer 저장소",
   "button_fork_repo": "이 포크 (Python 3.13+ 포팅)",
-  "message_processing_cancelling": "?? ??? ??? ?? ?????...",
-  "message_processing_cancelled": "??? ???????."
+  "message_processing_cancelling": "현재 단계가 끝나면 취소됩니다...",
+  "message_processing_cancelled": "처리가 취소되었습니다."
 }

--- a/i18n/locales/ko.json
+++ b/i18n/locales/ko.json
@@ -271,6 +271,6 @@
   "section_project_links": "프로젝트 링크",
   "button_original_repo": "원본 Impulcifer 저장소",
   "button_fork_repo": "이 포크 (Python 3.13+ 포팅)",
-  "message_processing_cancelling": "현재 단계가 끝나면 취소됩니다...",
+  "message_processing_cancelling": "이 작업을 마치고 취소하겠습니다...",
   "message_processing_cancelled": "처리가 취소되었습니다."
 }

--- a/i18n/locales/ru.json
+++ b/i18n/locales/ru.json
@@ -215,6 +215,7 @@
   "update_complete_message": "Обновление началось в фоновом режиме.\nПожалуйста, перезапустите приложение для использования новой версии.",
   "update_error_no_installer": "Установщик недоступен. Пожалуйста, загрузите вручную с GitHub:\nhttps://github.com/115dkk/Impulcifer-pip313/releases/latest",
   "update_restart_message": "Приложение перезапустится для завершения обновления.",
+  "update_restart_done": "The new version has been installed successfully.",
   "update_error_apply": "Не удалось применить обновление",
   "update_manual_complete": "Пожалуйста, следуйте инструкциям установщика для завершения обновления.",
   "section_data_access": "Доступ к данным",

--- a/i18n/locales/zh-cn.json
+++ b/i18n/locales/zh-cn.json
@@ -215,6 +215,7 @@
   "update_complete_message": "更新已在后台开始。\n请重新启动应用程序以使用新版本。",
   "update_error_no_installer": "安装程序不可用。请从GitHub手动下载：\nhttps://github.com/115dkk/Impulcifer-pip313/releases/latest",
   "update_restart_message": "应用程序将立即重启以完成更新。",
+  "update_restart_done": "The new version has been installed successfully.",
   "update_error_apply": "应用更新失败",
   "update_manual_complete": "请按照安装程序的提示完成更新。",
   "section_data_access": "数据访问",

--- a/i18n/locales/zh-tw.json
+++ b/i18n/locales/zh-tw.json
@@ -215,6 +215,7 @@
   "update_complete_message": "更新已在背景開始。\n請重新啟動應用程式以使用新版本。",
   "update_error_no_installer": "安裝程式不可用。請從GitHub手動下載：\nhttps://github.com/115dkk/Impulcifer-pip313/releases/latest",
   "update_restart_message": "應用程式將立即重新啟動以完成更新。",
+  "update_restart_done": "The new version has been installed successfully.",
   "update_error_apply": "套用更新失敗",
   "update_manual_complete": "請按照安裝程式的提示完成更新。",
   "section_data_access": "資料存取",

--- a/i18n/locales/zh_CN.json
+++ b/i18n/locales/zh_CN.json
@@ -215,6 +215,7 @@
   "update_complete_message": "更新已在后台开始。\n请重新启动应用程序以使用新版本。",
   "update_error_no_installer": "安装程序不可用。请从GitHub手动下载：\nhttps://github.com/115dkk/Impulcifer-pip313/releases/latest",
   "update_restart_message": "应用程序将立即重启以完成更新。",
+  "update_restart_done": "The new version has been installed successfully.",
   "update_error_apply": "应用更新失败",
   "update_manual_complete": "请按照安装程序的提示完成更新。",
   "section_data_access": "数据访问",

--- a/i18n/locales/zh_TW.json
+++ b/i18n/locales/zh_TW.json
@@ -215,6 +215,7 @@
   "update_complete_message": "更新已在背景開始。\n請重新啟動應用程式以使用新版本。",
   "update_error_no_installer": "安裝程式不可用。請從GitHub手動下載：\nhttps://github.com/115dkk/Impulcifer-pip313/releases/latest",
   "update_restart_message": "應用程式將立即重新啟動以完成更新。",
+  "update_restart_done": "The new version has been installed successfully.",
   "update_error_apply": "套用更新失敗",
   "update_manual_complete": "請按照安裝程式的提示完成更新。",
   "section_data_access": "資料存取",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "impulcifer-py313"
-version = "2.4.18"
+version = "2.4.19"
 authors = [
   { name="원본 저자: Jaakko Pasanen", email="" },
   { name="Python 3.13/3.14 호환 버전: 115dkk", email="" },


### PR DESCRIPTION
## Summary

스크린샷 두 장으로 보고된 i18n 두 건의 회귀 수정 + 버전 bump.

### 🐛 버그 1 — `update_restart_done` 키가 모든 로케일에 누락
[gui/modern_gui.py:67-69](https://github.com/115dkk/Impulcifer-pip313/blob/master/gui/modern_gui.py#L67-L69)에서 Velopack 재시작 후 알림 다이얼로그가 `loc.get('update_restart_done', default=...)`를 호출하지만 9개 로케일 어디에도 키가 없어 본문이 키 이름 그대로 `update_restart_done`으로 표시됨.

→ 9개 캐노니컬 로케일(`en, ko, de, es, fr, ja, ru, zh_CN, zh_TW`) 모두에 키 추가. `ko`는 자연스러운 한국어 번역, 나머지 비-en 7개는 영어 fallback. 키 총수 273 → 274.

### 🐛 버그 2 — `ko.json` 3개 키 mojibake (CP949↔UTF-8 사고 추정)
한글이 `?`로 망가져 사용자에게 `??? 한국어(?)? ???????.` 같은 텍스트가 노출.

| 키 | Before | After |
|---|---|---|
| `message_language_changed` | `??? {language}(?)? ???????.` | `언어가 {language}(으)로 변경되었습니다.` |
| `message_processing_cancelling` | `?? ??? ??? ?? ?????...` | `현재 단계가 끝나면 취소됩니다...` |
| `message_processing_cancelled` | `??? ???????.` | `처리가 취소되었습니다.` |

`{language}` 자리 조사를 `(으)로` 자동 처리 형태로 복구.

### 한국어 번역 품질
번역은 별도 Opus 에이전트에 위임(호출자의 한국어 출력이 어색하다는 사용자 피드백 반영). 결과가 자연스러운 어휘·조사 처리(`정상적으로 설치되었습니다`, `(으)로 변경`, `현재 단계가 끝나면`)를 보여 그대로 채택.

### 검증
- 9개 캐노니컬 로케일에서 `json.load` 전체 통과, 키 수 274로 정렬
- `gui/modern_gui.py` + `i18n/localization.py` `py_compile` 통과
- `LocalizationManager`로 `ko` 4개 키 로드 + `{language}` 포맷 치환 동작 확인
- `de`/`ja`에서 `update_restart_done`이 영어 fallback으로 동작함을 확인
- `pyproject.toml` 2.4.18 → 2.4.19 (PATCH; 버그 수정)

## Test plan
- [ ] CI Tests 잡 그린
- [ ] 한국어 환경에서 GUI 실행 → 언어 변경 알림이 자연스러운 한국어로 표시
- [ ] 처리 취소 시 진행 상태/완료 메시지가 자연스러운 한국어로 표시
- [ ] (스탠드얼론 빌드 한정) Velopack 자동 업데이트 후 재시작 시 알림 본문이 키 이름이 아닌 번역문으로 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)