### PR TITLE
fix: restore ffmpeg_utils shim lazy-state backward compat (Codex review on #123)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ first number changes, something has broken and you need to check your commands a
 changes there are only new features available and nothing old has broken and when the last number changes, old bugs have
 been fixed and old features improved.
 
+## 2.7.7 - 2026-06-09
+### f-9 후속 — ffmpeg_utils 셸 하위호환 복원
+
+PR #123(2.7.6)에 달린 Codex 자동 리뷰(P2)를 검증한 결과, `core/ffmpeg_utils.py`를 `ffmpeg_discovery`/`audio_truehd`로 분할(#115-9)하면서 함수만 재노출하고 lazy 모듈 글로벌(`FFMPEG_PATH`/`FFPROBE_PATH`/`_FFMPEG_SETUP_DONE` 등)을 빠뜨려, 분리 전 `core.ffmpeg_utils.FFMPEG_PATH`를 직접 읽던 코드가 `AttributeError`를 보게 되는 회귀가 사실로 확인됐다. 셸은 스스로 "Backward-compatible re-export shim"을 표방하므로 이는 계약 위반이다.
+
+#### 🐛 버그 수정
+- **`ffmpeg_utils` 셸의 lazy 상태 재노출 복원**: PEP 562 모듈 `__getattr__`로 누락된 속성 읽기를 `core.ffmpeg_discovery`에 위임했다. 단순 `from ... import FFMPEG_PATH` 재노출은 import 시점의 `None`에 고정돼 `ensure_ffmpeg_available()`의 재할당을 추적하지 못하므로(stale `None`), 매 접근 시 discovery 모듈에서 live 값을 해석하는 `__getattr__`가 정답이다. 회귀 테스트(`tests/test_ffmpeg_lazy_setup.py`)로 셸이 discovery의 mutation을 추적함과 미존재 속성의 `AttributeError`를 고정. BRIR 출력 무관(md5 byte-identical 확인).
+
 ## 2.7.6 - 2026-06-09
 ### 격주 감사(#113·#115) 잔여 deferred finding 해결
 

--- a/core/ffmpeg_utils.py
+++ b/core/ffmpeg_utils.py
@@ -25,3 +25,27 @@ from core.audio_truehd import (  # noqa: F401  (intentional re-export)
     read_audio,
     get_supported_audio_formats,
 )
+
+
+def __getattr__(name):
+    """Delegate attribute reads (lazy FFmpeg state) to ``core.ffmpeg_discovery``.
+
+    Before audit #115 finding 9, ``core.ffmpeg_utils`` owned the lazy-init
+    module globals ``FFMPEG_PATH`` / ``FFPROBE_PATH`` / ``_FFMPEG_SETUP_DONE``
+    (and the ``_FFMPEG_DETECTION_DONE`` / ``_FFMPEG_AUTO_INSTALL_ATTEMPTED``
+    flags). ``ensure_ffmpeg_available()`` reassigns them, so a plain
+    ``from core.ffmpeg_discovery import FFMPEG_PATH`` re-export here would bind
+    the import-time value (``None``) forever and never reflect that mutation —
+    leaving direct importers that read ``core.ffmpeg_utils.FFMPEG_PATH`` after
+    setup with a stale ``None``. PEP 562 module ``__getattr__`` resolves the
+    name against the discovery module on every access, so reads stay live and
+    this shim keeps the backward-compatible surface it advertises.
+    """
+    import core.ffmpeg_discovery as _discovery
+
+    try:
+        return getattr(_discovery, name)
+    except AttributeError:
+        raise AttributeError(
+            f"module {__name__!r} has no attribute {name!r}"
+        ) from None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "impulcifer-py313"
-version = "2.7.6"
+version = "2.7.7"
 authors = [
   { name="원본 저자: Jaakko Pasanen", email="" },
   { name="Python 3.13/3.14 호환 버전: 115dkk", email="" },

--- a/tests/test_ffmpeg_lazy_setup.py
+++ b/tests/test_ffmpeg_lazy_setup.py
@@ -236,6 +236,42 @@ class FfmpegLazySetupTest(unittest.TestCase):
             if os.path.exists(wav_path):
                 os.remove(wav_path)
 
+    def test_ffmpeg_utils_shim_exposes_live_discovery_state(self):
+        """The ``core.ffmpeg_utils`` shim must keep exposing the lazy FFmpeg
+        state that lived on it before the f-9 split, tracking
+        ``core.ffmpeg_discovery`` mutations.
+
+        Regression (Codex PR #123): the shim re-exported only functions, so a
+        direct importer reading ``core.ffmpeg_utils.FFMPEG_PATH`` (documented
+        backward-compatible surface) got an ``AttributeError``. The PEP 562
+        ``__getattr__`` proxy must resolve these against the discovery module
+        *live* — a plain ``from ... import FFMPEG_PATH`` would freeze the
+        import-time ``None`` and miss ``ensure_ffmpeg_available()`` updates.
+        """
+        _purge_ffmpeg_modules()
+        import core.ffmpeg_utils as shim
+        import core.ffmpeg_discovery as discovery
+
+        # Pre-setup: shim mirrors discovery's None state instead of raising.
+        discovery.FFMPEG_PATH = None
+        discovery.FFPROBE_PATH = None
+        discovery._FFMPEG_SETUP_DONE = False
+        self.assertIsNone(shim.FFMPEG_PATH)
+        self.assertIsNone(shim.FFPROBE_PATH)
+        self.assertFalse(shim._FFMPEG_SETUP_DONE)
+
+        # After a (simulated) successful setup, reads reflect the live values.
+        discovery.FFMPEG_PATH = "/usr/bin/ffmpeg"
+        discovery.FFPROBE_PATH = "/usr/bin/ffprobe"
+        discovery._FFMPEG_SETUP_DONE = True
+        self.assertEqual(shim.FFMPEG_PATH, "/usr/bin/ffmpeg")
+        self.assertEqual(shim.FFPROBE_PATH, "/usr/bin/ffprobe")
+        self.assertTrue(shim._FFMPEG_SETUP_DONE)
+
+        # A genuinely unknown attribute still raises AttributeError.
+        with self.assertRaises(AttributeError):
+            _ = shim.this_attribute_does_not_exist
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
PR #123에 달린 Codex 자동 리뷰(P2)를 검증한 뒤, **사실로 확인된 회귀만** 반영합니다.

## 검증 결과 — 사실

f-9 분할(#115-9)이 `core/ffmpeg_utils.py`를 `ffmpeg_discovery`/`audio_truehd`로 쪼개면서 **함수만** 재노출하고, 분리 전 이 모듈에 있던 lazy 모듈 글로벌을 빠뜨렸습니다.

- 분리 전(`3dc9e77^`) `core/ffmpeg_utils.py`: `FFMPEG_PATH` / `FFPROBE_PATH` / `_FFMPEG_SETUP_DONE`(+`_FFMPEG_DETECTION_DONE`/`_FFMPEG_AUTO_INSTALL_ATTEMPTED`) 모듈 레벨 노출 ✓
- 분리 후 셸: 함수만 재노출 → `core.ffmpeg_utils.FFMPEG_PATH` 접근 시 `AttributeError` ✓
- 셸 docstring이 "Backward-compatible re-export shim"을 표방 → **계약 위반** ✓
- `core.utils`는 분리 전에도 이 상태를 노출한 적 없음 → 범위 밖(회귀 아님)

## 수정

PEP 562 모듈 `__getattr__`로 누락된 속성 읽기를 `core.ffmpeg_discovery`에 위임. 매 접근 시 discovery에서 **live 값**을 해석하므로 `ensure_ffmpeg_available()`의 재할당을 추적합니다.

> 핵심: 단순 `from core.ffmpeg_discovery import FFMPEG_PATH` 재노출은 import 시점의 `None`에 바인딩돼 mutation을 추적 못 함(stale `None`, 오히려 더 나쁨). 그래서 Codex가 짚은 "module-level proxying"(`__getattr__`)이 정답.

## 검증

- 신규 회귀 테스트 `tests/test_ffmpeg_lazy_setup.py::test_ffmpeg_utils_shim_exposes_live_discovery_state`: 셸이 discovery mutation 추적 + 미존재 속성 `AttributeError` 고정.
- 전체 스위트 **200 passed, 3 skipped**(직전 199 + 신규 1).
- BRIR md5 byte-identical (동일 머신 로컬 오라클): vbass `07eef9ef…`, 기본값 `cf37a9aa…`.
- 버전 2.7.6 → 2.7.7 (PATCH, 하위호환 복원), CHANGELOG 갱신.

🤖 Generated with [Claude Code](https://claude.com/claude-code)