### PR TITLE
perf(autoeq): 플롯 의존성 지연 로딩 + 핫 헬퍼 벡터화

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ first number changes, something has broken and you need to check your commands a
 changes there are only new features available and nothing old has broken and when the last number changes, old bugs have
 been fixed and old features improved.
 
+## 2.6.10 - 2026-05-29
+### 내장 AutoEQ 임포트/연산 경량화
+
+#### ⚡ 성능 개선
+- **AutoEQ 임포트에서 matplotlib/Pillow/tabulate 지연 로딩**: `autoeq/frequency_response.py`와 `autoeq/biquad.py`가 모듈 최상위에서 `matplotlib.pyplot`·`PIL.Image`·`tabulate`를 끌어오던 것을, 실제로 사용하는 메서드(`plot_graph`·`write_readme`·`main`) 안으로 옮겨 지연 import로 전환했다. 특히 `biquad.py`가 데모용 `main()`만을 위해 matplotlib을 최상위에서 import하던 탓에, 플롯과 무관한 EQ 워커가 `FrequencyResponse`만 import해도 matplotlib까지 강제로 로드되던 문제를 해소했다. 그 결과 EQ 전용 ProcessPool 워커(`core/parallel_workers.py`)의 신규 프로세스 import 비용이 약 1.07s → 0.82s로 감소하며, spawn 시작 방식(Python 3.14 기본, macOS/Windows)에서 워커 수에 비례한 시작 지연이 줄어든다.
+- **`_init_data` 벡터화**: 모든 `FrequencyResponse` 생성 시 데이터 배열을 원소 단위 파이썬 루프(`[None if ... for x in data]`)로 재구성하던 것을, NaN이 없는 숫자형 배열은 `np.asarray` 빠른 경로로 처리하도록 바꿨다. None/NaN을 포함한 배열은 기존 경로를 그대로 유지해 dtype·값이 비트 단위로 동일하다.
+- **`_sort` 중복 주파수 검사 벡터화**: 정렬 후 인접 주파수 중복을 파이썬 루프로 검사하던 것을 `np.diff` 기반 벡터 비교로 교체했다. 중복이 있을 때 보고하는 주파수 값과 예외 동작은 동일하다.
+
+#### 검증
+- **BRIR 출력 무결성 유지**: 데모 데이터로 생성한 `hesuvi.wav`의 md5가 기본값 경로·`--vbass --vbass_freq=250` 경로 모두에서 master와 비트 단위로 동일함을 확인했다(vbass: `d295982d021a6d16ab2c194c3517c162`). `_init_data`는 None/NaN/정수/object 배열 등 엣지 케이스에서도 원본 구현과 dtype·값이 일치함을 별도 검증했다.
+
 ## 2.6.9 - 2026-05-29
 ### 일본어 GUI 폰트 적용 + 미사용 세리프 폰트 정리
 

--- a/autoeq/biquad.py
+++ b/autoeq/biquad.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 
 import numpy as np
-import matplotlib.pyplot as plt
-import matplotlib.ticker as ticker
+
+# matplotlib is only used by the ``main()`` demo below; it is imported lazily
+# there so importing this module (e.g. from ProcessPool workers) stays cheap.
 
 
 def numpyfy(fc, Q, gain, fs):
@@ -135,6 +136,8 @@ def impulse_response(a0, a1, a2, b0, b1, b2, n=250):
 
 
 def main():
+    import matplotlib.pyplot as plt
+    import matplotlib.ticker as ticker
     fc = [20, 220, 450, 1280, 2200, 3000, 5700, 6600, 7600]
     Q = [1.1, 0.9, 1.0, 1.5, 4.0, 2.0, 6.0, 7.0, 5.0]
     gain = [2.1, -3.8, -2.0, 4.0, -3.5, 4.5, -5.0, 0.4, -2.4]

--- a/autoeq/frequency_response.py
+++ b/autoeq/frequency_response.py
@@ -2,8 +2,6 @@
 
 import os
 import csv
-import matplotlib.pyplot as plt
-import matplotlib.ticker as ticker
 import math
 from io import StringIO
 from scipy.interpolate import InterpolatedUnivariateSpline
@@ -13,9 +11,6 @@ from scipy.special import expit
 from scipy.stats import linregress
 from scipy.fftpack import next_fast_len
 import numpy as np
-import urllib
-from tabulate import tabulate
-from PIL import Image
 import re
 import warnings
 from autoeq import biquad
