### PR TITLE
ci: skip existing PyPI artifacts on master publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -112,4 +112,7 @@ jobs:
         # Rekor is an external transparency log; transient 5xx responses
         # should not block package publication.
         attestations: false
+        # Master can receive CI/docs-only merges without a version bump.
+        # Keep those pushes green when PyPI already has this exact release.
+        skip-existing: true
         verbose: true


### PR DESCRIPTION
## Summary
- let the master-push PyPI workflow skip artifacts that already exist on PyPI
- keeps CI/docs-only master merges green when the package version has not changed

## Context
The merge-triggered `Publish to PyPI` run after PR #121 failed because PyPI rejected re-uploading `impulcifer_py313-2.7.5` with `400 File already exists`. Release publishing remains strict in `.github/workflows/python-publish.yml`; this only affects the push-to-master workflow.

## Tests
- `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/publish.yml').read_text(encoding='utf-8')); print('yaml ok')"`
- `git diff --check`