### PR TITLE
ci: free-threaded CPython 3.14t 테스트 매트릭스 추가

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        # 3.14t는 free-threaded(no-GIL) 빌드다. core/parallel_utils.py의
+        # ThreadPoolExecutor 경로가 실제 no-GIL 런타임에서 검증된다.
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
 
     steps:
     - name: Checkout code
@@ -33,6 +35,24 @@ jobs:
     - name: Install dependencies
       run: |
         uv pip install --system -r requirements-dev.txt
+
+    - name: Verify GIL is disabled (free-threaded runtime)
+      if: matrix.python-version == '3.14t'
+      run: |
+        python - <<'PY'
+        import sys
+        # C 확장이 free-threaded 지원을 선언하지 않으면 임포트 시점에 GIL이
+        # 조용히 재활성화된다. 핵심 의존성을 임포트한 뒤에도 GIL이 꺼져
+        # 있어야 ThreadPoolExecutor 병렬 경로가 실제로 검증된 것이다.
+        import numpy, scipy, matplotlib, soundfile, PIL  # noqa: F401
+        assert not sys._is_gil_enabled(), (
+            "GIL re-enabled after importing core dependencies - "
+            "free-threaded path is not actually being tested"
+        )
+        from core.parallel_utils import is_gil_disabled
+        assert is_gil_disabled(), "is_gil_disabled() must be True on 3.14t"
+        print("OK: GIL disabled, free-threaded path active")
+        PY
 
     - name: Run unit tests
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,6 +103,50 @@ jobs:
       run: |
         python -m pytest tests/test_brir_integrity.py -v --tb=short
 
+  # 멀티스레드 하이젠버그 트랩: free-threaded 런타임(ThreadPoolExecutor 경로)에서
+  # 데모 BRIR을 반복 생성해 모든 출력 .wav가 실행 간 byte-identical인지 검사한다.
+  # 데이터 레이스는 간헐적으로만 출력에 나타나므로, 매 CI 실행이 포획 시도가 된다.
+  brir-thread-determinism:
+    name: BRIR Thread Determinism (3.14t)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v5
+
+    - name: Set up free-threaded Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.14t"
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: true
+
+    - name: Install dependencies
+      run: |
+        uv pip install --system -r requirements-dev.txt
+
+    - name: Verify GIL is disabled (free-threaded runtime)
+      run: |
+        python - <<'PY'
+        import sys
+        import numpy, scipy, matplotlib, soundfile, PIL  # noqa: F401
+        assert not sys._is_gil_enabled(), (
+            "GIL re-enabled after importing core dependencies - "
+            "determinism run would not exercise the threaded path"
+        )
+        print("OK: GIL disabled, free-threaded path active")
+        PY
+
+    - name: Check BRIR thread determinism (repeated-run hashes)
+      env:
+        IMPULCIFER_RUN_BRIR_THREAD_DETERMINISM: "1"
+        MPLBACKEND: Agg
+      run: |
+        python -m pytest tests/test_brir_thread_determinism.py -v --tb=short
+
   test-imports:
     name: Test Module Imports
     runs-on: ubuntu-latest
@@ -203,18 +247,19 @@ jobs:
   test-summary:
     name: Test Summary
     runs-on: ubuntu-latest
-    needs: [test, brir-integrity, test-imports, lint]
+    needs: [test, brir-integrity, brir-thread-determinism, test-imports, lint]
     if: always()
     steps:
     - name: Check test results
       run: |
-        if [ "${{ needs.test.result }}" = "success" ] && [ "${{ needs['brir-integrity'].result }}" = "success" ] && [ "${{ needs.test-imports.result }}" = "success" ] && [ "${{ needs.lint.result }}" = "success" ]; then
+        if [ "${{ needs.test.result }}" = "success" ] && [ "${{ needs['brir-integrity'].result }}" = "success" ] && [ "${{ needs['brir-thread-determinism'].result }}" = "success" ] && [ "${{ needs.test-imports.result }}" = "success" ] && [ "${{ needs.lint.result }}" = "success" ]; then
           echo "✅ All tests passed!"
           exit 0
         else
           echo "❌ Some tests failed"
           echo "  test: ${{ needs.test.result }}"
           echo "  brir-integrity: ${{ needs['brir-integrity'].result }}"