@@ -27,10 +22,20 @@ from autoeq.constants import DEFAULT_F_MIN, DEFAULT_F_MAX, DEFAULT_STEP, DEFAULT
     DEFAULT_BASS_BOOST_Q, DEFAULT_GRAPHIC_EQ_STEP, HARMAN_INEAR_PREFENCE_FREQUENCIES, \
     HARMAN_ONEAR_PREFERENCE_FREQUENCIES
 
-try:
-    ADAPTIVE_PALETTE = Image.Palette.ADAPTIVE
-except AttributeError:
-    ADAPTIVE_PALETTE = getattr(Image, 'ADAPTIVE')
+# matplotlib, Pillow and tabulate are only needed for plotting / README / image
+# export. They are imported lazily inside the methods that use them so that the
+# hot processing path (and lightweight ProcessPool workers that only call
+# smoothen/equalize/minimum_phase_impulse_response) does not pay their import
+# cost. See core/parallel_workers.py for the worker design this enables.
+
+
+def _adaptive_palette():
+    """Returns Pillow's adaptive palette constant, importing Pillow lazily."""
+    from PIL import Image
+    try:
+        return Image.Palette.ADAPTIVE
+    except AttributeError:
+        return getattr(Image, 'ADAPTIVE')
 
 
 class FrequencyResponse:
@@ -87,11 +92,21 @@ class FrequencyResponse:
         """Initializes data to a clean format. If None is passed and empty array is created. Non-numbers are removed."""
         if data is None:
             # None means empty array
-            data = []
+            return np.array([])
         elif isinstance(data, (float, int)) and not isinstance(data, bool):
             # Scalar means all values are that, same shape as frequency
             data = np.ones(self.frequency.shape) * data
-        # Replace nans with Nones
+
+        # Fast path: a numeric (non-object) ndarray/list without NaNs is
+        # unaffected by the None/NaN replacement below, so it can be wrapped
+        # directly. ``np.array`` makes a fresh copy, matching the original
+        # ``np.array(list_comprehension)`` semantics (no input aliasing).
+        arr = np.asarray(data)
+        if arr.dtype.kind in 'fiub' and not (arr.dtype.kind == 'f' and np.isnan(arr).any()):
+            return np.array(arr)
+
+        # Slow path preserves the original element-wise None/NaN handling for
+        # object arrays and arrays that actually contain NaN values.
         data = [None if x is None or math.isnan(x) else x for x in data]
         # Wrap in Numpy array
         data = np.array(data)
@@ -100,11 +115,11 @@ class FrequencyResponse:
     def _sort(self):
         sorted_inds = self.frequency.argsort()
         self.frequency = self.frequency[sorted_inds]
-        for i in range(1, len(self.frequency)):
-            if self.frequency[i] == self.frequency[i - 1]:
-                raise ValueError('Duplicate values found at frequency {}. Remove duplicates manually.'.format(
-                    self.frequency[i])
-                )
+        if len(self.frequency) > 1 and np.any(self.frequency[1:] == self.frequency[:-1]):
+            dup_ind = int(np.flatnonzero(self.frequency[1:] == self.frequency[:-1])[0]) + 1
+            raise ValueError('Duplicate values found at frequency {}. Remove duplicates manually.'.format(
+                self.frequency[dup_ind])
+            )
         if len(self.raw):
             self.raw = self.raw[sorted_inds]
         if len(self.error):
@@ -688,6 +703,8 @@ class FrequencyResponse:
 
     def write_readme(self, file_path, max_filters=None, max_gains=None):
         """Writes README.md with picture and Equalizer APO settings."""
+        import urllib
+        from tabulate import tabulate
         file_path = os.path.abspath(file_path)
         dir_path = os.path.dirname(file_path)
         model = self.name
@@ -1331,6 +1348,8 @@ class FrequencyResponse:
                    target_plot_kwargs=None,
                    close=False):
         """Plots frequency response graph."""
+        import matplotlib.pyplot as plt
+        import matplotlib.ticker as ticker
         if fig is None:
             fig, ax = plt.subplots()
             fig.set_size_inches(12, 8)
@@ -1405,10 +1424,11 @@ class FrequencyResponse:
         ax.grid(True, which='minor')
         ax.xaxis.set_major_formatter(ticker.StrMethodFormatter('{x:.0f}'))
         if file_path is not None:
+            from PIL import Image
             file_path = os.path.abspath(file_path)
             fig.savefig(file_path, dpi=120)
             im = Image.open(file_path)
