### PR TITLE
fix(font): Pretendard render-layer 보장 + 일반 폰트 스캐너 (v2.4.28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ first number changes, something has broken and you need to check your commands a
 changes there are only new features available and nothing old has broken and when the last number changes, old bugs have
 been fixed and old features improved.
 
+## 2.4.28 - 2026-05-06
+### 🐛 Pretendard render-layer 보장 + 일반 폰트 스캐너 + 빠른 로컬 빌드
+
+#### 🐛 버그 수정
+- **GUI Pretendard 적용 누락 회귀 차단 (root cause fix)**: 일반 Windows에서 Modern GUI가 Pretendard 대신 시스템 한글 폰트(맑은 고딕 / 명조계 substitute)로 렌더링되던 회귀를 추적해 수정. MacType을 별도로 사용하는 dev 환경에서는 표면적으로 가려져 있었으나, 일반 Windows에서는 명백히 노출되던 문제다.
+  - **원인**: `gui/utils.py::setup_pretendard_font`가 `tkfont.families()` 캐시에 의존해 Pretendard 등록을 검증했는데, `AddFontResourceExW(FR_PRIVATE)` + `WM_FONTCHANGE`는 Windows GDI에는 즉시 반영되지만 Tk의 families 캐시는 첫 호출 시점 스냅샷이라 항상 갱신되지는 않는다. 결과적으로 setup_pretendard_font가 `None`을 반환 → `CTkFont(family=None)` → Korean Windows의 Tk default(맑은 고딕)로, 글리프 링크에 따라 명조계 substitute가 끼어들었다.
+  - **수정**: families 캐시 대신 Tk 렌더 레이어를 직접 프로빙하는 `_tk_renders_family()` 도입. `tkfont.Font(family=name).actual('family')`가 요청한 family를 verbatim 반환하는지로 판정한다. Tk render는 GDI를 통해 process-private 폰트를 즉시 보므로 등록 직후에도 신뢰 가능하다.
+- **`core/utils.py::set_matplotlib_font()` 결과 노출**: silent fallback이던 함수를 `font_setup_result` 모듈 전역(`source`/`family`/`path`/`is_pretendard`)으로 결과를 보고하도록 리팩토링. 호출 측이 "Pretendard 적용 보장"을 검증할 수 있다.
+- **`gui_main.py --smoke-test` 보장 강화**: 시스템 Pretendard를 마스킹한 상태에서 (1) matplotlib이 번들 파일을 채택하는지, (2) Tk root에서 `setup_pretendard_font('ko')` → `actual('family')`가 'Pretendard'로 해상되는지를 검증한다. 어느 한 경로라도 실패하면 exit 2로 떨어져 정적 빌드 회귀를 잡는다.
+
+#### ⭐ 새로운 기능 / 개선
+- **번들 폰트 일반 스캐너**: `core/utils.py::_scan_bundled_fonts()` / `gui/utils.py::_scan_bundled_fonts()` 가 `font/` 디렉토리의 `.otf`/`.ttf`/`.ttc`를 모두 자동 스캔·등록한다. 사용자가 `font/`에 본명조(SourceHanSerif) 같은 보조 폰트를 떨어뜨리면 wheel/standalone 양쪽에 자동으로 번들·등록되어 코드 변경 없이 family 이름으로 바로 참조 가능. `pyproject.toml`의 force-include는 `font/Pretendard-Regular.otf` → `font/**` glob으로 확장.
+- **`build_scripts/build_local.py` 신설**: 16-core 머신 기준 `--jobs=14`(`max(2, min(cpu_count - 2, 14))`)로 자동 산출. dist/local/ 으로 출력해 CI release 산출물과 충돌하지 않는다. `nuitka_flags.build_nuitka_args(jobs=…)` 파라미터로 CI는 `--jobs=4` 기본값을 유지하면서 로컬은 빠르게 반복 가능.
+
+#### 🔧 빌드 / 설정 변경
+- **검증 (Windows / Nuitka 4.0.8 / Python 3.13.3 / standalone)**:
+  ```
+  python build_scripts/build_local.py
+  ./dist/local/gui_main.dist/ImpulciferGUI.exe --smoke-test
+  → Tk render layer resolves Pretendard: Pretendard
+  → smoke-test OK (imports=18, font.matplotlib=bundled, font.gui='Pretendard',
+                   font.path=...\dist\local\gui_main.dist\font\Pretendard-Regular.otf)
+  ```
+- **BRIR md5 회귀 없음**:
+  - 기본값:                  `cf37a9aaf95e717c04e309fba05fa61d`
+  - --vbass --vbass_freq=250: `07eef9ef89cc0d55313c9c0c18edbc76`
+- **테스트**: 기존 `_match_tk_family` stub 기반 GUI 테스트 3건을 `_tk_renders_family`-기반 3건(render check + cache 안정성)으로 대체. 79건 모두 통과.
+
 ## 2.4.27 - 2026-05-06
 ### 🐛 PyPI 100MB 업로드 한도 복구 + 데이터 경로 단일화
 

--- a/build_scripts/build_local.py
+++ b/build_scripts/build_local.py
@@ -1,0 +1,145 @@
+"""Local fast-iteration Nuitka build.
+
+Same flag set as :mod:`build_scripts.build_nuitka` but cranks ``--jobs`` up
+to (CPU count - 2) so multi-minute C compilation collapses to roughly a
+quarter of the CI build time on developer machines. CI keeps the canonical
+``--jobs=4`` because GitHub runners are not guaranteed to be wide.
+
+Output is written to ``dist/local/`` so it never collides with CI's release
+output directory and can be wiped without affecting other builds.
+
+Usage:
+    python build_scripts/build_local.py
+    PYTHONIOENCODING=utf-8 python build_scripts/build_local.py
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# When invoked as a script, add project root to sys.path so the package import
+# below resolves regardless of the current working directory.
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from build_scripts.nuitka_flags import (  # noqa: E402
+    PLATFORM_OUTPUT_FILENAMES,
+    build_nuitka_args,
+)
+
+
+def _detect_platform() -> str:
+    """Return canonical platform string used in nuitka_flags."""
+    import platform
+
+    system = platform.system().lower()
+    if system == "windows":
+        return "windows"
+    if system == "darwin":
+        return "macos"
+    if system == "linux":
+        return "linux"
+    return "unknown"
+
+
+def _read_project_version() -> str:
+    """Run ``infra/get_version.py`` to fetch the current project version."""
+    try:
+        result = subprocess.run(
+            [sys.executable, "infra/get_version.py"],
+            capture_output=True,
+            text=True,
+            check=True,
+            encoding="utf-8",
+        )
+        version = (result.stdout or "").strip()
+        return version or "0.0.0-local"
+    except Exception as exc:  # noqa: BLE001 - best-effort fallback
+        print(f"  warning: could not read version ({exc}); using 0.0.0-local")
+        return "0.0.0-local"
+
+
+def _generate_build_marker(version: str) -> None:
+    """Write infra/_build_info.py exactly like the canonical build script."""
+    target = _PROJECT_ROOT / "infra" / "_build_info.py"
+    target.write_text(
+        '# -*- coding: utf-8 -*-\n'
+        '"""빌드 정보 마커 — build_local.py에 의해 자동 생성됨."""\n'
+        'BUILD_TYPE = "standalone"\n'
+        f'VERSION = "{version}"\n',
+        encoding="utf-8",
+    )
+
+
+def main() -> int:
+    target_platform = _detect_platform()
+    if target_platform == "unknown":
+        print(f"  ERROR: unsupported platform {sys.platform!r}", flush=True)
+        return 2
+
+    version = _read_project_version()
+    print(f"=== build_local.py ===", flush=True)
+    print(f"  platform: {target_platform}", flush=True)
+    print(f"  version:  {version}", flush=True)
+
+    cpu_count = os.cpu_count() or 4
+    # Leave 2 cores for the OS / IDE so the machine remains usable. Cap at 14
+    # which empirically gives diminishing returns past that on Windows MSVC.
+    jobs = max(2, min(cpu_count - 2, 14))
+    print(f"  jobs:     {jobs} (cpu_count={cpu_count})", flush=True)
+
+    output_dir = "dist/local"
+    output_filename = PLATFORM_OUTPUT_FILENAMES.get(target_platform, "Impulcifer")
+    print(f"  output:   {output_dir}/gui_main.dist/{output_filename}.exe", flush=True)
+
+    _generate_build_marker(version)
+
+    args = build_nuitka_args(
+        target_platform=target_platform,
+        version=version,
+        project_root=str(_PROJECT_ROOT),
+        output_dir=output_dir,
+        output_filename=output_filename,
+        jobs=jobs,
+    )
+    cmd = [sys.executable, "-m", "nuitka", *args]
+    print(f"\nlaunching: {' '.join(cmd[:5])} ... ({len(cmd)} args total)", flush=True)
+
+    try:
+        # Stream Nuitka's own progress (capture_output=True hides --show-progress).
+        completed = subprocess.run(cmd, check=False)
+    except KeyboardInterrupt:
+        print("\n  build_local.py: interrupted by user.", flush=True)
+        return 130
+
+    if completed.returncode != 0:
+        print(
+            f"\n  ERROR: nuitka exited with code {completed.returncode}",
+            flush=True,
+        )
+        return completed.returncode
+
+    binary = Path(output_dir) / "gui_main.dist" / f"{output_filename}.exe"
+    if target_platform != "windows":
+        binary = Path(output_dir) / "gui_main.dist" / output_filename
+    if binary.exists():
+        size_mb = binary.stat().st_size // (1024 * 1024)
+        print(f"\n  OK: built {binary} ({size_mb} MB)", flush=True)
+    else:
+        print(f"\n  WARNING: expected binary not found at {binary}", flush=True)
+
+    print(
+        "\n  Hint: run\n"
+        f"    {binary} --smoke-test\n"
+        "  to verify the bundled binary's import chain + Pretendard guarantee.",
+        flush=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/build_scripts/nuitka_flags.py
+++ b/build_scripts/nuitka_flags.py
@@ -150,6 +150,7 @@ def build_nuitka_args(
     output_dir: Optional[str] = None,
     output_filename: Optional[str] = None,
     entry_point: str = "gui_main.py",
+    jobs: Optional[int] = None,
 ) -> List[str]:
     """Assemble the complete argument list for ``python -m nuitka``.
 
@@ -158,13 +159,27 @@ def build_nuitka_args(
 
     ``project_root`` is used to test for optional assets (icons, README.txt,
     LICENSE) so they are only included when they exist.
+
+    ``jobs`` overrides the canonical ``--jobs=4`` from ``COMMON_FLAGS`` for
+    callers that need a higher core count (e.g. local fast-iteration builds
+    via ``build_scripts/build_local.py``). CI keeps the default of 4 since
+    GitHub runners are not always 16-core.
     """
     if output_dir is None:
         output_dir = PLATFORM_OUTPUT_DIRS.get(target_platform, "dist")
     if output_filename is None:
         output_filename = PLATFORM_OUTPUT_FILENAMES.get(target_platform, "Impulcifer")
 
-    args: List[str] = list(COMMON_FLAGS)
+    if jobs is None:
+        common_args = list(COMMON_FLAGS)
+    else:
+        # Replace the ``--jobs=N`` flag in COMMON_FLAGS so we don't end up
+        # with a duplicated flag on the command line (Nuitka would error).
+        common_args = [
+            f"--jobs={jobs}" if a.startswith("--jobs=") else a
+            for a in COMMON_FLAGS
+        ]
+    args: List[str] = common_args
     args.append(f"--output-dir={output_dir}")
     args.extend(platform_specific_flags(target_platform, project_root))
 

--- a/core/utils.py
+++ b/core/utils.py
@@ -13,7 +13,6 @@ import matplotlib.pyplot as plt
 import matplotlib.font_manager as fm
 import platform
 import shutil
-import importlib.resources
 from pathlib import Path
 
 plt.rcParams['axes.unicode_minus'] = False
@@ -24,98 +23,216 @@ except AttributeError:
     ADAPTIVE_PALETTE = getattr(Image, 'ADAPTIVE')
 
 _font_configured = False
+# Result of the most recent set_matplotlib_font() call. Public read-only
+# diagnostic surface so the smoke-test in gui_main.py can verify Pretendard
+# was actually applied (not just silently fell back to a system font).
+#
+# Shape:
+#     {
+#         "source": "bundled" | "system" | "fallback" | None,
+#         "family": str | None,        # the family name written to rcParams
+#         "path":   Path | None,       # the file findfont() resolved to
+#         "is_pretendard": bool,       # True iff the resolved path is a
+#                                       # Pretendard variant (.otf/.ttf with
+#                                       # "pretendard" in the file name)
+#     }
+font_setup_result: dict = {
+    "source": None,
+    "family": None,
+    "path": None,
+    "is_pretendard": False,
+}
+
+
+def _resolve_bundled_font_dir() -> "Path | None":
+    """Return the bundled ``font/`` directory across all runtime modes.
+
+    Routes through :func:`infra.resource_helper.get_resource_path` first
+    (Nuitka standalone / pip-install / dev), with a last-ditch
+    ``Path(__file__).parent.parent`` fallback for the rare case ``infra``
+    itself can't be imported (e.g. ad-hoc scripts).
+    """
+    try:
+        from infra.resource_helper import get_resource_path
+
+        candidate = Path(get_resource_path("font"))
+        if candidate.is_dir():
+            return candidate
+    except Exception:
+        pass
+
+    project_root = Path(__file__).parent.parent
+    for legacy in (project_root / "font", project_root / "fonts"):
+        if legacy.is_dir():
+            return legacy
+    return None
+
+
+def _scan_bundled_fonts() -> "list[Path]":
+    """List every ``.otf`` / ``.ttf`` / ``.ttc`` bundled in the ``font/`` dir.
+
+    Returns the files in case-insensitive name order so the same dev /
+    standalone tree always yields the same registration order — important
+    for matplotlib's ``findfont`` scoring when multiple bundled fonts
+    declare the same family.
+    """
+    font_dir = _resolve_bundled_font_dir()
+    if font_dir is None:
+        return []
+    suffixes = {".otf", ".ttf", ".ttc"}
+    return sorted(
+        (p for p in font_dir.iterdir() if p.suffix.lower() in suffixes),
+        key=lambda p: p.name.casefold(),
+    )
+
+
+def _resolve_bundled_pretendard_path() -> "Path | None":
+    """Find the bundled Pretendard regular weight (legacy compat name).
+
+    Kept as a thin wrapper over :func:`_scan_bundled_fonts` so existing tests
+    and old callers keep working. New code should prefer the scan-all helper
+    so user-dropped fonts (e.g. a Source Han Serif placed alongside
+    Pretendard) are also picked up.
+    """
+    for path in _scan_bundled_fonts():
+        if "pretendard-regular" in path.stem.lower():
+            return path
+    # Pretendard not present? Return whatever Pretendard-shaped file we have.
+    for path in _scan_bundled_fonts():
+        if "pretendard" in path.stem.lower():
+            return path
+    return None
+
+
+def _register_bundled_fonts_with_matplotlib() -> "list[Path]":
+    """addfont() every bundled font for matplotlib and return the registered list.
+
+    matplotlib's ``fontManager.addfont`` is idempotent (it deduplicates by
+    file path), so this is safe to call multiple times. Used by
+    :func:`set_matplotlib_font` so that BOTH Pretendard AND any extra Korean
+    serif (e.g. Source Han Serif) the user drops into ``font/`` are
+    available to matplotlib code that may want to reference them by family
+    name.
+    """
+    registered: list[Path] = []
+    for path in _scan_bundled_fonts():
+        try:
+            fm.fontManager.addfont(str(path))
+            registered.append(path)
+        except Exception:
+            continue
+    return registered
 
 
 def set_matplotlib_font():
-    """한글을 지원하는 폰트를 matplotlib에 설정합니다.
+    """한글을 지원하는 폰트를 matplotlib에 설정한다.
 
-    Pretendard 번들 폰트를 우선 사용하고, 없으면 OS별 시스템 폰트로 대체합니다.
-    한 번만 실행되며 이후 호출은 무시됩니다.
+    번들 Pretendard 우선 → 시스템 Pretendard → OS별 한글 폴백 순으로
+    시도하며, 한 번만 실행되고 이후 호출은 캐시된 결과를 반환한다.
+
+    이전 구현은 silent fallback이라 "Pretendard 적용에 실패해 Malgun으로
+    떨어졌다"를 추적할 방법이 없었다. 이번 리팩토링은:
+
+    1. 번들 경로 해석을 ``infra.resource_helper.get_font_path`` 로 일원화해
+       Nuitka standalone 환경에서도 같은 경로 규칙을 따른다.
+    2. 어떤 source가 채택됐는지(``bundled`` / ``system`` / ``fallback``)와
+       findfont가 실제로 어떤 파일을 골랐는지를 ``font_setup_result`` 모듈
+       전역에 기록한다 — smoke-test가 이를 보고 "Pretendard 보장" 검증을
+       수행할 수 있다.
+
+    Returns:
+        ``font_setup_result`` 의 사본. ``is_pretendard`` 가 ``True`` 일 때
+        만 호출자는 Pretendard 적용이 보장되었다고 간주해야 한다.
     """
     global _font_configured
     if _font_configured:
-        return
+        return dict(font_setup_result)
+
     _font_configured = True
 
     system = platform.system()
-    font_loaded = False
 
-    # 1. 번들 Pretendard 폰트 시도
-    font_search_paths = []
+    # Register EVERY bundled font (Pretendard + any user-dropped extras such
+    # as Source Han Serif). matplotlib only renders text in the family set on
+    # rcParams, but registering the others makes them addressable when code
+    # explicitly opts-in via FontProperties(family=...).
+    registered = _register_bundled_fonts_with_matplotlib()
+    bundled_pretendard = next(
+        (p for p in registered if "pretendard" in p.stem.lower()),
+        None,
+    )
 
-    try:
-        if hasattr(importlib.resources, "files"):
-            try:
-                font_resource = (
-                    importlib.resources.files("impulcifer_py313")
-                    .joinpath("font")
-                    .joinpath("Pretendard-Regular.otf")
-                )
-                font_search_paths.append(("bundled_files", font_resource))
-            except (FileNotFoundError, ModuleNotFoundError):
-                pass
-    except Exception:
-        pass
+    chosen_source = None
+    chosen_family = None
 
-    # 2. 로컬 개발 환경 폰트 경로
-    project_root = Path(__file__).parent.parent
-    local_candidates = [
-        project_root / "font" / "Pretendard-Regular.otf",
-        project_root / "fonts" / "Pretendard-Regular.otf",
-    ]
-    for local_path in local_candidates:
-        if local_path.exists():
-            font_search_paths.append(("local", str(local_path)))
-            break
-
-    # 3. 시스템 설치 Pretendard
-    try:
-        if any(f.name == "Pretendard" for f in fm.fontManager.ttflist):
-            font_search_paths.append(("system", "Pretendard"))
-    except Exception:
-        pass
-
-    # 로딩 시도
-    for source_type, font_path in font_search_paths:
+    # 1) 번들 Pretendard (the default sans-serif body font)
+    if bundled_pretendard is not None:
         try:
-            if source_type == "bundled_files":
-                with importlib.resources.as_file(font_path) as fp:
-                    fm.fontManager.addfont(str(fp))
-                    prop = fm.FontProperties(fname=str(fp))
-                    plt.rcParams["font.family"] = prop.get_name()
-                    font_loaded = True
-                    break
-            elif source_type == "local":
-                fm.fontManager.addfont(font_path)
-                prop = fm.FontProperties(fname=font_path)
-                plt.rcParams["font.family"] = prop.get_name()
-                font_loaded = True
-                break
-            elif source_type == "system":
-                plt.rcParams["font.family"] = "Pretendard"
-                font_loaded = True
-                break
+            prop = fm.FontProperties(fname=str(bundled_pretendard))
+            family = prop.get_name()
+            plt.rcParams["font.family"] = family
+            chosen_source = "bundled"
+            chosen_family = family
         except Exception:
-            continue
+            chosen_source = None  # fall through to system
 
-    # 4. OS 기본 한글 폰트 대체
-    if not font_loaded:
+    # 2) 시스템 설치 Pretendard
+    if chosen_source is None:
+        try:
+            if any(f.name == "Pretendard" for f in fm.fontManager.ttflist):
+                plt.rcParams["font.family"] = "Pretendard"
+                chosen_source = "system"
+                chosen_family = "Pretendard"
+        except Exception:
+            pass
+
+    # 3) OS 한글 폴백
+    if chosen_source is None:
+        chosen_source = "fallback"
         if system == "Windows":
             win_font = "C:/Windows/Fonts/malgun.ttf"
             if os.path.exists(win_font):
                 prop = fm.FontProperties(fname=win_font)
-                plt.rcParams["font.family"] = prop.get_name()
+                family = prop.get_name()
+                plt.rcParams["font.family"] = family
+                chosen_family = family
             else:
                 plt.rcParams["font.family"] = "Malgun Gothic"
+                chosen_family = "Malgun Gothic"
         elif system == "Darwin":
             plt.rcParams["font.family"] = "AppleGothic"
+            chosen_family = "AppleGothic"
         elif system == "Linux":
-            # NanumGothic 시도, 없으면 sans-serif 유지
             try:
                 if any(f.name == "NanumGothic" for f in fm.fontManager.ttflist):
                     plt.rcParams["font.family"] = "NanumGothic"
+                    chosen_family = "NanumGothic"
             except Exception:
                 pass
+
+    # 4) findfont로 실제 결과 검증
+    resolved_path = None
+    is_pretendard = False
+    try:
+        resolved = fm.findfont(
+            fm.FontProperties(family=chosen_family or "Pretendard"),
+            fallback_to_default=True,
+        )
+        if resolved:
+            resolved_path = Path(resolved)
+            is_pretendard = "pretendard" in resolved_path.name.lower()
+    except Exception:
+        pass
+
+    font_setup_result.update(
+        {
+            "source": chosen_source,
+            "family": chosen_family,
+            "path": resolved_path,
+            "is_pretendard": is_pretendard,
+        }
+    )
+    return dict(font_setup_result)
 
 # -- Backward-compat re-exports (issue #87 Phase 5) --
 # FFmpeg / TrueHD helpers were split into ``core.ffmpeg_utils``. We import

--- a/gui/utils.py
+++ b/gui/utils.py
@@ -180,27 +180,56 @@ def safe_get_string(var: Any, default: str = "") -> str:
 _font_cache: dict[str, Optional[str]] = {}
 
 
-def _find_pretendard_font_file() -> Optional[Path]:
-    """Return the bundled Pretendard font path when it is available."""
+def _resolve_bundled_font_dir() -> Optional[Path]:
+    """Return the bundled ``font/`` directory across runtime modes."""
     script_dir = Path(__file__).parent
     candidates: list[Path] = []
-
     try:
-        from infra.resource_helper import get_font_path
+        from infra.resource_helper import get_resource_path
 
-        candidates.append(Path(get_font_path("Pretendard-Regular.otf")))
+        candidates.append(Path(get_resource_path("font")))
     except Exception:
         pass
+    candidates.extend(
+        [
+            script_dir / "font",
+            script_dir / "fonts",
+            script_dir.parent / "font",
+            script_dir.parent / "fonts",
+        ]
+    )
+    for c in candidates:
+        if c.is_dir():
+            return c
+    return None
 
-    candidates.extend([
-        script_dir / "font" / "Pretendard-Regular.otf",
-        script_dir / "fonts" / "Pretendard-Regular.otf",
-        script_dir.parent / "font" / "Pretendard-Regular.otf",
-        script_dir.parent / "fonts" / "Pretendard-Regular.otf",
-    ])
 
-    for path in candidates:
-        if path.exists():
+def _scan_bundled_fonts() -> list[Path]:
+    """Enumerate every ``.otf`` / ``.ttf`` / ``.ttc`` in the bundled font dir."""
+    font_dir = _resolve_bundled_font_dir()
+    if font_dir is None:
+        return []
+    suffixes = {".otf", ".ttf", ".ttc"}
+    return sorted(
+        (p for p in font_dir.iterdir() if p.suffix.lower() in suffixes),
+        key=lambda p: p.name.casefold(),
+    )
+
+
+def _find_pretendard_font_file() -> Optional[Path]:
+    """Return the bundled Pretendard font path when it is available.
+
+    Looks for any ``Pretendard*Regular*.otf`` so a renamed / weight-suffixed
+    file (e.g. ``Pretendard-Regular.otf``, ``PretendardRegular.otf``) still
+    resolves. Falls back to the first ``Pretendard*`` file found.
+    """
+    fonts = _scan_bundled_fonts()
+    for path in fonts:
+        stem = path.stem.lower()
+        if "pretendard" in stem and "regular" in stem:
+            return path
+    for path in fonts:
+        if "pretendard" in path.stem.lower():
             return path
     return None
 
@@ -239,6 +268,34 @@ def _match_tk_family(families: Optional[set[str]], desired: str) -> Optional[str
     for family in families:
         if family.casefold() == desired_folded:
             return family
+    return None
+
+
+def _tk_renders_family(desired: str) -> Optional[str]:
+    """Return the family Tk's RENDER layer resolves ``desired`` to, or None.
+
+    This is the authoritative check, not :func:`tkfont.families`. After
+    ``AddFontResourceExW(FR_PRIVATE)`` registers a font for the current
+    process, Windows' GDI sees it immediately (Tk uses GDI for rendering),
+    but ``tkfont.families()`` caches its first-call output and may not list
+    the new font. Creating a ``tkfont.Font`` with ``family=desired`` and
+    inspecting its ``actual('family')`` exercises the render path: when Tk
+    can render with the requested family, ``actual`` returns that family
+    verbatim; otherwise it returns whatever Tk fell back to (e.g. the
+    system default like Malgun Gothic), which we treat as a miss.
+
+    This was the bug behind issue #87 follow-up: ``setup_pretendard_font``
+    bailed to ``None`` because ``families()`` lacked Pretendard even though
+    GDI / Tk render layer would have used it. CTk widgets then defaulted
+    to the system font (Malgun Gothic / 명조 fallback on Korean Windows).
+    """
+    try:
+        probe = tkfont.Font(family=desired, size=10)
+        actual = probe.actual("family")
+        if actual and actual.casefold() == desired.casefold():
+            return actual
+    except (RuntimeError, TclError):
+        pass
     return None
 
 
@@ -317,10 +374,42 @@ def _register_font_file_for_tk(font_path: Path) -> bool:
     return False
 
 
+_bundled_fonts_registered_for_tk = False
+
+
+def register_all_bundled_fonts_for_tk() -> list[Path]:
+    """Register every ``font/*.otf|*.ttf|*.ttc`` for the current Tk process.
+
+    Idempotent — subsequent calls are no-ops. Returns the list of paths that
+    were successfully registered the first time. So a Source Han Serif (or
+    any other Korean font) the user drops into ``font/`` becomes addressable
+    by family name from CTkFont / Tk widgets without any further code
+    change.
+    """
+    global _bundled_fonts_registered_for_tk
+    if _bundled_fonts_registered_for_tk:
+        return []
+    _bundled_fonts_registered_for_tk = True
+
+    registered: list[Path] = []
+    for path in _scan_bundled_fonts():
+        try:
+            if _register_font_file_for_tk(path):
+                registered.append(path)
+        except Exception:
+            continue
+    return registered
+
+
 def setup_pretendard_font(current_language: str = 'en') -> Optional[str]:
     """
     Setup Pretendard font for Korean and English languages.
     Returns font family name to use, or None for system default.
+
+    Side effect: every other font the user has dropped into ``font/`` (e.g.
+    a Source Han Serif "본명조" file) is also registered for Tk via
+    :func:`register_all_bundled_fonts_for_tk`, so the GUI can switch to
+    those families on demand without code changes.
 
     Args:
         current_language: Current language code (e.g., 'ko', 'en')
@@ -337,38 +426,57 @@ def setup_pretendard_font(current_language: str = 'en') -> Optional[str]:
 
     # Only use Pretendard for Korean and English
     if current_language not in ['ko', 'en']:
+        # Even when we don't pick Pretendard for the language, still register
+        # any bundled font so other code paths (e.g. matplotlib, dialogs that
+        # opt into a different family) can find them.
+        register_all_bundled_fonts_for_tk()
         return _cache_and_return(None)
 
     try:
-        available_fonts = _get_tk_font_families()
-        system_family = _match_tk_family(available_fonts, "Pretendard")
-        if system_family:
-            print(f"Using system-installed Pretendard font: {system_family}")
-            return _cache_and_return(system_family)
+        # Register every bundled font once — Pretendard is the primary, but
+        # any companion files (Source Han Serif, etc.) become addressable
+        # too. This is the place that satisfies "잡도록 수정" for fonts
+        # placed alongside Pretendard.
+        register_all_bundled_fonts_for_tk()
 
+        # PRIMARY check: ask Tk's render layer directly.
+        # tkfont.families() caches at startup and AddFontResourceExW does NOT
+        # always invalidate that cache, but Tk renders via GDI which DOES see
+        # process-private fonts immediately. So we trust actual() resolution
+        # over the families() snapshot.
+        rendered = _tk_renders_family("Pretendard")
+        if rendered:
+            print(f"Tk render layer resolves Pretendard: {rendered}")
+            return _cache_and_return(rendered)
+
+        # If the bundled file wasn't registered yet (e.g. the helper above
+        # short-circuited), force-register it now to fix Tk's render path.
         font_path = _find_pretendard_font_file()
         if font_path:
             family_name = _font_family_from_file(font_path)
             registered = _register_font_file_for_tk(font_path)
+            rendered = _tk_renders_family(family_name)
+            if rendered:
+                print(f"Registered + render-verified Pretendard: {font_path}")
+                return _cache_and_return(rendered)
+
+            # Last-chance fall-back: if registration succeeded and Tk still
+            # can't render the named family (extremely rare — usually means
+            # the font file's family-name metadata diverged from "Pretendard"),
+            # fall back to families() inspection so we at least return a
+            # related family rather than None.
             available_fonts = _get_tk_font_families()
-            tk_family = _match_tk_family(available_fonts, family_name)
-
-            if tk_family:
-                print(f"Successfully registered Pretendard font: {font_path}")
-                return _cache_and_return(tk_family)
-
-            if registered and available_fonts is None:
-                print(f"Registered Pretendard font before Tk font validation: {font_path}")
-                return family_name
-
-            print(f"Pretendard font file was found but is not visible to Tk: {font_path}")
-
-        available_fonts = _get_tk_font_families()
-        if available_fonts:
-            for font_name in available_fonts:
+            for font_name in (available_fonts or set()):
                 if "Pretendard" in font_name:
-                    print(f"Using system-installed Pretendard font: {font_name}")
-                    return _cache_and_return(font_name)
+                    rendered = _tk_renders_family(font_name)
+                    if rendered:
+                        print(f"Using nearby Pretendard variant: {font_name}")
+                        return _cache_and_return(rendered)
+
+            print(
+                f"Pretendard font file was found but Tk cannot render it: {font_path} "
+                f"(registered={registered}, family_name={family_name!r})"
+            )
 
         print("Pretendard font not available, using system default")
         return _cache_and_return(None)

--- a/gui_main.py
+++ b/gui_main.py
@@ -37,11 +37,22 @@ def _cleanup_on_uninstall():
 
 
 def _smoke_test():
-    """Non-interactive import-chain verification for Nuitka standalone builds.
+    """Non-interactive verification used in CI / standalone-build sanity checks.
 
-    Imports the full GUI tree without opening a Tk window. Used in CI to
-    confirm the bundled binary has all transitive modules available — if any
-    ``--include-module`` was wrongly trimmed, this exits non-zero.
+    Two-part guarantee:
+
+    1. **Import chain** — the full GUI tree must be importable. If any
+       ``--include-module`` was wrongly trimmed (or a Phase-N rename broke a
+       reference) this part exits non-zero.
+
+    2. **Pretendard application** — the bundled Pretendard font must be the
+       one matplotlib actually applies. The smoke-test masks every system
+       Pretendard from matplotlib's ``fontManager`` first, then re-runs
+       :func:`core.utils.set_matplotlib_font`. We trust the bundled font
+       loader only when the resulting :data:`core.utils.font_setup_result`
+       reports ``is_pretendard=True`` AND the resolved path is the bundled
+       file — silent fall-through to Malgun / sans-serif is an explicit
+       failure here.
     """
     import importlib
 
@@ -66,7 +77,79 @@ def _smoke_test():
         "infra.logger",
     ):
         importlib.import_module(mod)
-    print("smoke-test OK")
+
+    # Pretendard guarantee — simulate an end-user without system-installed
+    # Pretendard so the bundled file is the ONLY way to reach the font.
+    import matplotlib  # noqa: E402  (matplotlib not part of the Tk path)
+
+    matplotlib.use("Agg")
+    import matplotlib.font_manager as fm  # noqa: E402
+
+    fm.fontManager.ttflist = [
+        e for e in fm.fontManager.ttflist
+        if "pretendard" not in (e.fname or "").lower()
+    ]
+
+    import core.utils as core_utils  # noqa: E402
+
+    core_utils._font_configured = False
+    result = core_utils.set_matplotlib_font()
+
+    if result.get("source") != "bundled":
+        print(
+            f"smoke-test FAIL: bundled Pretendard not picked up "
+            f"(source={result.get('source')!r}, family={result.get('family')!r}, "
+            f"path={result.get('path')!r})"
+        )
+        sys.exit(2)
+
+    if not result.get("is_pretendard"):
+        print(
+            f"smoke-test FAIL: matplotlib didn't resolve Pretendard "
+            f"(family={result.get('family')!r}, path={result.get('path')!r})"
+        )
+        sys.exit(2)
+
+    bundled_path = result.get("path")
+    if bundled_path is None or "pretendard" not in str(bundled_path).lower():
+        print(
+            f"smoke-test FAIL: resolved font is not Pretendard "
+            f"(path={bundled_path!r})"
+        )
+        sys.exit(2)
+
+    # Tk / CTkFont render-layer guarantee — this is the path the GUI
+    # actually uses. Open a hidden Tk root, run setup_pretendard_font, and
+    # confirm Tk's render path resolves "Pretendard" (not Malgun / 명조).
+    import tkinter as tk_mod  # noqa: E402
+    import tkinter.font as tkfont_mod  # noqa: E402
+
+    tk_root = tk_mod.Tk()
+    tk_root.withdraw()
+    try:
+        from gui.utils import setup_pretendard_font  # noqa: E402
+
+        gui_family = setup_pretendard_font("ko")
+        if not gui_family:
+            print(
+                f"smoke-test FAIL: setup_pretendard_font returned None — "
+                f"Tk render layer cannot resolve bundled Pretendard."
+            )
+            sys.exit(2)
+        actual = tkfont_mod.Font(family=gui_family, size=12).actual("family")
+        if not actual or actual.casefold() != gui_family.casefold():
+            print(
+                f"smoke-test FAIL: Tk renders {gui_family!r} as {actual!r} — "
+                f"GUI would fall back to system default."
+            )
+            sys.exit(2)
+    finally:
+        tk_root.destroy()
+
+    print(
+        f"smoke-test OK (imports=18, font.matplotlib={result['source']}, "
+        f"font.gui={gui_family!r}, font.path={result['path']})"
+    )
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,11 @@ include = [
     "README.md",
     "CHANGELOG.md",
     "pyproject.toml",
-    "font/Pretendard-Regular.otf",
+    # Glob the entire ``font/`` directory so any companion font file
+    # (e.g. Source Han Serif "본명조") the user drops in is bundled too.
+    # The runtime loader (`core.utils._scan_bundled_fonts`) registers every
+    # ``.otf``/``.ttf``/``.ttc`` it finds.
+    "font/**",
 ]
 exclude = [
     "research/**/*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "impulcifer-py313"
-version = "2.4.27"
+version = "2.4.28"
 authors = [
   { name="원본 저자: Jaakko Pasanen", email="" },
   { name="Python 3.13/3.14 호환 버전: 115dkk", email="" },

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -52,51 +52,115 @@ def test_validate_recording_setup_ignores_unknown_filenames() -> None:
     assert validate_recording_setup("recording.wav", 2, True) is None
 
 
-def test_setup_pretendard_font_requires_tk_visible_family(
+def test_setup_pretendard_font_uses_render_layer_check(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Bundled Pretendard is used only after Tk can see the registered family."""
+    """Bundled Pretendard is used only after Tk's render layer resolves it.
+
+    The previous version of this test gated on ``tkfont.families()``. We now
+    gate on a render-layer probe (``tkfont.Font(family=X).actual('family')``)
+    because ``AddFontResourceExW`` does not always invalidate the families
+    cache, but Windows GDI / Tk render WILL pick up the registered font
+    immediately. That divergence was the root cause of the GUI falling
+    back to Malgun Gothic / 명조 on default Windows machines.
+    """
     font_path = Path("Pretendard-Regular.otf")
-    families = iter([set(), {"Pretendard"}])
+    # First probe: Tk can't render yet (mimics pre-registration). Second
+    # probe: registration succeeded and Tk's render layer reports the
+    # requested family.
+    rendered = iter([None, "Pretendard"])
 
     gui_utils._font_cache.clear()
+    gui_utils._bundled_fonts_registered_for_tk = False
     monkeypatch.setattr(gui_utils, "_find_pretendard_font_file", lambda: font_path)
     monkeypatch.setattr(gui_utils, "_font_family_from_file", lambda _: "Pretendard")
     monkeypatch.setattr(gui_utils, "_register_font_file_for_tk", lambda _: True)
-    monkeypatch.setattr(gui_utils, "_get_tk_font_families", lambda: next(families))
+    monkeypatch.setattr(gui_utils, "_tk_renders_family", lambda _: next(rendered))
 
     assert gui_utils.setup_pretendard_font("ko") == "Pretendard"
 
 
-def test_setup_pretendard_font_falls_back_when_tk_cannot_see_font(
+def test_setup_pretendard_font_falls_back_when_render_layer_cannot_resolve(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A found font file should not be treated as a GUI font unless Tk sees it."""
+    """If Tk's render layer can't resolve Pretendard despite registration,
+    return None so CTk widgets use the system default rather than silently
+    pretending Pretendard is in effect."""
     font_path = Path("Pretendard-Regular.otf")
 
     gui_utils._font_cache.clear()
+    gui_utils._bundled_fonts_registered_for_tk = False
     monkeypatch.setattr(gui_utils, "_find_pretendard_font_file", lambda: font_path)
     monkeypatch.setattr(gui_utils, "_font_family_from_file", lambda _: "Pretendard")
     monkeypatch.setattr(gui_utils, "_register_font_file_for_tk", lambda _: True)
+    monkeypatch.setattr(gui_utils, "_tk_renders_family", lambda _: None)
     monkeypatch.setattr(gui_utils, "_get_tk_font_families", lambda: set())
 
     assert gui_utils.setup_pretendard_font("ko") is None
 
 
-def test_setup_pretendard_font_does_not_cache_unvalidated_family(
+def test_setup_pretendard_font_caches_render_layer_hit(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Rootless registration should not poison the language cache."""
+    """Successful render-layer resolution is cached per language, so the
+    next call returns the same family without re-probing Tk."""
     font_path = Path("Pretendard-Regular.otf")
 
     gui_utils._font_cache.clear()
+    gui_utils._bundled_fonts_registered_for_tk = False
+    probe_calls = {"count": 0}
+
+    def fake_renders(_):
+        probe_calls["count"] += 1
+        return "Pretendard"
+
     monkeypatch.setattr(gui_utils, "_find_pretendard_font_file", lambda: font_path)
     monkeypatch.setattr(gui_utils, "_font_family_from_file", lambda _: "Pretendard")
     monkeypatch.setattr(gui_utils, "_register_font_file_for_tk", lambda _: True)
-    monkeypatch.setattr(gui_utils, "_get_tk_font_families", lambda: None)
+    monkeypatch.setattr(gui_utils, "_tk_renders_family", fake_renders)
 
     assert gui_utils.setup_pretendard_font("ko") == "Pretendard"
-    assert "ko" not in gui_utils._font_cache
+    first_count = probe_calls["count"]
+    assert gui_utils.setup_pretendard_font("ko") == "Pretendard"
+    assert probe_calls["count"] == first_count, "second call should hit the cache"
+
+
+def test_set_matplotlib_font_picks_bundled_when_no_system_pretendard(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-user simulation: with no system Pretendard, the BUNDLED file must
+    be the one matplotlib applies. Silent fall-through to Malgun / sans-serif
+    is treated as a hard failure here because rendering Korean glyphs without
+    Pretendard is the bug we are guarding against.
+    """
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.font_manager as fm
+
+    import core.utils as core_utils
+
+    # Drop every Pretendard the dev machine has installed so the loader's
+    # only path to a Pretendard family is the repo's bundled .otf.
+    monkeypatch.setattr(
+        fm.fontManager,
+        "ttflist",
+        [e for e in fm.fontManager.ttflist if "pretendard" not in (e.fname or "").lower()],
+    )
+    # Force re-run (the module memoizes the first call).
+    monkeypatch.setattr(core_utils, "_font_configured", False)
+
+    result = core_utils.set_matplotlib_font()
+
+    assert result["source"] == "bundled", (
+        f"Expected bundled source, got {result['source']!r}. "
+        f"This means the loader couldn't find font/Pretendard-Regular.otf "
+        f"via infra.resource_helper.get_font_path()."
+    )
+    assert result["is_pretendard"], (
+        f"matplotlib didn't resolve a Pretendard file: {result['path']!r}"
+    )
+    assert result["path"] is not None and "pretendard" in str(result["path"]).lower()
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Modern GUI가 일반 Windows에서 Pretendard가 아닌 시스템 한글 폰트(맑은 고딕 / 명조계 substitute)로 렌더링되던 회귀를 root cause까지 추적하여 수정합니다. MacType을 별도로 쓰는 dev 환경에서는 표면적으로 가려져 있었으나 일반 Windows에선 명백한 회귀였습니다.

### Root cause

`gui/utils.py::setup_pretendard_font`가 `tkfont.families()` 캐시에 의존해 Pretendard 등록을 검증했는데:

1. `AddFontResourceExW(FR_PRIVATE)` — 번들 .otf를 process-private 등록
2. `WM_FONTCHANGE` 브로드캐스트
3. ↑ Windows GDI에는 즉시 반영되지만 **Tk의 `tkfont.families()` 결과는 첫 호출 시점 스냅샷이라 항상 갱신되지는 않음**
4. `setup_pretendard_font`가 `families()`에 'Pretendard' 없다고 `None` 반환
5. `CTkFont(family=None)` → Korean Windows의 Tk default(맑은 고딕)로, 글리프 링크에 따라 명조계 substitute 노출

### Fix

`families()` 캐시 대신 **Tk 렌더 레이어를 직접 프로빙**:
```python
def _tk_renders_family(name):
    probe = tkfont.Font(family=name, size=10)
    return probe.actual('family') if probe.actual('family').casefold() == name.casefold() else None
```
Tk render는 GDI를 통해 process-private 폰트를 즉시 보므로 등록 직후에도 신뢰 가능.

## Commits

| 커밋 | 내용 |
|------|------|
| `4ee9466` | **fix(font)**: Pretendard render-layer 보장 — root cause 수정. core/utils.py + gui/utils.py + gui_main --smoke-test + tests |
| `7a661c7` | **build**: pyproject `font/**` glob + `build_scripts/build_local.py` (jobs=14) + `nuitka_flags.build_nuitka_args(jobs=…)` |
| `9e00d23` | **release**: v2.4.28 + CHANGELOG |

### 핵심 변경

* **`core/utils.py::set_matplotlib_font()`** — silent fallback이던 함수를 `font_setup_result` 모듈 전역(`source` / `family` / `path` / `is_pretendard`)으로 결과를 보고하도록 리팩토링.
* **`gui/utils.py::_tk_renders_family()`** — `tkfont.Font(family=X).actual('family')` 기반 render-layer 프로빙. setup_pretendard_font가 이를 사용해 families() 캐시를 우회.
* **`gui_main.py::_smoke_test()`** — 시스템 Pretendard 마스킹 후 (1) matplotlib 번들 채택 (2) Tk root에서 setup_pretendard_font('ko') → actual('family')='Pretendard' 양쪽 검증. 실패 시 exit 2.
* **번들 폰트 일반 스캐너** — `font/*.otf|.ttf|.ttc` 전체를 자동 등록. 사용자가 본명조(SourceHanSerif) 등 보조 폰트를 `font/`에 떨어뜨리면 wheel/standalone 양쪽에 자동 번들·등록됨. pyproject.toml force-include는 `font/Pretendard-Regular.otf` → `font/**` glob.
* **`build_scripts/build_local.py`** — 16-core 머신 기준 `--jobs=max(2, min(cpu-2, 14))`로 자동 산출. `dist/local/` 출력. CI는 default 4 유지.

## 검증

### Standalone Nuitka build (Windows / Nuitka 4.0.8 / Python 3.13.3)

```
$ python build_scripts/build_local.py
$ ./dist/local/gui_main.dist/ImpulciferGUI.exe --smoke-test
Tk render layer resolves Pretendard: Pretendard
smoke-test OK (imports=18, font.matplotlib=bundled, font.gui='Pretendard',
               font.path=...\dist\local\gui_main.dist\font\Pretendard-Regular.otf)
```

### BRIR md5 회귀 없음

| 경로 | md5 |
|------|-----|
| 기본값 | `cf37a9aaf95e717c04e309fba05fa61d` |
| `--vbass --vbass_freq=250` | `07eef9ef89cc0d55313c9c0c18edbc76` |

### 테스트

기존 `_match_tk_family` stub 기반 GUI 테스트 3건을 `_tk_renders_family`-기반 3건(render check + cache 안정성)으로 대체.

```
pytest tests/test_suite.py tests/test_gui.py tests/test_nuitka_flags.py \
       tests/test_update_executors.py tests/test_velopack_updater.py \
       tests/test_magnitude_response_parity.py tests/test_virtual_bass.py
→ 79 passed
```

## Test plan

- [x] `pytest tests/` 79건 통과
- [x] `python build_scripts/build_local.py` exit 0, ImpulciferGUI.exe 생성
- [x] `ImpulciferGUI.exe --smoke-test` exit 0 + `font.gui='Pretendard'` 확인
- [x] BRIR md5 두 경로 master와 동일 (Windows)
- [ ] CI(`brir-integrity`) 잡 통과
- [ ] CI(`test.yml`)에서 Python 3.9~3.14 매트릭스 통과
- [ ] (선택) MacType 미사용 일반 Windows에서 시각적으로 Pretendard 적용 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)