+          echo "  brir-thread-determinism: ${{ needs['brir-thread-determinism'].result }}"
           echo "  test-imports: ${{ needs.test-imports.result }}"
           echo "  lint: ${{ needs.lint.result }}"
           exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ been fixed and old features improved.
 
 #### 🔧 빌드 / 설정 변경
 - **BRIR 무결성 판정 SHA-256 전환**: `tests/test_brir_integrity.py`의 해시 비교를 md5에서 SHA-256으로 교체하고, `CLAUDE.md`의 Tier 3 절차를 sha256sum + 기준 ref(`origin/master`) worktree 자기 비교 방식으로 갱신했다(문서의 stale md5 절대값 baseline 제거).
+- **CI에 free-threaded 3.14t 테스트 추가** (2026-07-10, CI/문서만 변경 — 버전 bump 없음): 테스트 매트릭스에 CPython 3.14t(free-threaded)를 추가해 `core/parallel_utils.py`의 ThreadPoolExecutor 병렬 경로가 실제 no-GIL 런타임에서 검증되도록 했다. 핵심 C 확장(numpy/scipy/matplotlib/soundfile/Pillow) 임포트 후에도 GIL이 꺼져 있는지 확인하는 가드 스텝을 포함해, 의존성이 GIL을 조용히 재활성화하면 잡이 실패한다. README와 `docs/README_PYTHON314.md`에 free-threaded 권장 최소 패치(CPython 3.14.4+, 3.14.0의 GC 일시정지 폭주·GC 성능 회귀·mimalloc 페이지 누수가 3.14.1~3.14.4에서 수정됨)를 문서화하고, 문서의 stale한 `release-cross-platform.yml` 참조를 `publish.yml`로 바로잡았다.
 
 ## 2.7.9 - 2026-06-13
 ### GUI 디자인 적대적 리뷰 + 접근성 명암비 수리

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ been fixed and old features improved.
 #### 🔧 빌드 / 설정 변경
 - **BRIR 무결성 판정 SHA-256 전환**: `tests/test_brir_integrity.py`의 해시 비교를 md5에서 SHA-256으로 교체하고, `CLAUDE.md`의 Tier 3 절차를 sha256sum + 기준 ref(`origin/master`) worktree 자기 비교 방식으로 갱신했다(문서의 stale md5 절대값 baseline 제거).
 - **CI에 free-threaded 3.14t 테스트 추가** (2026-07-10, CI/문서만 변경 — 버전 bump 없음): 테스트 매트릭스에 CPython 3.14t(free-threaded)를 추가해 `core/parallel_utils.py`의 ThreadPoolExecutor 병렬 경로가 실제 no-GIL 런타임에서 검증되도록 했다. 핵심 C 확장(numpy/scipy/matplotlib/soundfile/Pillow) 임포트 후에도 GIL이 꺼져 있는지 확인하는 가드 스텝을 포함해, 의존성이 GIL을 조용히 재활성화하면 잡이 실패한다. README와 `docs/README_PYTHON314.md`에 free-threaded 권장 최소 패치(CPython 3.14.4+, 3.14.0의 GC 일시정지 폭주·GC 성능 회귀·mimalloc 페이지 누수가 3.14.1~3.14.4에서 수정됨)를 문서화하고, 문서의 stale한 `release-cross-platform.yml` 참조를 `publish.yml`로 바로잡았다.
