### PR TITLE
fix(i18n): resolve locales via real package, reject empty stale dir (v2.6.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ first number changes, something has broken and you need to check your commands a
 changes there are only new features available and nothing old has broken and when the last number changes, old bugs have
 been fixed and old features improved.
 
+## 2.6.5 - 2026-05-16
+### 🐛 PyPI 로케일 해석 버그 수정 — GUI가 i18n 키 원문으로 표시되던 문제
+
+#### 🐛 버그 수정
+- **PyPI 업그레이드 환경에서 모든 GUI 문자열이 번역되지 않던 치명적 버그**: `_find_locales_dir()`가
+  존재하지 않는 패키지명 `impulcifer_py313`으로 `importlib.resources.files()`를 호출해 항상
+  `ModuleNotFoundError`로 실패했고, 그 뒤 후보 경로를 단순히 `.exists()`로만 검사했다. 이 때문에
+  2.4.27 이전 shared-data 설치에서 업그레이드 시 남는 **빈** `<sys.prefix>/impulcifer_py313/locales`
+  디렉터리가 선택되어, `app_title`·`sidebar_recorder` 등 모든 라벨이 i18n 키 원문 그대로 노출됐다.
+  실제 패키지명 `i18n`으로 `importlib.resources.files('i18n')/'locales'`를 1순위로 사용하도록
+  고치고, 모든 후보 디렉터리를 `en.json` 존재 여부로 내용 검증하도록 변경했다. 빈 디렉터리를
+  생성해 성공으로 위장하던 폴백도 제거했다. 미업그레이드 구버전 호환을 위해 legacy shared-data
+  경로는 실제 JSON이 남아 있을 때만 인정한다.
+
 ## 2.6.4 - 2026-05-16
 ### PyPI GUI entry point shadowing fix
 

--- a/i18n/localization.py
+++ b/i18n/localization.py
@@ -40,51 +40,81 @@ LOCALE_MAPPING = {
 class LocalizationManager:
     """Manages translations and user preferences"""
 
+    @staticmethod
+    def _is_valid_locales_dir(path: Path) -> bool:
+        """A locales directory only counts if it actually holds the base
+        translation (``en.json``).
+
+        Pre-2.4.27 wheels shipped the JSON via a ``shared-data`` mapping that
+        installed a copy to ``<sys.prefix>/impulcifer_py313/locales``. Upgrading
+        removes those files but leaves the now-empty directory behind. The old
+        resolver accepted any directory that merely ``.exists()``, so that stale
+        empty folder won — and every GUI string rendered as its raw i18n key on
+        pip-upgraded environments. Validating by content rejects the decoy.
+        """
+        try:
+            return (path / 'en.json').is_file()
+        except OSError:
+            return False
+
     def _find_locales_dir(self) -> Path:
-        """Find the locales directory in multiple possible locations"""
-        # Try different possible locations
-        possible_paths = [
-            Path(__file__).parent / 'locales',  # Development environment (i18n/locales)
-            Path(__file__).parent.parent / 'i18n' / 'locales',  # Alternative: project root
-            Path(__file__).parent.parent / 'impulcifer_py313' / 'locales',  # PyPI package structure
-        ]
+        """Find the locales directory, preferring the actually-imported
+        ``i18n`` package's own data.
 
-        # Also try using sys.prefix for installed packages
-        import sys
-        if hasattr(sys, 'prefix'):
-            possible_paths.extend([
-                Path(sys.prefix) / 'impulcifer_py313' / 'locales',
-                Path(sys.prefix) / 'share' / 'impulcifer_py313' / 'locales',
-                Path(sys.prefix) / 'lib' / 'impulcifer_py313' / 'locales',
-            ])
+        ``importlib.resources.files('i18n')`` anchors to wherever the running
+        ``i18n`` package physically lives — the exact same install as this
+        module — so it cannot be fooled by a stale ``impulcifer_py313`` folder
+        under ``sys.prefix``. (The previous code queried the package name
+        ``'impulcifer_py313'``, which does not exist and always raised
+        ``ModuleNotFoundError``, defeating the only robust lookup.)
+        """
+        candidates = []
 
-        # Try importlib.resources for Python 3.9+
+        # 1. The real package's bundled data — canonical, install-agnostic.
         try:
             import importlib.resources as importlib_resources
-            try:
-                # Try to get the locales directory from package resources
-                if hasattr(importlib_resources, 'files'):  # Python 3.9+
-                    try:
-                        package_path = importlib_resources.files('impulcifer_py313')
-                        locales_path = package_path / 'locales'
-                        if locales_path.is_dir():
-                            return Path(str(locales_path))
-                    except Exception:
-                        pass
-            except Exception:
-                pass
-        except ImportError:
+            if hasattr(importlib_resources, 'files'):  # Python 3.9+
+                candidates.append(Path(str(importlib_resources.files('i18n'))) / 'locales')
+        except (ImportError, ModuleNotFoundError, AttributeError, TypeError):
             pass
 
-        # Find the first existing directory
-        for path in possible_paths:
-            if path.exists() and path.is_dir():
+        # 2. File-relative — sibling of this module (source checkout & wheel).
+        candidates.append(Path(__file__).resolve().parent / 'locales')
+
+        # 3. Same root that infra.resource_helper uses for every other bundled
+        #    resource, so locale resolution matches data/font/img in both pip
+        #    and Nuitka standalone builds.
+        try:
+            from infra.resource_helper import get_resource_path
+            candidates.append(Path(get_resource_path('i18n/locales')))
+        except Exception:
+            pass
+
+        # 4. Project-root layout (running from a source tree).
+        candidates.append(Path(__file__).resolve().parent.parent / 'i18n' / 'locales')
+
+        # 5. Legacy pre-2.4.27 shared-data location. Honoured only if it still
+        #    holds the JSON (an old install that was never upgraded); the empty
+        #    leftover from an upgrade fails the content check above.
+        import sys
+        for base in {Path(sys.prefix), Path(getattr(sys, 'base_prefix', sys.prefix))}:
+            candidates.append(base / 'impulcifer_py313' / 'locales')
+            candidates.append(base / 'share' / 'impulcifer_py313' / 'locales')
+            candidates.append(base / 'lib' / 'impulcifer_py313' / 'locales')
+
+        seen = set()
+        for path in candidates:
+            key = str(path)
+            if key in seen:
+                continue
+            seen.add(key)
+            if self._is_valid_locales_dir(path):
                 return path
 
-        # If nothing found, create in current directory as fallback
-        fallback_path = Path(__file__).parent / 'locales'
-        fallback_path.mkdir(exist_ok=True)
-        return fallback_path
+        # Nothing valid found. Return the package-relative path (without
+        # creating an empty decoy) so the diagnostic in load_translations
+        # points at the real expected location.
+        return Path(__file__).resolve().parent / 'locales'
 
     def __init__(self):
         self.current_language = 'en'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "impulcifer-py313"
-version = "2.6.4"
+version = "2.6.5"
 authors = [
   { name="원본 저자: Jaakko Pasanen", email="" },
   { name="Python 3.13/3.14 호환 버전: 115dkk", email="" },


### PR DESCRIPTION
## 문제

PyPI 설치 환경에서 GUI의 모든 문자열이 번역되지 않고 `app_title`, `sidebar_recorder`, `studio_recorder_title` 같은 **i18n 키 원문 그대로** 표시되는 치명적 버그. 스크린샷:

```
Translation file not found: ...\Python313\impulcifer_py313\locales\ko.json
Locales directory: ...\Python313\impulcifer_py313\locales
Directory exists: True
Files in locales dir: []
```

## 근본 원인

`i18n/localization.py`의 `_find_locales_dir()`에 두 가지 결함:

1. **존재하지 않는 패키지명 조회**: `importlib.resources.files('impulcifer_py313')`를 호출 — 그런 패키지는 없어서 항상 `ModuleNotFoundError`. 유일하게 견고했어야 할 조회가 항상 실패했다. (올바른 패키지명은 `i18n`.)
2. **빈 디렉터리 무검증 수락**: 후보 경로를 `.exists()`로만 검사. 2.4.27 이전 `shared-data` 설치본에서 업그레이드하면 `<sys.prefix>/impulcifer_py313/locales`에 **빈** 디렉터리가 남는데, 이게 선택되어 번역이 0건 로드됐다. 마지막 폴백은 빈 디렉터리를 `mkdir`해서 성공으로 위장하기까지 했다.

신규 클린 설치에서는 우연히 동작했으나(파일 상대 경로가 먼저 매칭), 구버전→2.6.4 업그레이드 경로에서 재현된다.

## 수정

- 1순위로 **실제 패키지명** `importlib.resources.files('i18n') / 'locales'` 사용 — 실행 중인 `i18n` 패키지가 물리적으로 있는 위치에 고정되어 `sys.prefix`/shared-data 혼선에 영향받지 않음
- 모든 후보 디렉터리를 `en.json` 존재 여부로 **내용 검증**(빈 stale 디렉터리 거부)
- 빈 디렉터리를 생성해 성공으로 위장하던 폴백 제거
- 미업그레이드 구버전 호환을 위해 legacy shared-data 경로는 실제 JSON이 남아 있을 때만 인정

## 검증

직접 빌드/PyPI 다운로드 wheel로 4개 시나리오 모두 통과:

- [x] 클린 published 2.6.4 설치 → 정상
- [x] **스크린샷 재현**(빈 `<sys.prefix>/impulcifer_py313/locales` decoy + 정상 `i18n/locales`) → decoy 거부, `importlib.resources('i18n')`로 정상 해석, `app_title` → `🎧 Impulcifer`
- [x] dev/소스 트리 → 정상
- [x] legacy 호환(shared-data 사본만 존재, `i18n/locales` 부재) → 내용 검증 후보가 정상 발견
- [x] Tier 1: `py_compile`, `ruff` 통과
- [x] Tier 2: `pytest tests/` 135 passed (실패 3건은 헤드리스 컨테이너의 `tkinter` 부재로 인한 무관 GUI 테스트)
- [x] 모듈 임포트 검증 (i18n / infra / updater)

버전 2.6.4 → 2.6.5 (PATCH, 런타임 버그 수정), CHANGELOG 갱신. README는 설치/사용법/CLI/의존성 변경 없어 미수정.

https://claude.ai/code/session_019dL3Da9xufRqm7GTnL4xDh

---
_Generated by [Claude Code](https://claude.ai/code/session_019dL3Da9xufRqm7GTnL4xDh)_