### PR TITLE
fix: address Codex review findings

### DIFF
--- a/.claude/skills/improve-codebase-architecture/SKILL.md
+++ b/.claude/skills/improve-codebase-architecture/SKILL.md
@@ -44,9 +44,11 @@ Then use the Agent tool with `subagent_type=Explore` to walk the codebase. Don't
 
 Apply the **deletion test** to anything you suspect is shallow: would deleting it concentrate complexity, or just move it? A "yes, concentrates" is the signal you want.
 
-### 2. Present candidates as an HTML report
+### 2. Present candidates as a report
 
-Write a self-contained HTML file to the OS temp directory so nothing lands in the repo. Resolve the temp dir from `$TMPDIR`, falling back to `/tmp` (or `%TEMP%` on Windows), and write to `<tmpdir>/architecture-review-<timestamp>.html` so each run gets a fresh file. Open it for the user — `xdg-open <path>` on Linux, `open <path>` on macOS, `start <path>` on Windows — and tell them the absolute path.
+When running in CI or other non-interactive automation (`CI=true`, `GITHUB_ACTIONS=true`, or the prompt explicitly asks for a CI artifact), write a persistent Markdown report to `ARCHITECTURE_AUDIT.md` in the repo root. This file is consumed by the biweekly audit workflow, so do not leave the architecture analysis only in `/tmp` or only in an opened browser. Print the report path and enough summary to stdout for the run log.
+
+For interactive local use, write a self-contained HTML file to the OS temp directory so nothing lands in the repo. Resolve the temp dir from `$TMPDIR`, falling back to `/tmp` (or `%TEMP%` on Windows), and write to `<tmpdir>/architecture-review-<timestamp>.html` so each run gets a fresh file. Open it for the user — `xdg-open <path>` on Linux, `open <path>` on macOS, `start <path>` on Windows — and tell them the absolute path.
 
 The report uses **Tailwind via CDN** for layout and styling, and **Mermaid via CDN** for diagrams where a graph/flow/sequence reliably communicates the structure. Mix Mermaid with hand-crafted CSS/SVG visuals — use Mermaid when relationships are graph-shaped (call graphs, dependencies, sequences), and hand-built divs/SVG when you want something more editorial (mass diagrams, cross-sections, collapse animations). Each candidate gets a **before/after visualisation**. Be visual.
 

--- a/.github/workflows/biweekly-audit.yml
+++ b/.github/workflows/biweekly-audit.yml
@@ -197,6 +197,9 @@ jobs:
           ── PART 1: Architecture Analysis ──
           Run /improve-codebase-architecture.
           Identify specific consolidation and deepening opportunities.
+          Because this is CI, write the complete architecture analysis to
+          ARCHITECTURE_AUDIT.md in the repository root. Do not leave the
+          detailed report only in a temp file or browser-opened HTML file.
           When done, print a Markdown horizontal rule (---) as a
           separator, then proceed immediately to Part 2.
 
@@ -209,10 +212,35 @@ jobs:
           CLAUDE_EXIT=$?
           set -e
 
+          if [ "$CLAUDE_EXIT" -eq 0 ] && [ ! -s ARCHITECTURE_AUDIT.md ]; then
+            echo "::error::Claude audit completed without ARCHITECTURE_AUDIT.md."
+            cat combined-audit-report.md
+            exit 1
+          fi
+
+          if [ "$CLAUDE_EXIT" -eq 0 ] && [ ! -s TECH_DEBT_AUDIT.md ]; then
+            echo "::error::Claude audit completed without TECH_DEBT_AUDIT.md."
+            cat combined-audit-report.md
+            exit 1
+          fi
+
+          if [ -f ARCHITECTURE_AUDIT.md ]; then
+            {
+              echo ""
+              echo "---"
+              echo ""
+              echo "# ARCHITECTURE_AUDIT.md"
+              echo ""
+              cat ARCHITECTURE_AUDIT.md
+            } >> combined-audit-report.md
+          fi
+
           if [ -f TECH_DEBT_AUDIT.md ]; then
             {
               echo ""
               echo "---"
+              echo ""
+              echo "# TECH_DEBT_AUDIT.md"
               echo ""
               cat TECH_DEBT_AUDIT.md
             } >> combined-audit-report.md
@@ -249,6 +277,7 @@ jobs:
             echo "이 이슈에서 읽을 수 있는 파일:"
             echo "- \`issue-body.md\` - 이 본문"
             echo "- \`change-summary.txt\` - 댓글"
+            echo "- \`ARCHITECTURE_AUDIT.md\` - 댓글"
             echo "- \`combined-audit-report.md\` - 댓글"
             echo "- \`TECH_DEBT_AUDIT.md\` - 댓글"
           } > issue-body.md
@@ -332,6 +361,7 @@ jobs:
           ISSUE_NUMBER="${ISSUE_URL##*/}"
 
           post_file_comments "$ISSUE_NUMBER" change-summary.txt "Change summary"
+          post_file_comments "$ISSUE_NUMBER" ARCHITECTURE_AUDIT.md "Architecture audit"
           post_file_comments "$ISSUE_NUMBER" combined-audit-report.md "Combined audit report"
           post_file_comments "$ISSUE_NUMBER" TECH_DEBT_AUDIT.md "Tech debt audit"
 
@@ -342,6 +372,7 @@ jobs:
           path: |
             combined-audit-report.md
             change-summary.txt
