### PR TITLE
ci: GitHub Actions Node.js 24 마이그레이션 (#106)

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -20,17 +20,17 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.14'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 
@@ -54,7 +54,7 @@ jobs:
             libopenblas-dev
 
       - name: Cache Nuitka compilation
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/Nuitka
           key: ${{ runner.os }}-nuitka-${{ hashFiles('**/*.py') }}
@@ -251,7 +251,7 @@ jobs:
           echo "✅ Linux tarball distribution created."
 
       - name: Upload Linux artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: linux-distribution
           path: |

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -20,22 +20,22 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.14'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 
       - name: Cache Nuitka compilation
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/Library/Caches/Nuitka
           key: ${{ runner.os }}-nuitka-${{ hashFiles('**/*.py') }}
@@ -111,7 +111,7 @@ jobs:
           echo "✅ macOS distribution package created."
 
       - name: Upload macOS artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: macos-distribution
           path: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.13'
 
@@ -56,10 +56,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.13'
 
@@ -76,7 +76,7 @@ jobs:
       run: python -m build
 
     - name: Upload distributions
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: python-package-distributions
         path: dist/
@@ -100,7 +100,7 @@ jobs:
 
     steps:
     - name: Download distributions
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v6
       with:
         name: python-package-distributions
         path: dist/

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -25,14 +25,14 @@ jobs:
     name: Run Tests Before Publishing
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 
@@ -54,14 +54,14 @@ jobs:
     needs: test  # 테스트 통과 후에만 빌드
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 
@@ -72,7 +72,7 @@ jobs:
           python -m build
 
       - name: Upload distributions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: release-dists
           path: dist/
@@ -100,7 +100,7 @@ jobs:
 
     steps:
       - name: Retrieve release distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: release-dists
           path: dist/

--- a/.github/workflows/release-cross-platform.yml
+++ b/.github/workflows/release-cross-platform.yml
@@ -19,27 +19,27 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.14'
 
       - name: Set up .NET SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '8.0.x'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 
       - name: Cache Nuitka compilation
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~\AppData\Local\Nuitka\Nuitka\Cache
           key: ${{ runner.os }}-nuitka-${{ hashFiles('**/*.py') }}
@@ -116,7 +116,7 @@ jobs:
           DOTNET_CLI_TELEMETRY_OPTOUT: 1
 
       - name: Upload Velopack releases
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: windows-velopack
           path: ${{ env.VELOPACK_OUTPUT_DIR }}/*
@@ -129,22 +129,22 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.14'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 
       - name: Cache Nuitka compilation
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/Library/Caches/Nuitka
           key: ${{ runner.os }}-nuitka-${{ hashFiles('**/*.py') }}
@@ -224,7 +224,7 @@ jobs:
             "dist/dmg/"
 
       - name: Upload macOS DMG
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: macos-dmg
           path: dist/Impulcifer-*.dmg
@@ -238,17 +238,17 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.14'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 
@@ -272,7 +272,7 @@ jobs:
             libopenblas-dev
 
       - name: Cache Nuitka compilation
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/Nuitka
           key: ${{ runner.os }}-nuitka-${{ hashFiles('**/*.py') }}
@@ -460,7 +460,7 @@ jobs:
           echo "Tarball created: dist/Impulcifer-${{ env.APP_VERSION }}-linux-x86_64.tar.gz"
 
       - name: Upload Linux AppImage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: linux-appimage
           path: Impulcifer-*.AppImage
@@ -468,7 +468,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Upload Linux tarball
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: linux-tarball
           path: dist/Impulcifer-*.tar.gz
@@ -484,12 +484,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
 
@@ -500,7 +500,7 @@ jobs:
           echo "Version: $APP_VERSION"
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           path: artifacts
 
@@ -534,7 +534,7 @@ jobs:
           echo "EOF" >> $GITHUB_ENV
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ env.TAG_NAME }}
           name: "Impulcifer ${{ env.APP_VERSION }} - Cross-Platform Release"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,15 +18,15 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
 
@@ -43,10 +43,10 @@ jobs:
         pytest tests/ -v --cov=. --cov-report=xml --cov-report=term-missing
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v6
       if: matrix.python-version == '3.11'
       with:
-        file: ./coverage.xml
+        files: ./coverage.xml
         flags: unittests
         name: codecov-umbrella
         fail_ci_if_error: false
@@ -57,17 +57,17 @@ jobs:
     timeout-minutes: 20
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.13"
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
 
@@ -88,15 +88,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.11"
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
 
