### PR TITLE
[codex] Enable tech debt audit skill invocation

### DIFF
--- a/.claude/skills/tech-debt-audit/SKILL.md
+++ b/.claude/skills/tech-debt-audit/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: tech-debt-audit
-description: Thorough, user-invoked tech debt and architecture audit of the current codebase. Produces TECH_DEBT_AUDIT.md with file-cited findings, severity, effort estimates, and a required "looks bad but is actually fine" section. Use when the user asks for a debt audit, codebase health check, architecture review, or code quality assessment of an entire repo. Does not auto-invoke.
-disable-model-invocation: true
+description: Thorough tech debt and architecture audit of the current codebase. Produces TECH_DEBT_AUDIT.md with file-cited findings, severity, effort estimates, and a required "looks bad but is actually fine" section. Use when the user asks for a debt audit, codebase health check, architecture review, or code quality assessment of an entire repo.
 ---
 
 # Tech Debt Audit

--- a/.github/workflows/biweekly-audit.yml
+++ b/.github/workflows/biweekly-audit.yml
@@ -209,6 +209,15 @@ jobs:
           CLAUDE_EXIT=$?
           set -e
 
+          if [ -f TECH_DEBT_AUDIT.md ]; then
+            {
+              echo ""
+              echo "---"
+              echo ""
+              cat TECH_DEBT_AUDIT.md
+            } >> combined-audit-report.md
+          fi
+
           if [ ! -s combined-audit-report.md ]; then
             echo "Audit produced no output." > combined-audit-report.md
             cat combined-audit-report.md
@@ -269,6 +278,7 @@ jobs:
           path: |
             combined-audit-report.md
             change-summary.txt
+            TECH_DEBT_AUDIT.md
           retention-days: 90
 
       - name: Tag audit checkpoint


### PR DESCRIPTION
Removes the disable-model-invocation guard from the vendored tech-debt-audit skill so Claude Code can invoke it from the biweekly audit prompt. Also captures TECH_DEBT_AUDIT.md in the workflow report and artifact if the skill writes its deliverable to disk. This does not rerun the audit.