### PR TITLE
[codex] Fail audit workflow on Claude auth errors

### DIFF
--- a/.github/workflows/biweekly-audit.yml
+++ b/.github/workflows/biweekly-audit.yml
@@ -128,6 +128,14 @@ jobs:
       - name: Install Claude Code
         run: npm install -g @anthropic-ai/claude-code
 
+      - name: Verify Claude credentials
+        run: |
+          if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+            echo "::error::ANTHROPIC_API_KEY secret is not configured."
+            echo "Add it under Settings > Secrets and variables > Actions."
+            exit 1
+          fi
+
       - name: Generate change summary
         id: changes
         run: |
@@ -144,6 +152,7 @@ jobs:
 
       - name: Run combined audit
         run: |
+          set +e
           claude \
             --model claude-opus-4-8 \
             --effort xhigh \
@@ -171,10 +180,20 @@ jobs:
           Produce the full TECH_DEBT_AUDIT.md content with severity,
           effort estimates, and the required 'looks bad but is
           actually fine' section.
-          " > combined-audit-report.md 2>&1 || true
+          " > combined-audit-report.md 2>&1
+          CLAUDE_EXIT=$?
+          set -e
 
           if [ ! -s combined-audit-report.md ]; then
             echo "Audit produced no output." > combined-audit-report.md
+            cat combined-audit-report.md
+            exit 1
+          fi
+
+          if [ "$CLAUDE_EXIT" -ne 0 ]; then
+            echo "Claude audit failed with exit code $CLAUDE_EXIT."
+            cat combined-audit-report.md
+            exit "$CLAUDE_EXIT"
           fi
 
       - name: Create GitHub Issue


### PR DESCRIPTION
## What changed

Updates `.github/workflows/biweekly-audit.yml` so the audit workflow fails clearly when Claude Code is not authenticated instead of creating a misleading audit issue.

Specifically:
- adds a preflight check for `ANTHROPIC_API_KEY`
- removes the unconditional `|| true` behavior around the Claude audit command
- fails the run if Claude exits non-zero or produces an empty report
- prints the captured Claude output into the job log before failing

## Why

The first manual run of the newly merged workflow completed successfully from GitHub Actions' point of view, but the generated audit report only contained:

```text
Not logged in · Please run /login
```

Because the workflow swallowed the Claude exit code, it also created issue #110 with no real audit findings. I commented on and closed that generated issue.

## Validation

- `git diff --cached --check`
- YAML parsed locally with Python/PyYAML
- Verified the first generated report artifact contained only the Claude login error

`actionlint` is not installed in this local environment, so I could not run that validator here.