@@ -126,15 +126,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.11"
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ first number changes, something has broken and you need to check your commands a
 changes there are only new features available and nothing old has broken and when the last number changes, old bugs have
 been fixed and old features improved.
 
+## 2.7.0 - 2026-06-03
+### GitHub Actions Node.js 24 마이그레이션
+
+#### 🔧 빌드 / 설정 변경
+- **Node.js 20 기반 액션 일괄 업그레이드**: GitHub이 2026년 9월 16일 러너에서 Node.js 20을 제거하고 6월부터 Node.js 24를 기본값으로 강제함에 따라, 모든 워크플로(`test.yml`, `release-cross-platform.yml`, `build-linux.yml`, `build-macos.yml`, `publish.yml`, `python-publish.yml`)의 액션을 Node.js 24를 지원하는 첫 메이저 버전으로 올렸다. `actions/checkout` v4→v5, `actions/setup-python` v5→v6, `actions/cache` v4→v5, `actions/upload-artifact` v4→v5, `actions/download-artifact` v4→v6, `actions/setup-dotnet` v4→v5, `astral-sh/setup-uv` v5→v7, `softprops/action-gh-release` v2→v3. 기존 동작을 보존하기 위해 최신 메이저가 아니라 "Node 24를 처음 지원하는" 메이저를 선택했다(예: setup-uv는 v6이 아직 node20이라 v7 채택, download-artifact는 v5가 node20이라 v6 채택).
+- **codecov-action v4→v6 + 입력명 갱신**: `codecov/codecov-action`을 node20인 v4/v5에서 node24 composite 액션인 v6으로 올리고, v5에서 제거된 단수형 입력 `file:`을 복수형 `files:`로 교체했다(`fail_ci_if_error: false`라 업로드 실패가 CI를 막지 않는 best-effort 동작은 유지).
+- Docker 액션인 `pypa/gh-action-pypi-publish@release/v1`은 Node 런타임 대상이 아니라 경고가 발생하지 않으므로 그대로 두었다.
+
 ## 2.7.0 - 2026-05-30
 ### 마이크 착용 편차 보정 음향학 기반 재설계 (v4.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ first number changes, something has broken and you need to check your commands a
 changes there are only new features available and nothing old has broken and when the last number changes, old bugs have
 been fixed and old features improved.
 
-## 2.7.0 - 2026-06-03
+## 2.7.1 - 2026-06-03
 ### GitHub Actions Node.js 24 마이그레이션
 
 #### 🔧 빌드 / 설정 변경

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "impulcifer-py313"
-version = "2.7.0"
+version = "2.7.1"
 authors = [
   { name="원본 저자: Jaakko Pasanen", email="" },
   { name="Python 3.13/3.14 호환 버전: 115dkk", email="" },


### PR DESCRIPTION
## 배경
GitHub이 2026년 9월 16일 러너에서 Node.js 20을 제거하고, 6월부터 Node.js 24를 기본값으로 강제합니다. 빌드/릴리스 워크플로 실행 시 `Node.js 20 actions are deprecated` 경고가 발생하던 현상을 수정합니다.

## 변경
모든 활성 워크플로(`test.yml`, `release-cross-platform.yml`, `build-linux.yml`, `build-macos.yml`, `publish.yml`, `python-publish.yml`)의 액션을 **Node.js 24를 처음 지원하는 메이저**로 업그레이드했습니다(최신 메이저가 아니라 기존 동작 보존이 목적).

| 액션 | 변경 |
|------|------|
| actions/checkout | v4 → v5 |
| actions/setup-python | v5 → v6 |
| actions/cache | v4 → v5 |
| actions/upload-artifact | v4 → v5 |
| actions/download-artifact | v4 → v6 (v5는 아직 node20) |
| actions/setup-dotnet | v4 → v5 |
| astral-sh/setup-uv | v5 → v7 (v6는 아직 node20) |
| softprops/action-gh-release | v2 → v3 |
| codecov/codecov-action | v4 → v6 (v5도 node20, composite). 입력 `file:` → `files:` |

## 손대지 않은 것
- `pypa/gh-action-pypi-publish@release/v1` — Docker 액션이라 Node 경고 대상 아님.
- `_nuitka-distribution.yml.disabled` — `.disabled`라 GitHub이 무시 → 경고 미발생.

## 검증
- 6개 워크플로 YAML 파싱 정상.
- 각 타깃 버전의 `action.yml` `runs.using`이 node24인지 확인.
- CI·빌드 설정 전용 변경이라 버전 bump·README·i18n 불필요. CHANGELOG는 2.7.0 아래 오늘 날짜로 🔧 항목 추가.

🤖 Generated with [Claude Code](https://claude.com/claude-code)