-            im = im.convert('P', palette=ADAPTIVE_PALETTE, colors=60)
+            im = im.convert('P', palette=_adaptive_palette(), colors=60)
             im.save(file_path, optimize=True)
         if show:
             plt.show()

--- a/autoeq/frequency_response.py
+++ b/autoeq/frequency_response.py
@@ -101,9 +101,13 @@ class FrequencyResponse:
         # unaffected by the None/NaN replacement below, so it can be wrapped
         # directly. ``np.array`` makes a fresh copy, matching the original
         # ``np.array(list_comprehension)`` semantics (no input aliasing).
-        arr = np.asarray(data)
-        if arr.dtype.kind in 'fiub' and not (arr.dtype.kind == 'f' and np.isnan(arr).any()):
-            return np.array(arr)
+        # Masked arrays are excluded: ``np.asarray`` would silently drop the
+        # mask, whereas the original element-wise path turned masked samples
+        # into ``None`` (via ``math.isnan``), so they must use the slow path.
+        if not np.ma.isMaskedArray(data):
+            arr = np.asarray(data)
+            if arr.dtype.kind in 'fiub' and not (arr.dtype.kind == 'f' and np.isnan(arr).any()):
+                return np.array(arr)
 
         # Slow path preserves the original element-wise None/NaN handling for
         # object arrays and arrays that actually contain NaN values.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "impulcifer-py313"
-version = "2.6.9"
+version = "2.6.10"
 authors = [
   { name="원본 저자: Jaakko Pasanen", email="" },
   { name="Python 3.13/3.14 호환 버전: 115dkk", email="" },


### PR DESCRIPTION
## 개요

내장 AutoEQ(`autoeq/`)의 출력은 그대로 유지하면서 import/연산 비용을 줄이는 최적화입니다. BRIR 출력(`hesuvi.wav`)은 기본값 경로와 `--vbass --vbass_freq=250` 경로 모두에서 master와 **비트 단위로 동일**합니다.

## 변경 내용

### ⚡ matplotlib / Pillow / tabulate 지연 로딩
- `autoeq/frequency_response.py`와 `autoeq/biquad.py`가 모듈 최상위에서 끌어오던 `matplotlib.pyplot`·`PIL.Image`·`tabulate`를 실제 사용 메서드(`plot_graph`·`write_readme`·`main`) 내부로 이동.
- 핵심 문제: `biquad.py`가 데모용 `main()` 하나 때문에 matplotlib을 최상위 import하던 탓에, 플롯과 무관한 EQ 워커가 `FrequencyResponse`만 import해도 matplotlib까지 강제 로드되었습니다. 이는 `core/parallel_workers.py`의 "워커는 matplotlib을 끌어오지 않는다"는 설계 의도와 모순이었습니다.
- 효과: 신규 프로세스에서 `from autoeq.frequency_response import FrequencyResponse` 비용 **약 1.07s → 0.82s**. spawn 시작 방식(Python 3.14 기본, macOS/Windows)에서 워커 수에 비례한 시작 지연 감소.

### ⚡ 핫 헬퍼 벡터화
- `_init_data`: 모든 `FrequencyResponse` 생성 시 돌던 원소 단위 파이썬 루프(`[None if x is None or math.isnan(x) else x for x in data]`)를, NaN 없는 숫자형 배열에 대해 `np.asarray` 빠른 경로로 대체. None/NaN 포함 배열은 기존 경로 유지 → dtype·값 비트 단위 동일.
- `_sort`: 정렬 후 인접 중복 주파수 검사를 파이썬 루프 → `np.diff` 기반 벡터 비교로 교체. 중복 보고 값·예외 동작 동일.

## 검증
- ✅ `hesuvi.wav` md5: 기본값 `3405f5cdd3c7c5411dc299aad3639640`, vbass `d295982d021a6d16ab2c194c3517c162` — 둘 다 master와 일치
- ✅ `_init_data`를 None/NaN/정수/float32/object 배열 등 엣지 케이스에서 원본 구현과 dtype·값 일치 확인
- ✅ 전체 테스트 통과 (tkinter 미설치로 GUI 테스트만 스킵, 본 변경과 무관): `test_suite`, `test_magnitude_response_parity`, `test_brir_integrity`, `test_parallel_processing`, `test_integration`, `test_virtual_bass` 등 57 passed
- ✅ `ruff check autoeq/` 통과

버전: 2.6.9 → 2.6.10 (PATCH, 출력 무변화 성능 개선)

https://claude.ai/code/session_01N6LErgQKszppdmgjSYzujq

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6LErgQKszppdmgjSYzujq)_