+            ARCHITECTURE_AUDIT.md
             TECH_DEBT_AUDIT.md
             issue-body.md
           retention-days: 90

--- a/gui/dialogs.py
+++ b/gui/dialogs.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import threading
+import logging
 from collections.abc import Callable
 from tkinter import TclError, messagebox
 from typing import Optional
@@ -23,14 +24,13 @@ from gui.constants import (
 from gui.recording_status import format_duration
 from gui.utils import build_fonts, setup_pretendard_font
 from i18n.localization import SUPPORTED_LANGUAGES
-from infra.logger import get_logger
 from updater.updater_core import (
     UpdateExecutionError,
     UpdateExecutionResult,
     create_update_executor,
 )
 
-logger = get_logger()
+ui_lifecycle_logger = logging.getLogger(__name__)
 
 
 def _run_ui_safe(action: str, fn: Callable[[], None]) -> None:
@@ -45,9 +45,17 @@ def _run_ui_safe(action: str, fn: Callable[[], None]) -> None:
     try:
         fn()
     except TclError as exc:
-        logger.debug(f"UI update '{action}' skipped (widget unavailable): {exc}")
+        ui_lifecycle_logger.debug(
+            "UI update %r skipped (widget unavailable): %s",
+            action,
+            exc,
+        )
     except Exception as exc:  # pragma: no cover - defensive, exercised via tests
-        logger.warning(f"UI update '{action}' failed unexpectedly: {exc}")
+        ui_lifecycle_logger.warning(
+            "UI update %r failed unexpectedly: %s",
+            action,
+            exc,
+        )
 
 
 class BaseDialog(ctk.CTkToplevel):
@@ -300,7 +308,11 @@ class ProcessingDialog(BaseDialog):
         try:
             self.after(0, lambda: _run_ui_safe(action, fn))
         except (TclError, RuntimeError) as exc:
-            logger.debug(f"UI update '{action}' could not be scheduled: {exc}")
+            ui_lifecycle_logger.debug(
+                "UI update %r could not be scheduled: %s",
+                action,
+                exc,
+            )
 
     def update_progress(self, value: int, message: str = "") -> None:
         """Update progress controls from any thread."""

--- a/tests/test_dialogs_logging.py
+++ b/tests/test_dialogs_logging.py
@@ -22,7 +22,7 @@ def test_run_ui_safe_runs_the_action() -> None:
 def test_run_ui_safe_logs_tclerror_as_debug(monkeypatch) -> None:
     """A destroyed-widget TclError during teardown is expected → debug, swallowed."""
     fake_logger = MagicMock()
-    monkeypatch.setattr(dialogs, "logger", fake_logger)
+    monkeypatch.setattr(dialogs, "ui_lifecycle_logger", fake_logger)
 
     def raise_tcl_error() -> None:
         raise TclError("widget has been destroyed")
@@ -36,7 +36,7 @@ def test_run_ui_safe_logs_tclerror_as_debug(monkeypatch) -> None:
 def test_run_ui_safe_logs_unexpected_as_warning(monkeypatch) -> None:
     """Any other exception is a real bug and must surface as a warning."""
     fake_logger = MagicMock()
-    monkeypatch.setattr(dialogs, "logger", fake_logger)
+    monkeypatch.setattr(dialogs, "ui_lifecycle_logger", fake_logger)
 
     def raise_value_error() -> None:
         raise ValueError("boom")
@@ -44,3 +44,24 @@ def test_run_ui_safe_logs_unexpected_as_warning(monkeypatch) -> None:
     dialogs._run_ui_safe("add_log", raise_value_error)  # must not raise
 
     assert fake_logger.warning.called
+
+
+def test_schedule_ui_uses_non_gui_lifecycle_logger(monkeypatch) -> None:
+    """A closed dialog must not report scheduling failure through add_log again."""
+    fake_logger = MagicMock()
+    monkeypatch.setattr(dialogs, "ui_lifecycle_logger", fake_logger)
+
+    class ClosedDialog:
+        def after(self, *_args, **_kwargs):
+            raise TclError("window has been destroyed")
+
+        def add_log(self, *_args, **_kwargs):
+            raise AssertionError("GUI log callback must not be re-entered")
+
+    dialogs.ProcessingDialog._schedule_ui(
+        ClosedDialog(),
+        "add_log",
+        lambda: None,
+    )
+
+    assert fake_logger.debug.called


### PR DESCRIPTION
## Summary
- make the architecture audit skill emit `ARCHITECTURE_AUDIT.md` in CI instead of leaving the detailed report only in temp/browser output
- require both `ARCHITECTURE_AUDIT.md` and `TECH_DEBT_AUDIT.md` before tagging an audit checkpoint
- publish `ARCHITECTURE_AUDIT.md` as an issue comment and artifact alongside the existing audit files
- route processing-dialog lifecycle failures through a non-GUI stdlib logger to avoid re-entering `dialog.add_log()` after teardown

## Codex review triage
- PR #109: valid, but already fixed by later workflow error handling (`CLAUDE_EXIT` now fails the step before checkpoint tagging)
- PR #114: valid, fixed here
- PR #119: valid, fixed here

## Tests
- `python -m pytest tests/test_dialogs_logging.py -q`
- `python -m ruff check gui/dialogs.py tests/test_dialogs_logging.py`
- `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/biweekly-audit.yml').read_text(encoding='utf-8')); print('yaml ok')"`
- `git diff --check`