### PR TITLE
[codex] Use Claude OAuth token for audit workflow

### DIFF
--- a/.github/workflows/biweekly-audit.yml
+++ b/.github/workflows/biweekly-audit.yml
@@ -10,14 +10,20 @@
 # Effort: xhigh
 #
 # 필요 사항:
-#   1. Settings > Secrets에 ANTHROPIC_API_KEY 등록
+#   1. `claude setup-token`으로 구독 OAuth 토큰을 생성한 뒤
+#      Settings > Secrets에 CLAUDE_CODE_OAUTH_TOKEN 등록
 #   2. Settings > Actions > Workflow permissions를
 #      "Read and write permissions"로 설정
 #   3. 프로젝트에 두 스킬이 설치되어 있어야 합니다
 #
+# 주의:
+#   ANTHROPIC_API_KEY / ANTHROPIC_AUTH_TOKEN이 있으면 Claude Code는
+#   구독 OAuth보다 API 인증을 우선합니다. 이 workflow는 구독 할당을
+#   쓰기 위해 Claude 실행 직전에 해당 변수를 제거합니다.
+#
 # Codex 전환 시:
 #   claude 명령을 codex -q로 교체하고,
-#   ANTHROPIC_API_KEY를 OPENAI_API_KEY로 변경하십시오.
+#   CLAUDE_CODE_OAUTH_TOKEN을 OPENAI_API_KEY로 변경하십시오.
 # ──────────────────────────────────────────────────────────────
 
 name: Biweekly Audit
@@ -114,7 +120,7 @@ jobs:
     if: needs.check-changes.outputs.should_audit == 'true'
     runs-on: ubuntu-latest
     env:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -128,12 +134,17 @@ jobs:
       - name: Install Claude Code
         run: npm install -g @anthropic-ai/claude-code
 
-      - name: Verify Claude credentials
+      - name: Verify Claude subscription credentials
         run: |
-          if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
-            echo "::error::ANTHROPIC_API_KEY secret is not configured."
+          if [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]; then
+            echo "::error::CLAUDE_CODE_OAUTH_TOKEN secret is not configured."
+            echo "Generate a subscription OAuth token with 'claude setup-token'."
             echo "Add it under Settings > Secrets and variables > Actions."
             exit 1
+          fi
+
+          if [ -n "${ANTHROPIC_API_KEY:-}" ] || [ -n "${ANTHROPIC_AUTH_TOKEN:-}" ]; then
+            echo "::warning::Ignoring ANTHROPIC_* credentials so Claude Code uses CLAUDE_CODE_OAUTH_TOKEN."
           fi
 
       - name: Generate change summary
@@ -152,6 +163,8 @@ jobs:
 
       - name: Run combined audit
         run: |
+          unset ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN
+
           set +e
           claude \
             --model claude-opus-4-8 \


### PR DESCRIPTION
## What changed

Switches the biweekly audit workflow from direct API-key authentication to Claude Code subscription OAuth token authentication.

The workflow now:
- expects `CLAUDE_CODE_OAUTH_TOKEN` from repository Actions secrets
- documents generating that token with `claude setup-token`
- removes `ANTHROPIC_API_KEY` from the job environment
- unsets `ANTHROPIC_API_KEY` and `ANTHROPIC_AUTH_TOKEN` immediately before `claude -p` so API credentials cannot take precedence over the subscription OAuth token
- updates the preflight failure message to point at `CLAUDE_CODE_OAUTH_TOKEN`

## Why

Claude Code docs state that `CLAUDE_CODE_OAUTH_TOKEN` is generated by `claude setup-token`, is intended for CI pipelines/scripts where browser login is unavailable, and authenticates with a Pro, Max, Team, or Enterprise subscription. The same docs list `ANTHROPIC_API_KEY` and `ANTHROPIC_AUTH_TOKEN` ahead of `CLAUDE_CODE_OAUTH_TOKEN` in credential precedence, so the workflow must avoid exporting them when the goal is subscription quota.

The Claude Agent SDK/help docs also note that `claude -p`, Agent SDK usage, and Claude Code GitHub Actions are covered by the Agent SDK credit path starting June 15, 2026.

## Validation

- `git diff --check`
- `git diff --cached --check`
- YAML parsed locally with Python/PyYAML

`actionlint` is not installed in this local environment, so I could not run that validator here.