### PR TITLE
ci: switch biweekly audit model to claude-fable-5

### DIFF
--- a/.github/workflows/biweekly-audit.yml
+++ b/.github/workflows/biweekly-audit.yml
@@ -6,7 +6,7 @@
 # 단일 claude -p 세션에서 실행합니다.
 # 직전 감사 이후 코드 변경이 없으면(문서 등 제외) 실행하지 않습니다.
 #
-# 모델: Opus 4.8 (1M 컨텍스트, 기본 제공)
+# 모델: claude-fable-5
 # Effort: xhigh
 #
 # 필요 사항:
@@ -179,7 +179,7 @@ jobs:
 
           set +e
           claude \
-            --model claude-opus-4-8 \
+            --model claude-fable-5 \
             --effort xhigh \
             --permission-mode auto \
             --max-turns 50 \
@@ -269,7 +269,7 @@ jobs:
             echo "# Biweekly Audit: ${DATE}"
             echo ""
             echo "변경된 코드 파일: **${COUNT}개**"
-            echo "모델: Opus 4.8 · Effort: xhigh · 1M context"
+            echo "모델: claude-fable-5 · Effort: xhigh"
             echo ""
             echo "이 이슈 본문은 artifact의 \`issue-body.md\`에 해당합니다."
             echo "나머지 감사 산출물은 아래 댓글에 파일별로 전체 게시됩니다."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ PR #123(2.7.6)에 달린 Codex 자동 리뷰(P2)를 검증한 결과, `core/ffmp
 
 #### 🔧 빌드 / 설정 변경
 - **자동 버전 bump + PyPI-성공 게이팅 릴리스 파이프라인**: 흩어져 있던 릴리스 워크플로(`publish.yml` + `python-publish.yml` + `release-cross-platform.yml`, master push마다 무조건 3-플랫폼 Nuitka 빌드)를 단일 게이트 파이프라인 `publish.yml` 하나로 통합했다. master push 시 `gate`(→ `.github/scripts/release_gate.py`)가 변경 경로를 검사해, 출하물 변경인데 수동 bump가 누락됐으면 PATCH를 자동 증가(`[skip ci]` 커밋)하고, 수동 bump(특히 MINOR/MAJOR)는 존중한다. 빌드(`build-windows`/`macos`/`linux`)는 `needs: publish-pypi`로 **PyPI 발행 성공 후에만** 시작하므로, docs/CI/tests만 바꾼 push는 PyPI·빌드를 모두 건너뛴다(러너 절약). PyPI Trusted Publisher OIDC 보존을 위해 파일명 `publish.yml` + `environment: PyPI`를 유지. 게이트 결정 로직은 `tests/test_release_gate.py`로 고정. 이중 PyPI publish 위험 제거. (런타임/출하물 무변경 → 버전 bump 없음.)
+- **격주 감사 모델 변경**: CI 자동감사(`biweekly-audit.yml`)가 사용하는 모델을 `claude-fable-5`로 변경. (CI 설정 변경 → 버전 bump 없음.)
 
 ## 2.7.6 - 2026-06-09
 ### 격주 감사(#113·#115) 잔여 deferred finding 해결


### PR DESCRIPTION
CI 자동감사(`biweekly-audit.yml`)가 사용하는 모델을 `claude-opus-4-8` → **`claude-fable-5`**로 변경.

- `--model` 플래그(line 182) + 일관성을 위한 주석/로그 2곳(line 9, 272) 갱신.
- 검증 불가한 "1M 컨텍스트" 문구는 제거(모델명만 정확히 반영).
- CI 설정 변경만 → **버전 bump 없음**. 새 릴리스 게이트가 `.github/**`를 제외하므로 머지 시 빌드/PyPI 트리거 없음.
- YAML 문법 검증 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)