### PR TITLE
fix(packaging): wheel 100MB 한도 복구 — shared-data dead copy 제거 + get_data_path 단일화 (v2.4.27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,17 @@ first number changes, something has broken and you need to check your commands a
 changes there are only new features available and nothing old has broken and when the last number changes, old bugs have
 been fixed and old features improved.
 
-## 2.4.26 - 2026-05-05
+## 2.4.27 - 2026-05-06
+### 🐛 PyPI 100MB 업로드 한도 복구 + 데이터 경로 단일화
+
+#### 🐛 버그 수정
+- **PyPI 업로드 실패 해결 (2.4.19~2.4.26 8개 버전 누적 실패)**: 빌드된 wheel이 ~117 MB로 PyPI의 프로젝트별 100 MB 파일 한도(`400 File too large. Limit for project 'impulcifer-py313' is 100 MB.`)를 넘기면서 8개 버전이 모두 업로드 실패한 것이 원인이었다. wheel 내부에 `data/` 폴더가 두 벌(약 200 MB uncompressed) 들어가 있던 것이 직접 원인:
+  - **사본 1 (실제 사용)**: `[tool.hatch.build] include`로 wheel root의 `data/...`에 들어가, 설치 시 `<site-packages>/data/...`로 풀린다. `infra.resource_helper.get_resource_path()`가 `__file__` 기준 상대 경로로 이 사본을 찾는다.
+  - **사본 2 (dead copy)**: `[tool.hatch.build.targets.wheel.shared-data]`가 `data/` → `impulcifer_py313/data/`로 매핑해 wheel data scheme으로 한 벌 더 묶었다. 설치 시 `<sys.prefix>/impulcifer_py313/data/...`로 풀리지만 그곳에는 `__init__.py`가 없어 Python 패키지가 아니다. 이를 찾던 `core/constants.py:get_data_path()`의 `importlib.resources.files('impulcifer_py313')` 호출은 항상 `ModuleNotFoundError`로 떨어지고 fallback `core/data`(존재하지 않음)를 반환하던 상태였다.
+  - **수정**: `[tool.hatch.build.targets.wheel.shared-data]` 섹션을 제거. 데이터 파일 자체(데모 wav 포함)는 그대로 유지된다. 빌드된 wheel은 117 MB → 약 56 MB로 축소되어 PyPI 한도 여유 충족.
+- **`core/constants.get_data_path()` 단일화**: 위 문제로 인해 사실상 기능하지 않던 `importlib.resources` 기반 lookup을 제거하고, dev/pip-install/Nuitka standalone 세 환경을 모두 정확히 처리하는 `infra.resource_helper.get_resource_path('data')`에 위임하도록 정리. 호출처(`impulcifer.py:851,876`)의 동작은 동일.
+
+
 ### 🔧 Nuitka 빌드 클린업 + 워크플로 통합 + updater_core 분리 (이슈 #87 후속)
 
 #### 🔧 빌드 / 설정 변경

--- a/core/constants.py
+++ b/core/constants.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import os
-import importlib.resources
 
 # https://en.wikipedia.org/wiki/Surround_sound
 # TrueHD 지원을 위해 확장된 스피커 이름 목록
@@ -121,17 +120,15 @@ TEST_SIGNALS = {
 
 # 패키지 내 데이터 폴더 경로
 def get_data_path():
-    """패키지 내 데이터 폴더 경로를 반환합니다."""
-    try:
-        # 패키지로 설치된 경우
-        if hasattr(importlib.resources, 'files'):
-            return str(importlib.resources.files('impulcifer_py313').joinpath('data'))
-        elif hasattr(importlib.resources, 'path'):
-            with importlib.resources.path('impulcifer_py313', 'data') as data_path:
-                return str(data_path)
-    except (ImportError, ModuleNotFoundError):
-        pass
+    """패키지 내 데이터 폴더 경로를 반환합니다.
 
-    # 폴백: 현재 파일 기준 상대 경로
-    script_dir = os.path.dirname(os.path.abspath(__file__))
-    return os.path.join(script_dir, 'data')
+    런타임 데이터 위치는 ``infra.resource_helper``가 단일 진실 공급원이다.
+    이전 구현은 ``importlib.resources.files('impulcifer_py313')``로 wheel
+    shared-data 사본을 찾으려 했지만, ``impulcifer_py313``은 Python 패키지가
+    아니어서(어디에도 ``__init__.py``가 없음) 항상 ModuleNotFoundError로
+    떨어졌고, 결과적으로 fallback인 ``core/data``(존재하지 않음)를 반환하는
+    버그가 있었다. dev / pip-install / Nuitka standalone 모두를 처리하는
+    ``infra.resource_helper.get_resource_path('data')``로 위임한다.
+    """
+    from infra.resource_helper import get_resource_path
+    return get_resource_path('data')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "impulcifer-py313"
-version = "2.4.26"
+version = "2.4.27"
 authors = [
   { name="원본 저자: Jaakko Pasanen", email="" },
   { name="Python 3.13/3.14 호환 버전: 115dkk", email="" },
@@ -96,11 +96,15 @@ exclude = [
     ".gitignore",
 ]
 
-# data 폴더를 패키지 데이터로 포함
-[tool.hatch.build.targets.wheel.shared-data]
-"data" = "impulcifer_py313/data"
-"font" = "impulcifer_py313/font"
-"i18n/locales" = "impulcifer_py313/locales"
+# data 폴더는 [tool.hatch.build].include 화이트리스트로 wheel root에 직접
+# 포함된다. 별도의 [tool.hatch.build.targets.wheel.shared-data] 매핑을 두면
+# `<sys.prefix>/impulcifer_py313/data/...`로 한 벌이 더 설치되지만, 그 경로는
+# `importlib.resources.files('impulcifer_py313')`(존재하지 않는 패키지)로만
+# 닿게 설계돼 항상 ModuleNotFoundError로 떨어진다. 즉 shared-data 사본은
+# 런타임에서 한 번도 참조되지 않는 dead copy이며 wheel 크기를 두 배로
+# 부풀려 PyPI 100MB 한도를 넘기는 원인이었다. 런타임 데이터 접근은
+# `infra.resource_helper.get_resource_path()`를 통한 file-relative 경로가
+# 단일 진실 공급원이다.
 
 # 빌드 훅 — PyPI 빌드 시 infra/_build_info.py에 마커 생성
 [tool.hatch.build.hooks.custom]


### PR DESCRIPTION
## 요약

PyPI 업로드 실패(2.4.19 ~ 2.4.26 누적 8개 버전, 모두 `400 File too large. Limit for project 'impulcifer-py313' is 100 MB.`) 복구.

원인은 wheel 내부에 `data/` 폴더가 **두 벌** 들어가 있던 것 — `[tool.hatch.build] include` 화이트리스트로 한 번, `[tool.hatch.build.targets.wheel.shared-data]`로 또 한 번. 후자는 `<sys.prefix>/impulcifer_py313/data/`로 풀리지만 그 위치엔 `__init__.py`가 없어 Python 패키지가 아니고, 그래서 이를 찾으려던 `core/constants.py:get_data_path()`의 `importlib.resources.files('impulcifer_py313')` 호출은 항상 `ModuleNotFoundError`로 떨어져 사실상 한 번도 사용된 적 없는 dead copy였다. 런타임 데이터 접근은 100% `infra/resource_helper.py`의 `__file__` 상대 경로(즉 첫 번째 사본)로 처리되고 있었다.

## 변경

- `pyproject.toml`: `[tool.hatch.build.targets.wheel.shared-data]` 섹션 제거. 데이터 파일(데모 wav 16개 포함)은 그대로 유지.
- `core/constants.py`: 망가진 `importlib.resources` lookup을 걷어내고 dev / pip-install / Nuitka standalone 세 환경 모두를 정확히 처리하는 `infra.resource_helper.get_resource_path('data')`에 위임. 호출처(`impulcifer.py:851,876`) 동작 동일.
- `pyproject.toml` version `2.4.26 → 2.4.27`.
- `CHANGELOG.md` 항목 추가.

데모 wav는 사용자가 무결성 검증/테스트에 활용하는 자산이라 보존(요청 사항). `research/`는 이미 `[tool.hatch.build].exclude`/`ruff.exclude`/`flake8.exclude`/`.gitignore`에서 빠져 있어 wheel/sdist 어느 쪽에도 들어가지 않는다.

## 효과

| | Before | After |
|---|---|---|
| wheel 압축 크기 | 116.5 MB | **58.5 MB** |
| wheel 비압축 크기 | 200 MB (data 195 MB) | 89 MB (data 85 MB) |
| `<site-packages>/data/13cmaster.mlp` | ✓ (사용됨) | ✓ (변경 없음) |
| `<sys.prefix>/impulcifer_py313/data/13cmaster.mlp` | ✓ (dead copy) | 제거 |
| PyPI 100 MB 한도 | ❌ 초과 | ✓ 여유 충족 |

## Test plan

- [x] `python -m build` → `dist/impulcifer_py313-2.4.27-py3-none-any.whl` 58.5 MB
- [x] 임시 venv에 wheel 설치 후 `<site-packages>/data/demo/`에 데모 wav 16개 모두 존재 확인 (`BL,SL.wav`, `FC.wav`, `FL,FR.wav`, `SR,BR.wav`, `headphones.wav`, `room-{FC,FL,FR,BL,SL,SR,BR}-{left,right}.wav`, `room-mic-calibration.txt`, `room-target.csv`, `README.md`)
- [x] `from core.constants import get_data_path; get_data_path()` 정상 반환
- [x] `pytest tests/ --ignore=tests/test_brir_integrity.py --ignore=tests/test_gui.py` → 94 passed, 5 skipped, 6 subtests passed
- [x] BRIR Tier 3: `python impulcifer.py --dir_path=data/demo --test_signal=data/sweep-...pkl --vbass --vbass_freq=250` → `data/demo/hesuvi.wav` md5 = `d295982d021a6d16ab2c194c3517c162` (baseline 일치)
- [ ] CI: BRIR Baseline Integrity / Test Module Imports / Code Quality / Tests on Python 3.9~3.14 / brir-integrity 모두 green
- [ ] master merge 후 Publish to PyPI 워크플로가 2.4.27을 PyPI에 정상 업로드

https://claude.ai/code/session_01T44Tu3sUQJVhBZjd2PRmMr

---
_Generated by [Claude Code](https://claude.ai/code/session_01T44Tu3sUQJVhBZjd2PRmMr)_