+- **CI에 BRIR 스레드 결정성(하이젠버그 트랩) 잡 추가** (2026-07-10, CI/테스트만 변경 — 버전 bump 없음): `tests/test_brir_thread_determinism.py`가 free-threaded 런타임에서 데모 BRIR을 같은 환경에서 3회 반복 생성해 모든 출력 `.wav`의 SHA-256이 실행 간 byte-identical인지 검증한다(기본+vbass 두 시나리오). 스레드 병렬 경로의 데이터 레이스는 간헐적으로만 출력을 오염시키므로, 전용 `brir-thread-determinism` 잡이 매 CI 실행마다 반복해 포획 확률을 누적시킨다. 실패 시 어떤 파일이 어떤 해시로 갈라졌는지 run별로 보고한다.
 
 ## 2.7.9 - 2026-06-13
 ### GUI 디자인 적대적 리뷰 + 접근성 명암비 수리

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Impulcifer-py313은 [Jaakko Pasanen의 Impulcifer](https://github.com/jaakkopasa
 - PyPI 패키지, standalone 릴리스, Modern GUI를 제공합니다.
 - CLI와 GUI에서 BRIR 생성, 룸 보정, 헤드폰 보정, Custom EQ, Virtual Bass, TrueHD 레이아웃 출력, 마이크 착용 편차 보정을 다룹니다.
 - 일반 Python에서는 process 기반 병렬 처리를, free-threaded Python에서는 thread 기반 병렬 처리를 우선 사용합니다. standalone 빌드는 free-threaded Python을 대상으로 하지 않습니다.
+- free-threaded 런타임은 CPython 3.14.4 이상(가능하면 최신 패치)을 권합니다. 3.14.1~3.14.4 패치에 free-threaded GC 일시정지 증가, GC 성능 회귀, mimalloc 메모리 누수 수정이 순차 반영되었습니다. CI는 free-threaded 3.14t에서도 전체 테스트를 확인합니다.
 
 ## 설치
 

--- a/docs/README_PYTHON314.md
+++ b/docs/README_PYTHON314.md
@@ -6,8 +6,8 @@
 
 | 항목 | 현재 상태 | 기준 코드 |
 | --- | --- | --- |
-| Python 테스트 범위 | CI에서 Python 3.9부터 3.14까지 확인합니다. | `.github/workflows/test.yml` |
-| Nuitka 릴리스 빌드 | 일반 CPython 3.14와 `nuitka>=4.1`을 씁니다. | `.github/workflows/build-linux.yml`, `.github/workflows/build-macos.yml`, `.github/workflows/release-cross-platform.yml` |
+| Python 테스트 범위 | CI에서 Python 3.9부터 3.14까지, 그리고 free-threaded 3.14t를 확인합니다. | `.github/workflows/test.yml` |
+| Nuitka 릴리스 빌드 | 일반 CPython 3.14와 `nuitka>=4.1`을 씁니다. | `.github/workflows/build-linux.yml`, `.github/workflows/build-macos.yml`, `.github/workflows/publish.yml` |
 | free-threaded standalone | 대상에서 제외합니다. `--disable-gil`, `3.14t`를 쓰지 않습니다. | `tests/test_build_config.py` |
 | Nuitka 플래그 | `build_scripts/nuitka_flags.py`가 단일 기준입니다. | `build_scripts/build_nuitka.py`, `build_scripts/nuitka_flags.py` |
 | 런타임 병렬 정책 | GIL 비활성화 여부를 보고 ThreadPool 또는 ProcessPool을 고릅니다. | `core/parallel_utils.py` |
@@ -114,6 +114,7 @@ python -m build_scripts.nuitka_flags --platform linux --version 0.0.0
 ## free-threaded Python 사용 시 주의
 
 - PyPI 패키지 실행에서는 free-threaded Python을 직접 쓸 수 있습니다.
+- free-threaded 빌드는 CPython 3.14.4 이상을 쓰세요. 3.14.0에는 힙이 커질수록 GC 일시정지가 2차 함수로 늘어나는 버그(3.14.1에서 수정), free-threaded GC 성능 회귀(3.14.3에서 수정), 스레드가 끝날 때까지 mimalloc 페이지가 회수되지 않는 누수(3.14.4에서 수정)가 있었습니다. 장시간 실행하는 GUI/DSP 작업에는 최신 패치를 권합니다.
 - standalone 릴리스는 일반 CPython 3.14 기준입니다.
 - no-GIL 런타임에서 ThreadPool 경로는 pickle 비용을 줄일 수 있지만, 모든 작업이 빨라진다고 보장할 수는 없습니다.
 - NumPy와 SciPy 내부 구현, BLAS 설정, 배열 크기에 따라 결과가 달라집니다.

--- a/docs/README_PYTHON314.md
+++ b/docs/README_PYTHON314.md
@@ -132,3 +132,14 @@ pytest tests/test_build_config.py tests/test_nuitka_flags.py -q
 ```bash
 pytest tests/test_parallel_processing.py tests/test_hrir_outputs.py -q
 ```
+
+free-threaded 런타임에서 스레드 병렬 경로가 출력 파일을 오염시키지 않는지는
+반복 생성 해시 비교로 검사합니다. 데모 BRIR을 같은 환경에서 여러 번 생성해
+모든 출력 `.wav`의 SHA-256이 실행 간 동일해야 합니다. CI의
+`brir-thread-determinism` 잡이 3.14t에서 매 실행마다 이를 반복하므로,
+간헐적인 데이터 레이스(하이젠버그)도 실행이 누적되면 잡힙니다.
+
+```bash
+IMPULCIFER_RUN_BRIR_THREAD_DETERMINISM=1 \
+  pytest tests/test_brir_thread_determinism.py -v
+```

--- a/tests/test_brir_thread_determinism.py
+++ b/tests/test_brir_thread_determinism.py
@@ -1,0 +1,94 @@
+"""Free-threaded BRIR output determinism checks.
+
+On a free-threaded (no-GIL) runtime ``core.parallel_utils`` switches the
+heavy pipeline stages to ``ThreadPoolExecutor``. A data race in any worker
+would show up as run-to-run differences in the generated WAV bytes — the
+classic heisenbug that a single test run cannot catch. This test generates
+the demo BRIR several times in the same environment and requires every
+produced ``.wav`` to be byte-identical (SHA-256) across runs, so repeated CI
+executions accumulate chances to trap an intermittent race.
+
+Opt-in via ``IMPULCIFER_RUN_BRIR_THREAD_DETERMINISM=1``; CI runs it in a
+dedicated job on the free-threaded interpreter. Unlike
+``test_brir_integrity`` this needs no reference ref — the comparison is
+between repeated runs of the same code, so it is platform-agnostic by
+construction (only the free-threaded runtime is required).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.test_brir_integrity import (
+    PROJECT_ROOT,
+    SCENARIOS,
+    _copy_demo_inputs,
+    _required_paths,
+    _run_impulcifer,
+    _sha256_file,
+)
+
+
+RUN_ENV_VAR = "IMPULCIFER_RUN_BRIR_THREAD_DETERMINISM"
+RUNS_ENV_VAR = "IMPULCIFER_BRIR_DETERMINISM_RUNS"
+DEFAULT_RUNS = 3
+
+
+def _is_free_threaded() -> bool:
+    is_gil_enabled = getattr(sys, "_is_gil_enabled", None)
+    return is_gil_enabled is not None and not is_gil_enabled()
+
+
+def _hash_wav_outputs(demo_dir: Path) -> dict:
+    """SHA-256 of every top-level .wav (inputs are identical copies, so
+    including them costs nothing and catches accidental input mutation)."""
+    return {path.name: _sha256_file(path) for path in sorted(demo_dir.glob("*.wav"))}
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(
+    os.environ.get(RUN_ENV_VAR) != "1",
+    reason=f"set {RUN_ENV_VAR}=1 to run the BRIR thread-determinism test",
+)
+@pytest.mark.skipif(
+    not _is_free_threaded(),
+    reason="requires a free-threaded (no-GIL) runtime so the ThreadPoolExecutor path is active",
+)
+@pytest.mark.parametrize("scenario", SCENARIOS, ids=[scenario.name for scenario in SCENARIOS])
+def test_brir_output_is_deterministic_under_threading(tmp_path, scenario) -> None:
+    """Repeated demo runs on the threaded path must be byte-identical."""
+    missing = [str(path) for path in _required_paths(PROJECT_ROOT) if not path.exists()]
+    if missing:
+        pytest.skip(f"demo integrity inputs are missing: {missing}")
+
+    runs = max(2, int(os.environ.get(RUNS_ENV_VAR, str(DEFAULT_RUNS))))
+    run_hashes = []
+    for run_index in range(1, runs + 1):
+        demo_dir = tmp_path / f"run-{run_index}" / scenario.name
+        _copy_demo_inputs(PROJECT_ROOT, demo_dir)
+        _run_impulcifer(PROJECT_ROOT, demo_dir, scenario)
+        run_hashes.append(_hash_wav_outputs(demo_dir))
+
+    baseline = run_hashes[0]
+    assert "hesuvi.wav" in baseline, f"{scenario.name}: run 1 produced no hesuvi.wav"
+
+    for run_index, current in enumerate(run_hashes[1:], start=2):
+        if current == baseline:
+            continue
+        changed = sorted(
+            name
+            for name in set(baseline) | set(current)
+            if baseline.get(name) != current.get(name)
+        )
+        details = "\n".join(
+            f"  {name}: {baseline.get(name, '<absent>')} -> {current.get(name, '<absent>')}"
+            for name in changed
+        )
+        pytest.fail(
+            f"{scenario.name}: non-deterministic output under free-threaded "
+            f"parallelism — run 1 vs run {run_index} differ in {changed}\n{details}"
+        )


### PR DESCRIPTION
## 배경

프로젝트의 간판 기능인 free-threaded 병렬 처리(`core/parallel_utils.py` — GIL 비활성 시 ThreadPoolExecutor 경로)가 지금까지 CI에서 한 번도 실제 no-GIL 런타임으로 검증되지 않았습니다. Python 3.14.x 패치 릴리스 조사(3.14.1~3.14.6)에서 free-threaded 빌드 관련 수정이 대량으로 확인되어, CI 커버리지 공백을 메우고 사용자 문서에 권장 최소 패치를 명시합니다.

## 변경 내용

### CI (`.github/workflows/test.yml`)
- 테스트 매트릭스에 `3.14t`(free-threaded) 추가 — 전체 pytest 스위트가 실제 no-GIL 인터프리터에서 실행됩니다.
- **GIL 가드 스텝**: C 확장이 free-threaded 지원을 선언하지 않으면 임포트 시점에 GIL이 조용히 재활성화됩니다. numpy/scipy/matplotlib/soundfile/Pillow 임포트 후 `sys._is_gil_enabled()`가 False인지 assert하여, "3.14t 잡이 사실은 GIL 켜진 채로 통과"하는 무의미한 그린을 방지합니다.

### 문서 (README.md, docs/README_PYTHON314.md)
- free-threaded 런타임 권장 최소 패치 명시: **CPython 3.14.4 이상**
  - 3.14.1: 힙 증가 시 GC 일시정지 2차 함수 증가 수정 (gh-142048)
  - 3.14.3: free-threaded GC 성능 회귀 수정 (gh-142531)
  - 3.14.4: 스케일링 개선 다수 + mimalloc 페이지 누수 수정 (gh-145615)
- `docs/README_PYTHON314.md`의 stale한 `release-cross-platform.yml` 참조를 `publish.yml`로 수정.

## 버전 / 릴리스

CI + 문서만 변경 — 버전 bump 없음. release gate가 `should_release=false`로 판정해 PyPI/Nuitka가 스킵되는 것이 기대 동작입니다. 변경 경로 전부(`.github/*`, `*.md`, `docs/*`, `CHANGELOG*`)가 `release_gate.py`의 EXCLUDE에 해당함을 확인했습니다.

## 검증

- `test.yml` YAML 파스 OK
- `tests/test_build_config.py` + `tests/test_release_gate.py` 22 passed — `3.14t` 금지 문자열 검사는 빌드 워크플로/스크립트만 대상이므로 test.yml 추가와 충돌하지 않음
- ruff OK, `tests/test_suite.py -m "not slow"` 19 passed
- 런타임 코드 무변경 → Tier 3 해당 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)