### PR TITLE
fix(gui): 빠른 휠 스크롤이 남기는 blit 잔상(고스팅) 수리

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ first number changes, something has broken and you need to check your commands a
 changes there are only new features available and nothing old has broken and when the last number changes, old bugs have
 been fixed and old features improved.
 
+## 2.7.8 - 2026-06-10
+### GUI 스크롤 잔상(고스팅) 수리
+
+스크롤 성능 최적화(`install_smooth_scrolling`) 이후에도 빠른 휠 스크롤 시 행이 복제되고 글자가 반토막 나는 blit 잔상이 화면에 남는 버그를 수리했다. 원인: Tk 캔버스의 다시 그리기는 idle 콜백이라, 연속 휠 이벤트가 이벤트 큐를 점유하면 "픽셀 밀기(blit)"만 누적되고 "다시 그리기"가 따라붙지 못한다 — 기존 프레임 병합은 밀기 횟수만 줄였을 뿐 밀기-그리기 짝을 보장하지 않았다.
+
+#### 🐛 버그 수정
+- **휠 flush 직후 강제 리페인트**: 프레임당 1회 병합된 스크롤 적용 직후 `update_idletasks()`로 캔버스 리드로우를 즉시 실행해, 모든 픽셀 이동이 자신의 다시 그리기와 짝을 이루도록 했다(`update_idletasks`는 idle 콜백만 처리하므로 이벤트 재진입 없음).
+- **settle 리페인트 보험**: 스크롤 움직임이 멈추고 150ms 후 scrollregion을 재적용해 전체 캔버스 리드로우를 1회 유도(Tk `ConfigureCanvas`는 값이 같아도 항상 전체 redisplay를 스케줄), 그래도 스쳐 지나간 잔상을 마지막에 청소한다. O(N) `bbox` walk는 제스처당 1회뿐이라 hot path 비용 불변.
+- **스크롤바 경로 병합 누락 수리**: `CTkScrollableFrame.__init__`이 스크롤바 `command=`에 **원본** `yview`를 캡처해 두므로, 스크롤바 드래그와 스크롤바 위 휠은 프레임 병합·settle을 모두 우회하고 있었다. `install_smooth_scrolling`이 스크롤바 command를 래퍼로 재배선해 두 입력 경로도 같은 처리를 받는다.
+- 회귀 테스트: flush-리페인트 짝/settle 스케줄(`FakeCanvas` 단위), 스크롤바 command 재배선(실디스플레이 기능 테스트)을 `tests/test_scroll_perf.py`에 고정. 기존 8개 계약(병합 cadence, 스크롤 중 bbox/configure 0회 등) 전부 유지.
+
 ## 2.7.7 - 2026-06-09
 ### f-9 후속 — ffmpeg_utils 셸 하위호환 복원
 

--- a/gui/utils.py
+++ b/gui/utils.py
@@ -736,6 +736,10 @@ _DEFAULT_SCROLL_REFRESH_RATE_HZ = 60.0
 _MIN_SCROLL_REFRESH_RATE_HZ = 30.0
 _MAX_SCROLL_REFRESH_RATE_HZ = 1000.0
 _SCROLL_REFRESH_ENV_VAR = "IMPULCIFER_SCROLL_REFRESH_HZ"
+# One full clean repaint fires this long after the last scroll movement.
+# Long enough to stay off the hot path during a wheel gesture, short enough
+# that any leftover blit residue is wiped before the user notices it linger.
+_SCROLL_SETTLE_REPAINT_DELAY_MS = 150
 
 
 def _refresh_rate_to_frame_interval_ms(refresh_rate_hz: float) -> int:
@@ -940,6 +944,35 @@ def _install_frame_limited_canvas_scroll(
     original_yview = canvas.yview
     pending_units = {"x": 0, "y": 0}
     after_ids: dict[str, Any] = {"x": None, "y": None}
+    settle_id: list[Any] = [None]
+
+    def _settle_repaint() -> None:
+        # Re-applying the scrollregion makes Tk schedule a full-window
+        # redisplay (ConfigureCanvas always calls Tk_CanvasEventuallyRedraw,
+        # even for an unchanged value), wiping any blit residue a fast wheel
+        # gesture left behind. Runs once per gesture, after movement stops,
+        # so the O(N) bbox walk stays off the per-frame hot path.
+        settle_id[0] = None
+        try:
+            bbox = canvas.bbox("all")
+            if bbox is not None:
+                canvas.configure(scrollregion=bbox)
+            canvas.update_idletasks()
+        except TclError:
+            pass
+
+    def _schedule_settle() -> None:
+        if settle_id[0] is not None:
+            try:
+                canvas.after_cancel(settle_id[0])
+            except (TclError, ValueError):
+                pass
+        try:
+            settle_id[0] = canvas.after(
+                _SCROLL_SETTLE_REPAINT_DELAY_MS, _settle_repaint
+            )
+        except TclError:
+            settle_id[0] = None
 
     def _flush(axis: str, original_view: Any) -> None:
         after_ids[axis] = None
@@ -949,8 +982,17 @@ def _install_frame_limited_canvas_scroll(
             return
         try:
             original_view("scroll", amount, "units")
+            # Paint the shifted view NOW. The canvas redraw is an idle
+            # callback; a continuous wheel stream keeps the event queue busy
+            # enough to starve it, so successive flushes blit-shift pixels
+            # without ever repainting the exposed strip — the duplicated
+            # half-cut rows seen on Win32. update_idletasks() runs only idle
+            # callbacks (no event reentrancy), pairing each shift with its
+            # repaint.
+            canvas.update_idletasks()
         except TclError:
-            pass
+            return
+        _schedule_settle()
 
     def _schedule(axis: str, original_view: Any) -> None:
         if after_ids[axis] is not None:
@@ -986,7 +1028,13 @@ def _install_frame_limited_canvas_scroll(
                 return None
 
             if args:
+                # Direct movement (scrollbar drag "moveto", page scroll):
+                # passes straight through, but still deserves the settle
+                # repaint — drags can leave the same blit residue.
                 _cancel_pending(axis)
+                result = original_view(*args)
+                _schedule_settle()
+                return result
             return original_view(*args)
 
         return _frame_limited_view
@@ -1020,12 +1068,36 @@ def install_smooth_scrolling(scroll_frame: ctk.CTkScrollableFrame) -> None:
     active monitor's refresh interval, which keeps scroll paint cadence above
     the 50 Hz target without hard-coding a 60 Hz display.
 
+    **Ghosting repair.** Frame-limiting alone is not enough on Win32: the
+    canvas redraw is an idle callback, so a fast wheel stream can starve it
+    and leave blit residue (duplicated, half-cut rows). Each coalesced flush
+    therefore forces the repaint with ``update_idletasks()``, and a one-shot
+    "settle" repaint re-applies the scrollregion ~150 ms after the last
+    movement to wipe anything that still slipped through.
+
     The fix is reversible: the size-change branch still calls the same
     ``bbox + configure(scrollregion)`` so layout-driven sizing still works
     exactly like the upstream CustomTkinter behavior.
     """
     canvas = scroll_frame._parent_canvas  # type: ignore[attr-defined]
     _install_frame_limited_canvas_scroll(canvas)
+
+    # CTkScrollableFrame.__init__ captured the ORIGINAL bound xview/yview in
+    # the scrollbar's command= (and CTkScrollbar's own wheel handler scrolls
+    # through that same command) — both bypass the frame-limited wrapper
+    # installed above. Rebind so drags and wheel-over-scrollbar take the
+    # coalesced path too.
+    scrollbar = getattr(scroll_frame, "_scrollbar", None)
+    if scrollbar is not None:
+        view = (
+            canvas.xview
+            if getattr(scroll_frame, "_orientation", "vertical") == "horizontal"
+            else canvas.yview
+        )
+        try:
+            scrollbar.configure(command=view)
+        except TclError:
+            pass
 
     # Drop the lambda installed by CTkScrollableFrame.__init__. ``unbind``
     # without a binding ID removes ALL bindings for the sequence on this

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "impulcifer-py313"
-version = "2.7.7"
+version = "2.7.8"
 authors = [
   { name="원본 저자: Jaakko Pasanen", email="" },
   { name="Python 3.13/3.14 호환 버전: 115dkk", email="" },

--- a/tests/test_scroll_perf.py
+++ b/tests/test_scroll_perf.py
@@ -171,6 +171,8 @@ class ScrollFrameLimiterTest(unittest.TestCase):
         def __init__(self) -> None:
             self.calls = []
             self.after_ms = []
+            self.update_idletasks_calls = 0
+            self.configure_calls = []
             self._callbacks = {}
             self._cancelled = set()
             self._next_after_id = 0
@@ -186,6 +188,15 @@ class ScrollFrameLimiterTest(unittest.TestCase):
                 return (0.0, 0.5)
             self.calls.append(("y", args))
             return None
+
+        def update_idletasks(self):
+            self.update_idletasks_calls += 1
+
+        def bbox(self, *args):
+            return (0, 0, 400, 2000)
+
+        def configure(self, **kwargs):
+            self.configure_calls.append(kwargs)
 
         def after(self, delay_ms, callback):
             self._next_after_id += 1
@@ -259,6 +270,48 @@ class ScrollFrameLimiterTest(unittest.TestCase):
         canvas.run_pending()
 
         self.assertEqual(canvas.calls, [("y", ("moveto", 0.25))])
+
+    def test_flush_forces_repaint_and_schedules_settle(self) -> None:
+        """Ghosting repair: each flush pairs the scroll with a forced repaint,
+        and a one-shot settle repaint re-applies the scrollregion after the
+        gesture stops (wiping any blit residue left on screen)."""
+        from gui.utils import (
+            _SCROLL_SETTLE_REPAINT_DELAY_MS,
+            _install_frame_limited_canvas_scroll,
+        )
+
+        canvas = self.FakeCanvas()
+        _install_frame_limited_canvas_scroll(canvas, frame_interval_ms=7)
+
+        canvas.yview("scroll", 3, "units")
+        self.assertEqual(canvas.update_idletasks_calls, 0)
+
+        canvas.run_pending()  # flush fires
+
+        self.assertEqual(
+            canvas.calls, [("y", ("scroll", 3, "units"))],
+            "Flush should apply the coalesced scroll exactly once.",
+        )
+        self.assertGreaterEqual(
+            canvas.update_idletasks_calls, 1,
+            "Flush must force the repaint via update_idletasks() — without "
+            "it the idle-time canvas redraw is starved by further wheel "
+            "events, leaving blit residue (duplicated half-cut rows).",
+        )
+        self.assertIn(
+            _SCROLL_SETTLE_REPAINT_DELAY_MS, canvas.after_ms,
+            "Flush must schedule the one-shot settle repaint.",
+        )
+
+        canvas.run_pending()  # settle fires
+
+        self.assertEqual(
+            canvas.configure_calls, [{"scrollregion": (0, 0, 400, 2000)}],
+            "Settle must re-apply the scrollregion to force a full clean "
+            "redisplay once scrolling stops.",
+        )
+        # No further scroll movement was applied by the settle pass.
+        self.assertEqual(canvas.calls, [("y", ("scroll", 3, "units"))])
 
 
 class FunctionalScrollFixTest(unittest.TestCase):
@@ -377,6 +430,26 @@ class FunctionalScrollFixTest(unittest.TestCase):
             f"not fire during scroll. Got {counter['configure_calls']} "
             f"calls — scrollregion churn has returned.",
         )
+
+    def test_fix_rebinds_scrollbar_command_to_wrapper(self) -> None:
+        """Scrollbar drags / wheel-over-scrollbar must take the coalesced path.
+
+        CTkScrollableFrame.__init__ captures the original bound yview in the
+        scrollbar's command= before install_smooth_scrolling replaces it, so
+        without the rebind those two input paths bypass the frame limiter
+        and the ghosting settle repaint entirely.
+        """
+        root, scroll, _counter = self._build_scrollable(fix=True)
+        try:
+            canvas = scroll._parent_canvas  # type: ignore[attr-defined]
+            self.assertIs(
+                scroll._scrollbar.cget("command"),  # type: ignore[attr-defined]
+                canvas.yview,
+                "Scrollbar command must be rebound to the frame-limited "
+                "yview wrapper installed by install_smooth_scrolling.",
+            )
+        finally:
+            root.destroy()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 문제

스크롤 성능 최적화(`install_smooth_scrolling`) 이후에도 빠른 휠 스크롤 시 **행이 복제되고 글자가 반토막 나는 잔상**이 화면에 남음 (스크린샷 보고됨). 표시 단계 착시가 아니라 픽셀 데이터에 실재하는 blit 잔여물.

## 원인

Tk 캔버스의 다시 그리기는 **idle 콜백**이다. 연속 휠 이벤트가 이벤트 큐를 점유하면 픽셀 밀기(blit)만 누적되고 다시 그리기가 따라붙지 못한다. 기존 프레임 병합(yview 래퍼)은 밀기 *횟수*만 줄였을 뿐, 밀기-그리기 *짝*을 보장하지 않았다.

## 수정 (`gui/utils.py`)

1. **flush 직후 강제 리페인트**: 병합된 스크롤 적용 직후 `update_idletasks()` — 모든 픽셀 이동이 자신의 리드로우와 짝을 이룸. idle 콜백만 처리하므로 이벤트 재진입 없음 (`update()` 아님).
2. **settle 리페인트 보험**: 움직임 멈춤 150ms 후 scrollregion 재적용으로 전체 redisplay 1회 유도(Tk `ConfigureCanvas`는 값이 같아도 항상 전체 리드로우 스케줄). O(N) bbox walk는 제스처당 1회 → hot path 비용 불변.
3. **스크롤바 우회 경로 수리**: `CTkScrollableFrame.__init__`이 스크롤바 `command=`에 **원본** yview를 캡처 → 드래그·스크롤바 위 휠이 병합/settle을 전부 우회하고 있었음. command를 래퍼로 재배선.

의도적 미적용: `yscrollincrement` 행높이 정렬 — CTk가 Windows에서 이미 `yscrollincrement=1`(픽셀 단위)이라 행높이로 바꾸면 스크롤 속도가 수십 배 증가.

## 검증

- `tests/test_scroll_perf.py` 8/8 통과 (Windows 실디스플레이에서 기능 테스트 포함 실행)
  - 신규: flush-리페인트 짝 + settle 스케줄 고정(FakeCanvas), 스크롤바 command 재배선 고정(실 Tk)
  - 기존 계약 유지: 병합 cadence, 스크롤 중 bbox/configure 0회
- 전체 스위트 217 passed, 3 skipped
- ruff clean, GUI import OK
- 버전 2.7.7 → 2.7.8 (PATCH), CHANGELOG 기록

🤖 Generated with [Claude Code](https://claude.com/claude-code)