### PR TITLE
ci: upload-artifact를 v6으로 정정 (v5는 아직 node20)

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -251,7 +251,7 @@ jobs:
           echo "✅ Linux tarball distribution created."
 
       - name: Upload Linux artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: linux-distribution
           path: |

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -111,7 +111,7 @@ jobs:
           echo "✅ macOS distribution package created."
 
       - name: Upload macOS artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: macos-distribution
           path: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,7 +76,7 @@ jobs:
       run: python -m build
 
     - name: Upload distributions
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v6
       with:
         name: python-package-distributions
         path: dist/

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -72,7 +72,7 @@ jobs:
           python -m build
 
       - name: Upload distributions
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: release-dists
           path: dist/

--- a/.github/workflows/release-cross-platform.yml
+++ b/.github/workflows/release-cross-platform.yml
@@ -116,7 +116,7 @@ jobs:
           DOTNET_CLI_TELEMETRY_OPTOUT: 1
 
       - name: Upload Velopack releases
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: windows-velopack
           path: ${{ env.VELOPACK_OUTPUT_DIR }}/*
@@ -224,7 +224,7 @@ jobs:
             "dist/dmg/"
 
       - name: Upload macOS DMG
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: macos-dmg
           path: dist/Impulcifer-*.dmg
@@ -460,7 +460,7 @@ jobs:
           echo "Tarball created: dist/Impulcifer-${{ env.APP_VERSION }}-linux-x86_64.tar.gz"
 
       - name: Upload Linux AppImage
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: linux-appimage
           path: Impulcifer-*.AppImage
@@ -468,7 +468,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Upload Linux tarball
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: linux-tarball
           path: dist/Impulcifer-*.tar.gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ first number changes, something has broken and you need to check your commands a
 changes there are only new features available and nothing old has broken and when the last number changes, old bugs have
 been fixed and old features improved.
 
+## 2.7.2 - 2026-06-03
+### upload-artifact를 실제 Node.js 24 메이저(v6)로 정정
+
+#### 🔧 빌드 / 설정 변경
+- **`actions/upload-artifact` v5→v6**: 2.7.1에서 upload-artifact를 v5로 올렸으나, GitHub 러너의 런타임 어노테이션 결과 v5는 여전히 `node20`임이 확인됐다(`runs.using: node20`). upload-artifact가 `node24`로 전환된 첫 메이저는 v6이므로, 8개 사용처(`build-linux.yml`, `build-macos.yml`, `release-cross-platform.yml`×4, `publish.yml`, `python-publish.yml`)를 모두 v6으로 정정했다. v6은 v4/v5와 업로드 의미(이름·경로·`if-no-files-found`·`retention-days`)가 동일하며 GitHub-hosted 러너의 최소 러너 버전(2.327.1)을 충족한다. 나머지 8개 액션(checkout v5, setup-python v6, cache v5, download-artifact v6, setup-dotnet v5, setup-uv v7, action-gh-release v3, codecov v6)은 각 태그의 `action.yml`에서 `node24`임을 재검증했다.
+
 ## 2.7.1 - 2026-06-03
 ### GitHub Actions Node.js 24 마이그레이션
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "impulcifer-py313"
-version = "2.7.1"
+version = "2.7.2"
 authors = [
   { name="원본 저자: Jaakko Pasanen", email="" },
   { name="Python 3.13/3.14 호환 버전: 115dkk", email="" },


### PR DESCRIPTION
#106 후속 수정.

## 문제
#106에서 `actions/upload-artifact`를 v5로 올렸으나, master 병합 후 `Publish to PyPI` 실행의 런타임 어노테이션에서 **`actions/upload-artifact@v5`가 여전히 Node.js 20**임이 드러났습니다(`runs.using: node20`). 사전 조사 시 "v5가 첫 node24"라고 판단한 것이 오류였습니다.

## 수정
- `actions/upload-artifact` **v5 → v6** (8개 사용처: `build-linux`, `build-macos`, `release-cross-platform`×4, `publish`, `python-publish`). v6이 upload-artifact의 첫 `node24` 메이저이며, v4/v5와 업로드 의미(이름·경로·`if-no-files-found`·`retention-days`)가 동일합니다.
- 재발 방지를 위해 **나머지 8개 액션의 `action.yml` `runs.using`을 직접 재검증**했습니다: checkout v5 / setup-python v6 / cache v5 / download-artifact v6 / setup-dotnet v5 / setup-uv v7 / action-gh-release v3 / codecov v6 → 전부 `node24` 확인.
- 버전 **2.7.2**로 bump (2.7.1은 v5 실수가 담긴 채 이미 PyPI 발행됨). 2.7.1 항목은 역사적 기록으로 보존하고, 2.7.2 항목에 정정 사유를 명시.

## 검증
- 활성 워크플로에 `upload-artifact@v5` 0건, 6개 YAML 파싱 정상.
- `test_build_config.py`(CHANGELOG 유일성·날짜 정렬 포함) + `test_suite.py` 27개 로컬 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)