### PR TITLE
feat: WebView 프론트엔드 표준화 — Cocoa/GTK 검증, 자동 업데이트, Nuitka standalone 기본 탑재

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -42,6 +42,7 @@ jobs:
             patchelf \
             desktop-file-utils \
             libfuse2 \
+            imagemagick \
             portaudio19-dev \
             python3-tk \
             python3-dev \

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -51,7 +51,14 @@ jobs:
             libhdf5-dev \
             libatlas-base-dev \
             gfortran \
-            libopenblas-dev
+            libopenblas-dev \
+            gir1.2-gtk-3.0 \
+            gir1.2-webkit2-4.1 \
+            libgirepository1.0-dev \
+            libgirepository-2.0-dev \
+            libcairo2-dev \
+            pkg-config \
+            gcc
 
       - name: Cache Nuitka compilation
         uses: actions/cache@v5
@@ -73,6 +80,8 @@ jobs:
           fi
           echo "Installing project dependencies from requirements.txt..."
           uv pip install --system -r requirements.txt
+          echo "Installing WebView frontend stack (pywebview + PyGObject)..."
+          uv pip install --system "pywebview[gtk]>=6.2,<7"
           echo "All dependencies installed successfully with uv!"
 
       - name: Read project version and set APP_VERSION

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -54,6 +54,8 @@ jobs:
           fi
           echo "Installing project dependencies from requirements.txt..."
           uv pip install --system -r requirements.txt
+          echo "Installing WebView frontend stack (pywebview + pyobjc)..."
+          uv pip install --system "pywebview>=6.2,<7"
           echo "All dependencies installed successfully with uv!"
 
       - name: Read project version and set APP_VERSION

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -157,6 +157,8 @@ jobs:
           fi
           echo "Installing project dependencies from requirements.txt..."
           uv pip install --system -r requirements.txt
+          echo "Installing WebView frontend stack (pywebview + pythonnet)..."
+          uv pip install --system "pywebview>=6.2,<7"
           echo "All dependencies installed successfully with uv!"
         shell: bash
 
@@ -262,6 +264,8 @@ jobs:
             uv pip install --system toml
           fi
           uv pip install --system -r requirements.txt
+          echo "Installing WebView frontend stack (pywebview + pyobjc)..."
+          uv pip install --system "pywebview>=6.2,<7"
           echo "All dependencies installed successfully!"
 
       - name: Read project version
@@ -372,7 +376,14 @@ jobs:
             libhdf5-dev \
             libatlas-base-dev \
             gfortran \
-            libopenblas-dev
+            libopenblas-dev \
+            gir1.2-gtk-3.0 \
+            gir1.2-webkit2-4.1 \
+            libgirepository1.0-dev \
+            libgirepository-2.0-dev \
+            libcairo2-dev \
+            pkg-config \
+            gcc
 
       - name: Cache Nuitka compilation
         uses: actions/cache@v5
@@ -392,6 +403,8 @@ jobs:
             uv pip install --system toml
           fi
           uv pip install --system -r requirements.txt
+          echo "Installing WebView frontend stack (pywebview + PyGObject)..."
+          uv pip install --system "pywebview[gtk]>=6.2,<7"
           echo "All dependencies installed successfully!"
 
       - name: Read project version

--- a/.github/workflows/webview-backend-validation.yml
+++ b/.github/workflows/webview-backend-validation.yml
@@ -1,0 +1,98 @@
+# WebView 백엔드 실기 검증.
+#
+# webview-gallery.yml은 headless Chromium + mock 브리지로 "화면"을 검증하고,
+# 이 워크플로는 각 플랫폼의 실제 렌더링 엔진(WebView2 / WKWebView /
+# WebKit2GTK)과 실제 WebviewBridge로 "런타임"을 검증한다. 세 잡이 모두
+# 그린이어야 해당 플랫폼의 Nuitka standalone에 WebView 프론트엔드를 기본으로
+# 실을 수 있다 (build_scripts/validate_webview_backend.py 참조).
+name: WebView Backend Validation
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'impulcifer_webview.py'
+      - 'application/**'
+      - 'webview_ui/**'
+      - 'build_scripts/validate_webview_backend.py'
+      - '.github/workflows/webview-backend-validation.yml'
+
+concurrency:
+  group: webview-backend-validation-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate-windows:
+    name: Validate edgechromium (Windows)
+    runs-on: windows-latest
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Install project with webview extra
+        run: pip install -e ".[webview]"
+
+      - name: Validate Edge WebView2 backend
+        run: python build_scripts/validate_webview_backend.py
+
+  validate-macos:
+    name: Validate cocoa (macOS)
+    runs-on: macos-latest
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Install project with webview extra
+        run: pip install -e ".[webview]"
+
+      - name: Validate Cocoa WKWebView backend
+        run: python build_scripts/validate_webview_backend.py
+
+  validate-linux:
+    name: Validate gtk (Linux)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      # WebKit2GTK + PyGObject 빌드 의존성. libgirepository는 PyGObject
+      # 3.50 미만(1.0)과 3.52 이상(2.0)이 서로 다른 dev 패키지를 요구하므로
+      # 둘 다 설치한다. libportaudio2는 sounddevice 임포트용(test.yml과 동일).
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            xvfb \
+            libportaudio2 \
+            gir1.2-gtk-3.0 \
+            gir1.2-webkit2-4.1 \
+            libgirepository1.0-dev \
+            libgirepository-2.0-dev \
+            libcairo2-dev \
+            pkg-config \
+            python3-dev \
+            gcc
+
+      - name: Install project with webview extra
+        run: pip install -e ".[webview]"
+
+      - name: Validate WebKit2GTK backend
+        run: xvfb-run -a python build_scripts/validate_webview_backend.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ first number changes, something has broken and you need to check your commands a
 changes there are only new features available and nothing old has broken and when the last number changes, old bugs have
 been fixed and old features improved.
 
+## 2.10.0 - 2026-07-12
+### WebView 표준화 — 3-플랫폼 백엔드 검증, 자동 업데이트, standalone 기본 인터페이스 전환
+
+#### ⭐ 새로운 기능 / 개선
+- **WebView 프론트엔드의 macOS/Linux 지원**: Windows 전용 게이트를 제거하고 플랫폼별 렌더링 엔진을 강제 선택한다 — Windows는 Edge WebView2(edgechromium), macOS는 WKWebView(cocoa), Linux는 WebKit2GTK(gtk). KDE 세션에서 pywebview가 Qt를 우선하는 동작도 차단된다. 런타임 배지가 실제 백엔드명(WebView2/WKWebView/WebKitGTK)을 표시한다.
+- **WebView 자동 업데이트**: CTk `UpdateDialog`/`UpdateExecutor` 흐름을 application service job으로 이식했다. 부팅 2초 후 백그라운드 확인(CTk `after(2000)` 미러) → 릴리스 노트·버전 라인·"지금 업데이트/나중에/건너뛰기" 모달 → 다운로드 진행률 → 완료 메시지 → Velopack 경로는 OK 확인 시 `Update.exe` 인계 후 창 자동 종료·재시작. pip/legacy 경로는 각자의 완료 안내를 표시한다. Info 탭에 수동 "업데이트 확인" 버튼도 추가.
+- **Standalone 기본 인터페이스가 WebView로 전환**: `gui_main.py`가 런처가 되어 실행 인자(`--frontend=webview|ctk`) > 저장된 설정(`~/.impulcifer/settings.json`의 `frontend` 키) > 기본값 webview 순으로 결정한다. 바로가기/Velopack 실행 모두 WebView가 뜬다. pywebview 미탑재·시스템 WebKit 부재 등 WebView 스택을 쓸 수 없는 환경에서는 CustomTkinter로 자동 폴백한다. WebView 설정 탭과 CTk 설정 탭 양쪽에 "기본 인터페이스" 선택을 추가했다.
+- **CustomTkinter deprecation 고지**: CTk 인터페이스는 버전 3에서 제거될 예정이며, 버전 2 동안에는 유지보수와 기능 추가를 포함해 계속 완전히 지원된다. CTk 설정 탭·README·CHANGELOG에 고지를 추가했다.
+
+#### 🔧 빌드 / 설정 변경
+- **3-플랫폼 백엔드 실기 검증 CI (`.github/workflows/webview-backend-validation.yml`)**: mock 기반 갤러리와 상보적으로, 각 플랫폼의 실제 엔진 + 실제 `WebviewBridge`로 DOM 렌더 → boot() 완주(bootstrap 왕복) → promise 기반 브리지 왕복을 검증한다(`build_scripts/validate_webview_backend.py`, watchdog 포함). 첫 실행에서 cocoa/gtk/edgechromium 모두 통과.
+- **Nuitka standalone에 WebView 스택 번들**: `webview_ui/` 데이터 디렉토리를 포함하고, pywebview 자체는 명시적 include 없이 정적 `import webview` 체인의 자동 추적에 맡긴다 — `--include-module/package=webview`는 어느 형태든 Nuitka 내장 pywebview 플러그인의 "타 플랫폼 백엔드 제외" 결정과 충돌해 빌드가 즉사한다(로컬 빌드로 확인, `tests/test_nuitka_flags.py`가 이 불변식을 고정). 플러그인·패키지 설정이 백엔드 선택과 webview js/lib·pythonnet·clr_loader DLL 번들을 전부 처리한다. 빌드 잡 3종(publish.yml + 수동 build-linux/build-macos)에 pywebview 설치(리눅스는 `pywebview[gtk]` + WebKit2GTK/GObject 시스템 패키지)를 추가했다. `--smoke-test`가 webview 모듈·application service·`webview_ui/index.html` 번들 여부까지 검증한다.
+- **`[webview]` extra의 Linux GTK 지원**: `pywebview[gtk]`(PyGObject)을 Linux 마커로 요구한다. 소스 빌드에 필요한 시스템 패키지는 README에 문서화.
+- **서드파티 라이선스 고지 정비**: 재배포물에 포함되는 서드파티의 고지 파일을 추가했다 — `THIRD_PARTY_LICENSES.md`(루트: pywebview BSD-3, CustomTkinter MIT, AutoEQ MIT, Pretendard·JetBrains Mono OFL 1.1 전문), `autoeq/LICENSE`(원본 MIT 사본), `font/OFL-Pretendard.txt`·`font/OFL-JetBrainsMono.txt`(OFL 1.1은 폰트 재배포 시 라이선스 동봉 요구). wheel(`[tool.hatch.build] include`)과 Nuitka standalone(`INCLUDED_DATA_FILES`, font 디렉토리 동승) 양쪽에 포함된다.
+- **Nuitka pywebview 플러그인 화이트리스트 핫픽스 (`build_scripts/patch_nuitka_pywebview.py`)**: Nuitka 내장 pywebview 플러그인의 Windows 화이트리스트가 구버전 pywebview 기준이라 pywebview 6.x winforms가 import하는 헬퍼 모듈 `webview.platforms.win32`를 "actively excluded"로 빼버려, 패키징된 앱이 기동 시 조용히 CTk로 폴백하는 문제를 로컬 빌드 실검증으로 발견했다. 명시적 include는 플러그인 결정과 충돌하므로, 빌드 직전에 설치된 플러그인 화이트리스트에 누락 항목을 삽입하는 idempotent 패치를 두 빌드 스크립트(build_nuitka.py/build_local.py)에 연결했다(업스트림 수정 시 자동 no-op).
+
 ## 2.9.0 - 2026-07-12
 ### Qt 없는 WebView 전환 — application service, Pulse Studio 프론트엔드, 갤러리 리뷰 CI
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ been fixed and old features improved.
 - **WebView 프론트엔드의 macOS/Linux 지원**: Windows 전용 게이트를 제거하고 플랫폼별 렌더링 엔진을 강제 선택한다 — Windows는 Edge WebView2(edgechromium), macOS는 WKWebView(cocoa), Linux는 WebKit2GTK(gtk). KDE 세션에서 pywebview가 Qt를 우선하는 동작도 차단된다. 런타임 배지가 실제 백엔드명(WebView2/WKWebView/WebKitGTK)을 표시한다.
 - **WebView 자동 업데이트**: CTk `UpdateDialog`/`UpdateExecutor` 흐름을 application service job으로 이식했다. 부팅 2초 후 백그라운드 확인(CTk `after(2000)` 미러) → 릴리스 노트·버전 라인·"지금 업데이트/나중에/건너뛰기" 모달 → 다운로드 진행률 → 완료 메시지 → Velopack 경로는 OK 확인 시 `Update.exe` 인계 후 창 자동 종료·재시작. pip/legacy 경로는 각자의 완료 안내를 표시한다. Info 탭에 수동 "업데이트 확인" 버튼도 추가.
 - **Standalone 기본 인터페이스가 WebView로 전환**: `gui_main.py`가 런처가 되어 실행 인자(`--frontend=webview|ctk`) > 저장된 설정(`~/.impulcifer/settings.json`의 `frontend` 키) > 기본값 webview 순으로 결정한다. 바로가기/Velopack 실행 모두 WebView가 뜬다. pywebview 미탑재·시스템 WebKit 부재 등 WebView 스택을 쓸 수 없는 환경에서는 CustomTkinter로 자동 폴백한다. WebView 설정 탭과 CTk 설정 탭 양쪽에 "기본 인터페이스" 선택을 추가했다.
-- **CustomTkinter deprecation 고지**: CTk 인터페이스는 버전 3에서 제거될 예정이며, 버전 2 동안에는 유지보수와 기능 추가를 포함해 계속 완전히 지원된다. CTk 설정 탭·README·CHANGELOG에 고지를 추가했다.
+- **CustomTkinter 지원 일정 고지**: CTk 인터페이스는 버전 2 동안 유지보수와 기능 추가를 포함해 계속 완전히 지원되며, 버전 3부터는 제거되지 않고 지금의 레거시 GUI처럼 업데이트 없이 동결 상태로 유지된다(버전 3에서 제거되는 것은 구버전 레거시 GUI뿐). CTk 설정 탭·README·CHANGELOG에 고지를 추가했다.
 
 #### 🔧 빌드 / 설정 변경
 - **3-플랫폼 백엔드 실기 검증 CI (`.github/workflows/webview-backend-validation.yml`)**: mock 기반 갤러리와 상보적으로, 각 플랫폼의 실제 엔진 + 실제 `WebviewBridge`로 DOM 렌더 → boot() 완주(bootstrap 왕복) → promise 기반 브리지 왕복을 검증한다(`build_scripts/validate_webview_backend.py`, watchdog 포함). 첫 실행에서 cocoa/gtk/edgechromium 모두 통과.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,9 +11,14 @@ Impulcifer-py313은 HRIR(Head-Related Impulse Response)을 측정하고 헤드�
 ## 아키텍처
 
 ```
-gui_main.py              ← 엔트리포인트 (standalone 빌드 대상)
-impulcifer_webview.py     ← 실험적 WebView 프론트엔드 엔트리포인트 (Windows 전용,
-                            pywebview Edge WebView2 고정, 선택적 [webview] extra)
+gui_main.py              ← 런처 엔트리포인트 (standalone 빌드 대상). 기본 프론트엔드는
+                            WebView(2.10+). --frontend=webview|ctk 인자 >
+                            settings.json의 frontend 키 > 기본 webview 순으로 결정,
+                            WebView 스택 불가 시 CTk 자동 폴백
+impulcifer_webview.py     ← WebView 프론트엔드 (Windows=edgechromium / macOS=cocoa /
+                            Linux=gtk 강제 맵; webview-backend-validation.yml이
+                            3-플랫폼 실기 검증; pip에서는 선택적 [webview] extra,
+                            Linux는 pywebview[gtk]+시스템 WebKit2GTK 필요)
 application/
   impulcifer_service.py   ← Tk 비종속 JSON-safe application service (job 모델,
                             ProcessingConfig 전체 표면 검증, UI 설정/시스템 정보)
@@ -44,7 +49,8 @@ core/
   parallel_utils.py       ← 병렬 처리 유틸리티
   channel_generation.py   ← 가상 채널 생성
 gui/
-  modern_gui.py           ← CustomTkinter GUI (~295줄, tabs/로 분리됨)
+  modern_gui.py           ← CustomTkinter GUI (~295줄, tabs/로 분리됨. 버전 2 동안
+                            유지보수+기능추가 지속, 버전 3에서 제거 예정 고지됨)
   tabs/                   ← Recorder / Impulcifer / Settings / Info 탭
   legacy_gui.py           ← 구버전 Tkinter GUI (deprecated, 신규 작업 금지)
 autoeq/                   ← 벤더링된 AutoEQ (PR #63에서 in-tree 전환)
@@ -77,6 +83,8 @@ updater/
 `core/utils.py`의 `magnitude_response()`는 현재 검증된 NumPy `rfft` 기반 출력과 bit-identical해야 한다. full FFT 경로는 수치적으로 가까워도 BRIR 해시를 바꿀 수 있으므로, `test_magnitude_response_parity.py`가 이 verified 동작을 고정한다.
 
 데모 WAV 파일(`data/demo/*.wav`)은 raw 바이너리로 repo에 포함되어 있다(약 55MB). 일반 `git clone`으로 받아진다. `.gitignore`가 demo 폴더를 기본 무시하면서 화이트리스트로 필요한 파일들만 통과시키므로, 새 데모 파일을 추가할 때는 `.gitignore`의 `!data/demo/...` 라인을 갱신해야 한다.
+
+pywebview는 Nuitka 플래그에 명시적 include로 넣지 말 것 — `--include-module=webview`든 `--include-package=webview`든 Nuitka의 follow 패턴에 들어가 내장 pywebview 플러그인(타 플랫폼 백엔드 제외 결정)과 충돌하고 빌드가 FATAL로 죽는다("Conflict between user and plugin decision for module 'webview.platforms.android'", 로컬 빌드로 확인). 정적 `import webview` 체인(gui_main → impulcifer_webview)의 자동 추적과 플러그인/패키지 설정이 백엔드 모듈 선택·webview js/lib·pythonnet/clr_loader DLL 번들을 전부 처리한다. 단, 그 플러그인의 Windows 화이트리스트에는 pywebview 6.x가 요구하는 `webview.platforms.win32`가 누락되어 있어(업스트림 버그) 빌드 스크립트가 `build_scripts/patch_nuitka_pywebview.py`로 빌드 직전에 화이트리스트를 패치한다 — 이 패치를 제거하면 패키징된 Windows 앱이 기동 시 조용히 CTk로 폴백한다. `tests/test_nuitka_flags.py`가 이 불변식들을 고정한다.
 
 Nuitka 빌드 플래그의 정본은 `build_scripts/nuitka_flags.py`다. 모든 빌드 진입점 — 릴리스 파이프라인(`.github/workflows/publish.yml`의 `build-windows`/`build-macos`/`build-linux` 잡)과 수동 빌드 워크플로(`build-linux.yml`, `build-macos.yml`) — 은 인라인 Nuitka 명령 없이 `python build_scripts/build_nuitka.py`를 호출하고, 이 스크립트가 `nuitka_flags.py`를 import하므로 플래그는 한 곳에서 동기화된다(이슈 #87 Phase 4에서 인라인 명령 제거 완료). 빌드 플래그를 추가/변경할 때는 `nuitka_flags.py`만 갱신하면 된다. `python build_scripts/nuitka_flags.py --platform linux --version X` 으로 정본 플래그 목록을 한 줄씩 출력해 비교에 활용할 수 있다.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,9 +50,11 @@ core/
   channel_generation.py   ← 가상 채널 생성
 gui/
   modern_gui.py           ← CustomTkinter GUI (~295줄, tabs/로 분리됨. 버전 2 동안
-                            유지보수+기능추가 지속, 버전 3에서 제거 예정 고지됨)
+                            유지보수+기능추가 지속, 버전 3부터는 레거시 GUI처럼
+                            동결 유지[패치 없음] — 제거 아님)
   tabs/                   ← Recorder / Impulcifer / Settings / Info 탭
-  legacy_gui.py           ← 구버전 Tkinter GUI (deprecated, 신규 작업 금지)
+  legacy_gui.py           ← 구버전 Tkinter GUI (deprecated, 신규 작업 금지,
+                            버전 3에서 제거 예정)
 autoeq/                   ← 벤더링된 AutoEQ (PR #63에서 in-tree 전환)
   frequency_response.py   ← 주파수 응답 처리 핵심
 i18n/

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ impulcifer_webview
 
 Standalone 릴리스(2.10+)의 기본 인터페이스는 WebView입니다. CustomTkinter 인터페이스도 계속 함께 설치되며, 설정 탭의 "기본 인터페이스" 선택이나 실행 인자 `--frontend=ctk`로 전환할 수 있습니다 (`--frontend=webview`로 되돌리기). WebView 스택을 사용할 수 없는 환경에서는 자동으로 CustomTkinter로 폴백합니다.
 
-> **CustomTkinter 지원 안내**: CustomTkinter 인터페이스는 버전 3에서 제거될 예정입니다. 버전 2 동안에는 유지보수와 기능 추가를 포함해 계속 완전히 지원됩니다.
+> **CustomTkinter 지원 안내**: CustomTkinter 인터페이스는 버전 2 동안 유지보수와 기능 추가를 포함해 계속 완전히 지원됩니다. 버전 3부터는 제거되지 않고 지금의 레거시 GUI처럼 업데이트 없이 동결 상태로 유지됩니다 — 버전 3에서 제거되는 것은 구버전 레거시 GUI(`impulcifer_gui_legacy`)입니다.
 
 CLI를 쓰려면 측정 폴더를 지정합니다.
 

--- a/README.md
+++ b/README.md
@@ -44,10 +44,17 @@ pip install impulcifer-py313
 uv pip install impulcifer-py313
 ```
 
-Windows에서 실험적 WebView 프론트엔드를 시험하려면 선택적 extra를 설치합니다. 이 경로는 Microsoft Edge WebView2를 사용하며 Qt backend로 fallback하지 않습니다.
+WebView 프론트엔드(2.10부터 기본 인터페이스)를 pip 환경에서 쓰려면 선택적 extra를 설치합니다. 플랫폼별로 Windows는 Microsoft Edge WebView2, macOS는 WKWebView(Cocoa), Linux는 WebKit2GTK를 사용하며 Qt backend로 fallback하지 않습니다.
 
 ```bash
 pip install "impulcifer-py313[webview]"
+```
+
+Linux에서는 PyGObject 소스 빌드를 위해 시스템 패키지가 먼저 필요합니다 (Debian/Ubuntu 기준):
+
+```bash
+sudo apt-get install -y gir1.2-gtk-3.0 gir1.2-webkit2-4.1 \
+  libgirepository1.0-dev libgirepository-2.0-dev libcairo2-dev pkg-config gcc python3-dev
 ```
 
 ### Standalone 릴리스
@@ -62,11 +69,15 @@ GUI를 쓰려면 다음 명령을 실행합니다.
 impulcifer_gui
 ```
 
-Windows 전용 실험적 WebView 프론트엔드는 다음 명령으로 실행합니다. Studio 스킨과 같은 Pulse 디자인의 사이드바 UI에서 Recorder / Processing / Settings / Info 탭, CustomTkinter GUI와 동등한 BRIR 옵션 전체(가상 저음, decay, channel balance, 마이크 편차 보정 등), 네이티브 파일·폴더 선택, 9개 언어와 dark/light/system 테마를 제공합니다. 기존 CustomTkinter GUI와 standalone 릴리스의 기본 진입점은 바뀌지 않습니다.
+WebView 프론트엔드는 다음 명령으로 실행합니다 (Windows/macOS/Linux). Pulse 디자인의 Studio/Stable 스킨, Recorder / Processing / Settings / Info 탭, CustomTkinter GUI와 동등한 BRIR 옵션 전체(가상 저음, decay, channel balance, 마이크 편차 보정 등), 네이티브 파일·폴더 선택, 자동 업데이트, 9개 언어와 dark/light/system 테마를 제공합니다.
 
 ```bash
 impulcifer_webview
 ```
+
+Standalone 릴리스(2.10+)의 기본 인터페이스는 WebView입니다. CustomTkinter 인터페이스도 계속 함께 설치되며, 설정 탭의 "기본 인터페이스" 선택이나 실행 인자 `--frontend=ctk`로 전환할 수 있습니다 (`--frontend=webview`로 되돌리기). WebView 스택을 사용할 수 없는 환경에서는 자동으로 CustomTkinter로 폴백합니다.
+
+> **CustomTkinter 지원 안내**: CustomTkinter 인터페이스는 버전 3에서 제거될 예정입니다. 버전 2 동안에는 유지보수와 기능 추가를 포함해 계속 완전히 지원됩니다.
 
 CLI를 쓰려면 측정 폴더를 지정합니다.
 

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,316 @@
+# Third-Party Licenses
+
+본 파일은 Impulcifer와 함께 배포되는 제3자 소프트웨어 및 폰트의 라이선스를 명시합니다.
+
+## pywebview
+
+- **Project:** https://github.com/r0x0r/pywebview
+- **License:** BSD 3-Clause
+- **Distribution:** Standalone builds only (bundled library code)
+
+```
+BSD 3-Clause License
+
+Copyright (c) 2014-2017, Roman Sirokov
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```
+
+## CustomTkinter
+
+- **Project:** https://github.com/TomSchimansky/CustomTkinter
+- **License:** MIT
+- **Distribution:** Standalone builds only (bundled library code)
+
+```
+MIT License
+
+Copyright (c) 2023 Tom Schimansky
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+## Pretendard
+
+- **Project:** https://github.com/orioncactus/pretendard
+- **License:** SIL OFL 1.1
+- **Distribution:** Bundled in `font/` directory (wheel and standalone builds)
+
+```
+Copyright (c) 2021, Kil Hyung-jin (https://github.com/orioncactus/pretendard),
+with Reserved Font Name 'Pretendard'.
+
+Copyright 2014-2021 Adobe (http://www.adobe.com/),
+with Reserved Font Name 'Source'.
+Source is a trademark of Adobe in the United States and/or other countries.
+
+Copyright (c) 2016 The Inter Project Authors (https://github.com/rsms/inter),
+with Reserved Font Name 'Inter'.
+
+Copyright 2021 The M+ FONTS Project Authors (https://github.com/coz-m/MPLUS_FONTS),
+with Reserved Font Name 'M PLUS 1'.
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+https://scripts.sil.org/OFL
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.
+```
+
+## JetBrains Mono
+
+- **Project:** https://github.com/JetBrains/JetBrainsMono
+- **License:** SIL OFL 1.1
+- **Distribution:** Bundled in `font/` directory (wheel and standalone builds)
+
+```
+Copyright 2020 The JetBrains Mono Project Authors (https://github.com/JetBrains/JetBrainsMono)
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+https://openfontlicense.org
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.
+```
+
+## AutoEQ
+
+- **Project:** https://github.com/jaakkopasanen/AutoEq
+- **License:** MIT
+- **Distribution:** Vendored in `autoeq/` directory (wheel and standalone builds)
+
+```
+MIT License
+
+Copyright (c) 2018-2022 Jaakko Pasanen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/application/impulcifer_service.py
+++ b/application/impulcifer_service.py
@@ -53,6 +53,9 @@ _THEME_CODES = ("dark", "light", "system")
 # Mirrors gui.skins.SKIN_CHOICES without importing the gui package (this
 # module must stay importable without tkinter).
 _SKIN_CODES = ("stable", "studio")
+# gui_main launcher targets; ``webview`` is the default since 2.10 and CTk
+# stays supported for the rest of version 2 (removal planned for version 3).
+_FRONTEND_CODES = ("webview", "ctk")
 
 _brir_field_kinds_cache: dict[str, str] | None = None
 
@@ -422,6 +425,18 @@ class ImpulciferApplicationService:
         get_localization_manager().set_skin(skin)
         return _ok({"skin": skin})
 
+    def set_frontend(self, frontend: str) -> dict[str, Any]:
+        from i18n.localization import get_localization_manager
+
+        if frontend not in _FRONTEND_CODES:
+            return _error(
+                "INVALID_REQUEST",
+                "Frontend must be one of: " + ", ".join(_FRONTEND_CODES) + ".",
+                details={"frontend": frontend},
+            )
+        get_localization_manager().set_frontend(frontend)
+        return _ok({"frontend": frontend})
+
     @staticmethod
     def _ui_settings_payload(loc: Any) -> dict[str, Any]:
         from i18n.localization import SUPPORTED_LANGUAGES
@@ -430,6 +445,9 @@ class ImpulciferApplicationService:
             "language": loc.current_language,
             "theme": loc.get_theme(),
             "skin": loc.get_skin(),
+            # Older LocalizationManager instances (or test fakes) may predate
+            # the frontend setting; default matches get_frontend().
+            "frontend": loc.get_frontend() if hasattr(loc, "get_frontend") else "webview",
             "languages": [
                 {"code": code, "name": name} for code, name in SUPPORTED_LANGUAGES.items()
             ],

--- a/application/impulcifer_service.py
+++ b/application/impulcifer_service.py
@@ -167,6 +167,11 @@ class ImpulciferApplicationService:
         self._lock = threading.RLock()
         self._jobs: dict[str, _Job] = {}
         self._active_job_id: str | None = None
+        # Deferred final action of a finished update job (e.g. Velopack's
+        # apply-and-restart); staged so the frontend can show the completion
+        # message first and apply on user confirmation, mirroring the CTk
+        # UpdateDialog messagebox → after_message sequence.
+        self._pending_update_apply: Callable[[], Any] | None = None
 
     def bootstrap(self) -> dict[str, Any]:
         from i18n.localization import get_localization_manager
@@ -360,7 +365,7 @@ class ImpulciferApplicationService:
             if not job.cancellable:
                 return _error(
                     "JOB_NOT_CANCELLABLE",
-                    "Recording jobs cannot be cancelled safely.",
+                    f"{job.kind} jobs cannot be cancelled safely.",
                     details={"job_id": job_id},
                 )
             job.status = "cancel_requested"
@@ -518,6 +523,110 @@ class ImpulciferApplicationService:
         except Exception as exc:
             return _error("INTERNAL_ERROR", str(exc) or exc.__class__.__name__)
         return _ok({"path": target})
+
+    # ------------------------------------------------------------------
+    # Auto-update (ports the CTk check_for_updates_background → UpdateDialog
+    # → UpdateExecutor flow onto the JSON job model)
+    # ------------------------------------------------------------------
+
+    def check_for_updates(self) -> dict[str, Any]:
+        """Query GitHub releases for a newer version (blocking, ~10s max)."""
+        from impulcifer import __version__
+        from updater.update_checker import UpdateChecker
+
+        try:
+            checker = UpdateChecker(__version__)
+            available, latest_version, download_url = checker.check_for_updates()
+        except Exception as exc:
+            return _error(
+                "UPDATE_CHECK_FAILED",
+                str(exc) or exc.__class__.__name__,
+                retryable=True,
+            )
+        # Same gate as the CTk background check: only prompt when there is
+        # both a newer version and something to download.
+        update_available = bool(available and download_url)
+        return _ok(
+            {
+                "update_available": update_available,
+                "current_version": __version__,
+                "latest_version": latest_version,
+                "download_url": download_url,
+                "release_notes": checker.get_release_notes() if update_available else None,
+                "release_url": checker.get_release_url(),
+            }
+        )
+
+    def start_update(self, request: dict[str, Any]) -> dict[str, Any]:
+        """Run the environment-appropriate update executor as a job."""
+        if not isinstance(request, dict):
+            return _error("INVALID_REQUEST", "Request must be an object.")
+        download_url = _optional_string(request.get("download_url"))
+        latest_version = _optional_string(request.get("latest_version"))
+        if latest_version is None:
+            return _error("INVALID_REQUEST", "latest_version is required.")
+
+        def run(job_id: str, _cancel_event: threading.Event) -> dict[str, Any]:
+            from updater.updater_core import UpdateExecutionError, create_update_executor
+
+            executor = create_update_executor(download_url or "", latest_version)
+
+            def progress(value: float, message: str = "") -> None:
+                # ``message`` is either an i18n key ("update_downloading") or
+                # preformatted text ("Downloading: 42%"); the frontend
+                # resolves keys and falls back to the raw string.
+                self._emit(
+                    job_id,
+                    "progress",
+                    {
+                        "progress": max(0.0, min(1.0, float(value))),
+                        "message": message,
+                    },
+                )
+
+            try:
+                result = executor.execute(progress)
+            except UpdateExecutionError as exc:
+                raise _ServiceFailure("UPDATE_FAILED", str(exc), retryable=True) from exc
+            with self._lock:
+                self._pending_update_apply = result.after_message
+            return {
+                "status_key": result.status_key,
+                "status_default": result.status_default,
+                "title_key": result.title_key,
+                "title_default": result.title_default,
+                "message_key": result.message_key,
+                "message_default": result.message_default,
+                "progress": result.progress,
+                "requires_restart": result.after_message is not None,
+            }
+
+        return self._start_job("update", False, run)
+
+    def apply_pending_update(self) -> dict[str, Any]:
+        """Run the staged post-update action (Velopack apply-and-restart)."""
+        with self._lock:
+            apply_fn = self._pending_update_apply
+            self._pending_update_apply = None
+        if apply_fn is None:
+            return _error("INVALID_REQUEST", "No staged update to apply.")
+        try:
+            applied = apply_fn()
+        except SystemExit:
+            # VelopackUpdater.apply_and_restart hands over to Update.exe and
+            # calls sys.exit(); on a bridge worker thread that only unwinds
+            # this frame, so reaching here means the handover succeeded and
+            # the frontend should close the window.
+            return _ok({"restarting": True})
+        except Exception as exc:
+            return _error(
+                "UPDATE_FAILED",
+                str(exc) or exc.__class__.__name__,
+                retryable=True,
+            )
+        if applied is False:
+            return _error("UPDATE_FAILED", "Failed to apply update.", retryable=True)
+        return _ok({"restarting": True})
 
     def _start_job(
         self,

--- a/application/impulcifer_service.py
+++ b/application/impulcifer_service.py
@@ -54,7 +54,8 @@ _THEME_CODES = ("dark", "light", "system")
 # module must stay importable without tkinter).
 _SKIN_CODES = ("stable", "studio")
 # gui_main launcher targets; ``webview`` is the default since 2.10 and CTk
-# stays supported for the rest of version 2 (removal planned for version 3).
+# stays supported for the rest of version 2 (kept frozen like the legacy GUI
+# from version 3 on — not removed).
 _FRONTEND_CODES = ("webview", "ctk")
 
 _brir_field_kinds_cache: dict[str, str] | None = None

--- a/autoeq/LICENSE
+++ b/autoeq/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018-2022 Jaakko Pasanen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/build_scripts/build_local.py
+++ b/build_scripts/build_local.py
@@ -98,6 +98,11 @@ def main() -> int:
 
     _generate_build_marker(version)
 
+    # Nuitka pywebview 플러그인의 stale 화이트리스트 핫픽스 (모듈 docstring 참조).
+    from build_scripts.patch_nuitka_pywebview import patch_pywebview_plugin
+
+    patch_pywebview_plugin()
+
     args = build_nuitka_args(
         target_platform=target_platform,
         version=version,

--- a/build_scripts/build_nuitka.py
+++ b/build_scripts/build_nuitka.py
@@ -123,6 +123,13 @@ def build_impulcifer(project_version="0.0.0", output_base_dir="dist", target_pla
 
     print(f"최종 빌드 결과물은 다음 폴더에 생성됩니다: {final_output_dir.resolve()}", flush=True)
 
+    # Nuitka pywebview 플러그인의 stale 화이트리스트 핫픽스 — 없으면 Windows
+    # 번들에서 webview.platforms.win32가 빠져 앱이 CTk로 폴백한다
+    # (build_scripts/patch_nuitka_pywebview.py docstring 참조).
+    from build_scripts.patch_nuitka_pywebview import patch_pywebview_plugin
+
+    patch_pywebview_plugin()
+
     nuitka_args = build_nuitka_args(
         target_platform=target_platform,
         version=project_version,

--- a/build_scripts/nuitka_flags.py
+++ b/build_scripts/nuitka_flags.py
@@ -66,6 +66,27 @@ INCLUDED_PACKAGES: tuple[str, ...] = (
     # CustomTkinter ships JSON theme files and PNG assets that Nuitka's
     # static analysis won't pull in by import — keep as a package include.
     "customtkinter",
+    # NOTE: pywebview (the WebView frontend, launcher default since 2.10) is
+    # deliberately NOT listed here — and must not be added to
+    # INCLUDED_MODULES either. Any --include-module/--include-package entry
+    # feeds Nuitka's follow patterns for the whole subtree, which conflicts
+    # with the auto-enabled 'pywebview' plugin excluding other platforms'
+    # backend modules (observed FATAL: "Conflict between user and plugin
+    # decision for module 'webview.platforms.android'"). The static
+    # ``import webview`` chain (gui_main → impulcifer_webview) is traced
+    # automatically; the plugin selects the platform backend and Nuitka's
+    # package config bundles webview/js, webview/lib DLLs and the pythonnet /
+    # clr_loader runtime pieces on Windows.
+)
+
+# ``--include-package-data`` targets: packages that load non-Python files at
+# runtime. (Data-file flags do not feed follow patterns, so unlike module
+# includes this cannot conflict with the pywebview plugin.)
+INCLUDED_PACKAGE_DATA: tuple[str, ...] = (
+    # webview/js/*.js bootstrap + webview/lib DLLs — Nuitka's package config
+    # already covers these; kept as belt-and-suspenders against upstream
+    # config changes.
+    "webview",
 )
 
 # Nuitka in --standalone mode follows static (and lazy) imports automatically,
@@ -106,11 +127,19 @@ INCLUDED_DATA_DIRS: tuple[tuple[str, str], ...] = (
     ("logo", "logo"),
     ("i18n/locales", "i18n/locales"),
     ("gui/theme", "gui/theme"),
+    # WebView frontend HTML/CSS/JS — resolved via get_resource_path at the
+    # same relative path as in the source tree.
+    ("webview_ui", "webview_ui"),
 )
 
 INCLUDED_DATA_FILES: tuple[tuple[str, str], ...] = (
     ("LICENSE", "License.txt"),
     ("README.txt", "README.txt"),
+    # 서드파티 재배포 고지 — pywebview(BSD-3)·CustomTkinter(MIT) 코드와
+    # AutoEQ(MIT) 벤더링, OFL 폰트가 standalone에 번들되므로 고지 파일도
+    # 함께 실린다. (font/OFL-*.txt는 font 데이터 디렉토리에 이미 포함됨.)
+    ("THIRD_PARTY_LICENSES.md", "THIRD_PARTY_LICENSES.md"),
+    ("autoeq/LICENSE", "autoeq/LICENSE"),
 )
 
 
@@ -203,6 +232,8 @@ def build_nuitka_args(
 
     for pkg in INCLUDED_PACKAGES:
         args.append(f"--include-package={pkg}")
+    for pkg in INCLUDED_PACKAGE_DATA:
+        args.append(f"--include-package-data={pkg}")
     for mod in INCLUDED_MODULES:
         args.append(f"--include-module={mod}")
 

--- a/build_scripts/patch_nuitka_pywebview.py
+++ b/build_scripts/patch_nuitka_pywebview.py
@@ -1,0 +1,77 @@
+"""Nuitka pywebview 플러그인 화이트리스트 핫픽스.
+
+Nuitka(4.1.x, 2026-07 기준 upstream main 포함)의 내장 pywebview 플러그인은
+Windows에서 ``webview.platforms.{winforms,edgechromium,edgehtml,mshtml,cef}``
+만 포함하는 화이트리스트를 갖는데, pywebview 6.x의 winforms 백엔드는 헬퍼
+모듈 ``webview.platforms.win32``를 import한다. 화이트리스트에 이 항목이
+없으면 해당 모듈이 "actively excluded"로 번들에서 빠지고, 패키징된 앱이
+기동 시 ImportError를 맞아 CustomTkinter로 폴백한다(로컬 Windows 빌드에서
+관찰: "Module 'webview.platforms.win32' was actively excluded from Nuitka
+compilation").
+
+``--include-module=webview.platforms.win32``로는 해결할 수 없다 — 명시적
+include는 Nuitka의 follow 패턴에 들어가 플러그인의 제외 결정과 충돌해
+"Conflict between user and plugin decision" FATAL로 죽는다. 업스트림에
+항목이 추가될 때까지, 빌드 직전에 설치된 플러그인 파일의 화이트리스트에
+누락 모듈을 삽입한다. 이미 패치되었거나 업스트림이 고쳐진 경우 no-op.
+
+build_scripts/build_nuitka.py(릴리스 CI)와 build_scripts/build_local.py가
+Nuitka 호출 전에 이 모듈의 :func:`patch_pywebview_plugin`을 실행한다.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_ANCHOR = '"webview.platforms.winforms",'
+_MISSING_ENTRY = '"webview.platforms.win32",'
+
+
+def patch_source(text: str) -> tuple[str, str]:
+    """Return ``(patched_text, status)`` for the plugin source.
+
+    status is one of ``"patched"``, ``"already-ok"``, ``"anchor-missing"``.
+    """
+    if _MISSING_ENTRY in text:
+        return text, "already-ok"
+    if _ANCHOR not in text:
+        return text, "anchor-missing"
+    indent = text.split(_ANCHOR)[0].rsplit("\n", 1)[-1]
+    patched = text.replace(_ANCHOR, _ANCHOR + "\n" + indent + _MISSING_ENTRY, 1)
+    return patched, "patched"
+
+
+def patch_pywebview_plugin() -> bool:
+    """Patch the installed Nuitka plugin in place. Returns success."""
+    try:
+        import nuitka.plugins.standard as standard_plugins
+    except ImportError:
+        print("patch_nuitka_pywebview: nuitka is not installed; nothing to patch")
+        return False
+
+    plugin_path = Path(standard_plugins.__file__).parent / "PywebViewPlugin.py"
+    if not plugin_path.is_file():
+        print(f"patch_nuitka_pywebview: plugin file not found at {plugin_path}")
+        return False
+
+    text = plugin_path.read_text(encoding="utf-8")
+    patched, status = patch_source(text)
+    if status == "already-ok":
+        print("patch_nuitka_pywebview: webview.platforms.win32 already whitelisted")
+        return True
+    if status == "anchor-missing":
+        print(
+            "patch_nuitka_pywebview: WARNING — plugin layout changed, anchor "
+            f"{_ANCHOR!r} not found in {plugin_path}; skipping patch. If the "
+            "packaged app falls back to CustomTkinter on Windows, check "
+            "whether webview.platforms.win32 is still being excluded."
+        )
+        return False
+
+    plugin_path.write_text(patched, encoding="utf-8")
+    print(f"patch_nuitka_pywebview: whitelisted webview.platforms.win32 in {plugin_path}")
+    return True
+
+
+if __name__ == "__main__":
+    raise SystemExit(0 if patch_pywebview_plugin() else 1)

--- a/build_scripts/validate_webview_backend.py
+++ b/build_scripts/validate_webview_backend.py
@@ -1,0 +1,171 @@
+"""Validate the real pywebview backend on the current platform.
+
+Unlike ``build_scripts/webview_gallery.py`` (headless Chromium + mock bridge),
+this script drives the ACTUAL rendering engine pywebview selects for the
+platform — Edge WebView2 on Windows, WKWebView (cocoa) on macOS, WebKit2GTK on
+Linux — with the real :class:`impulcifer_webview.WebviewBridge` and the real
+``webview_ui/index.html``. It is the gate for shipping the WebView frontend in
+the Nuitka standalone builds: a platform whose job fails here must not default
+to the WebView frontend.
+
+Checks, in order:
+
+1. The window's document reaches ``readyState == "complete"``.
+2. The sidebar navigation rendered (>= 4 ``.nav-item[data-view]`` elements).
+3. ``boot()`` ran end-to-end: the brand badge shows the bridge-supplied
+   version, which requires a successful ``bootstrap()`` JS→Python roundtrip.
+4. A second explicit bridge roundtrip (``get_system_info``) resolves through
+   the backend's promise machinery and returns ``ok: true``.
+
+Exit codes: 0 = validated, 1 = a probe step failed, 2 = startup error,
+3 = watchdog timeout (GUI loop hang).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import threading
+import time
+import traceback
+from typing import Any, Callable
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _wait_js(
+    window: Any,
+    script: str,
+    predicate: Callable[[Any], bool],
+    timeout: float,
+    interval: float = 0.5,
+) -> Any:
+    """Poll ``evaluate_js(script)`` until ``predicate`` accepts the value."""
+    deadline = time.monotonic() + timeout
+    last: Any = None
+    while time.monotonic() < deadline:
+        try:
+            last = window.evaluate_js(script)
+        except Exception:
+            last = None
+        if predicate(last):
+            return last
+        time.sleep(interval)
+    raise TimeoutError(f"JS condition not met within {timeout:.0f}s: {script!r} (last={last!r})")
+
+
+def _probe(window: Any, results: dict[str, Any]) -> None:
+    """Run inside webview.start(): exercise DOM, boot() and the JS bridge."""
+    try:
+        _wait_js(window, "document.readyState", lambda v: v == "complete", 60)
+
+        nav_count = _wait_js(
+            window,
+            "document.querySelectorAll('.nav-item[data-view]').length",
+            lambda v: isinstance(v, (int, float)) and v >= 4,
+            30,
+        )
+
+        # boot() sets the brand badge from bootstrap()'s version — proving the
+        # pywebviewready event fired and the first bridge call succeeded. The
+        # HTML placeholder is "v—", so require a digit after the "v".
+        brand = _wait_js(
+            window,
+            "(document.getElementById('brand-version') || {}).textContent",
+            lambda v: isinstance(v, str) and len(v) > 1 and v[0] == "v" and v[1].isdigit(),
+            60,
+        )
+
+        # Explicit promise-based roundtrip through the backend's bridge.
+        window.evaluate_js(
+            "window.__impulciferProbe = null;"
+            "window.pywebview.api.get_system_info().then("
+            "  (r) => { window.__impulciferProbe = JSON.stringify(r); },"
+            "  (e) => { window.__impulciferProbe = JSON.stringify("
+            "    {ok: false, error: {message: String(e)}}); }"
+            ");"
+        )
+        raw = _wait_js(window, "window.__impulciferProbe", lambda v: bool(v), 60)
+        payload = json.loads(raw)
+        if not payload.get("ok"):
+            raise RuntimeError(f"bridge get_system_info() failed: {payload}")
+
+        results["ok"] = True
+        results["nav_count"] = int(nav_count)
+        results["brand"] = brand
+        results["info"] = payload["data"]
+    except Exception:
+        results["error"] = traceback.format_exc()
+    finally:
+        try:
+            window.destroy()
+        except Exception:
+            pass
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=240.0,
+        help="Hard watchdog in seconds; expiry force-exits with code 3.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        import webview
+
+        from impulcifer_webview import WebviewBridge, create_app_window, select_gui_backend
+    except Exception:
+        print("FATAL: could not import webview frontend modules", flush=True)
+        traceback.print_exc()
+        return 2
+
+    backend = select_gui_backend()
+    bridge = WebviewBridge()
+    window = create_app_window(webview, bridge)
+
+    # GUI event loops can hang without raising (e.g. missing system WebKit);
+    # a daemon watchdog guarantees the CI job fails fast instead of timing out.
+    def _watchdog() -> None:
+        time.sleep(args.timeout)
+        print(f"FATAL: watchdog expired after {args.timeout:.0f}s", flush=True)
+        os._exit(3)
+
+    threading.Thread(target=_watchdog, name="validate-watchdog", daemon=True).start()
+
+    results: dict[str, Any] = {}
+    try:
+        webview.start(_probe, (window, results), gui=backend, debug=False)
+    except Exception:
+        print(f"FATAL: webview.start(gui={backend!r}) raised", flush=True)
+        traceback.print_exc()
+        return 2
+
+    guilib = getattr(webview, "guilib", None)
+    guilib_name = getattr(guilib, "__name__", None) or repr(guilib)
+
+    if results.get("ok"):
+        info = results["info"]
+        print(
+            f"webview backend OK: gui={backend} guilib={guilib_name} "
+            f"nav_items={results['nav_count']} brand={results['brand']!r} "
+            f"version={info.get('version')} python={info.get('python_version')} "
+            f"os={info.get('os')!r}",
+            flush=True,
+        )
+        return 0
+
+    print(
+        f"webview backend FAILED: gui={backend} guilib={guilib_name}\n"
+        f"{results.get('error', 'probe did not run (window closed before probe?)')}",
+        flush=True,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/build_scripts/webview_gallery.py
+++ b/build_scripts/webview_gallery.py
@@ -31,8 +31,9 @@ VIEWS = ("recorder", "processing", "settings", "info")
 
 # 2 skins x 2 themes x 2 languages x 4 views + 3 busy-state shots
 # (studio checklist BRIR run, studio recording run, stable modal dialog)
-# + 2 failure shots (studio checklist abort, stable modal error).
-EXPECTED_SHOTS = len(SKINS) * len(LANGUAGES) * len(THEMES) * len(VIEWS) + 3 + 2
+# + 2 failure shots (studio checklist abort, stable modal error)
+# + 2 auto-update prompt shots (studio en, stable ko).
+EXPECTED_SHOTS = len(SKINS) * len(LANGUAGES) * len(THEMES) * len(VIEWS) + 3 + 2 + 2
 
 VIEWPORT_WIDTH = 1280
 MIN_HEIGHT = 860
@@ -161,6 +162,19 @@ def _mock_bridge_js(language: str, theme: str, scenario: str, version: str, skin
       next_seq: 6,
     }}),
     cancel_job: () => respond({{ job: runningJob(activeKind || "brir") }}),
+    check_for_updates: () => respond(SCENARIO === "update-available" ? {{
+      update_available: true,
+      current_version: VERSION,
+      latest_version: "99.0.0",
+      download_url: "https://github.com/115dkk/Impulcifer-pip313/releases/download/v99.0.0/Impulcifer-win-Setup.exe",
+      release_notes: "## 99.0.0 - 2026-07-12\\n\\n### Gallery placeholder release\\n\\n- Auto-update prompt review shot\\n- Release notes render in this scrollable box\\n- Buttons mirror the CTk UpdateDialog",
+      release_url: "https://github.com/115dkk/Impulcifer-pip313/releases/latest",
+    }} : {{
+      update_available: false, current_version: VERSION, latest_version: VERSION,
+      download_url: null, release_notes: null, release_url: null,
+    }}),
+    start_update: () => respond({{ job: runningJob("update") }}),
+    apply_pending_update: () => respond({{ restarting: true }}),
     set_language: (code) => respond({{ language: code, strings: STRINGS }}),
     set_theme: (theme) => respond({{ theme }}),
     set_skin: (skin) => respond({{ skin }}),
@@ -279,6 +293,19 @@ def render_gallery(out_dir: Path) -> list[Path]:
         page.wait_for_timeout(400)
         shots.append(_shoot(page, out_dir, "processing-stable-en-dark-failed"))
         context.close()
+
+        # Auto-update prompt (CTk UpdateDialog port): version line, release
+        # notes, Update Now / Remind / Skip. Triggered directly instead of
+        # waiting out boot()'s 2-second background-check timer.
+        for skin, language in (("studio", "en"), ("stable", "ko")):
+            context, page = _open_page(
+                browser, index_uri, language, "dark", "update-available", version, skin
+            )
+            page.evaluate("checkForUpdates(false)")
+            page.wait_for_selector("#update-modal:not([hidden])")
+            page.wait_for_timeout(200)
+            shots.append(_shoot(page, out_dir, f"update-{skin}-{language}-dark"))
+            context.close()
 
         browser.close()
     return shots

--- a/build_scripts/webview_gallery.py
+++ b/build_scripts/webview_gallery.py
@@ -95,7 +95,8 @@ def _mock_bridge_js(language: str, theme: str, scenario: str, version: str, skin
       platform: "windows",
       capabilities: {{ recording: true, brir: true, recording_cancel: false, brir_cancel: true }},
       active_job: activeKind ? runningJob(activeKind) : null,
-      ui: {{ language: LANGUAGE, theme: THEME, skin: SKIN, languages: LANGUAGES, strings: STRINGS }},
+      ui: {{ language: LANGUAGE, theme: THEME, skin: SKIN, frontend: "webview",
+             languages: LANGUAGES, strings: STRINGS }},
     }}),
     list_audio_devices: () => respond({{
       host_apis: ["Windows DirectSound", "MME", "Windows WASAPI"],
@@ -178,6 +179,7 @@ def _mock_bridge_js(language: str, theme: str, scenario: str, version: str, skin
     set_language: (code) => respond({{ language: code, strings: STRINGS }}),
     set_theme: (theme) => respond({{ theme }}),
     set_skin: (skin) => respond({{ skin }}),
+    set_frontend: (frontend) => respond({{ frontend }}),
     generate_sweep_set: () => respond({{ files: [], play_path: null }}),
     open_path: () => respond({{ path: "" }}),
     open_url: () => respond({{ url: "" }}),

--- a/font/OFL-JetBrainsMono.txt
+++ b/font/OFL-JetBrainsMono.txt
@@ -1,0 +1,93 @@
+Copyright 2020 The JetBrains Mono Project Authors (https://github.com/JetBrains/JetBrainsMono)
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+https://openfontlicense.org
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/font/OFL-Pretendard.txt
+++ b/font/OFL-Pretendard.txt
@@ -1,0 +1,104 @@
+Copyright (c) 2021, Kil Hyung-jin (https://github.com/orioncactus/pretendard),
+with Reserved Font Name 'Pretendard'.
+
+Copyright 2014-2021 Adobe (http://www.adobe.com/),
+with Reserved Font Name 'Source'.
+Source is a trademark of Adobe in the United States and/or other countries.
+
+Copyright (c) 2016 The Inter Project Authors (https://github.com/rsms/inter),
+with Reserved Font Name 'Inter'.
+
+Copyright 2021 The M+ FONTS Project Authors (https://github.com/coz-m/MPLUS_FONTS),
+with Reserved Font Name 'M PLUS 1'.
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+https://scripts.sil.org/OFL
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/gui/tabs/settings_tab.py
+++ b/gui/tabs/settings_tab.py
@@ -93,6 +93,54 @@ class SettingsTab:
             text_color="gray"
         ).grid(row=2, column=0, columnspan=2, sticky="w", padx=15, pady=(0, 15))
 
+        # === Frontend Section (gui_main launcher default) ===
+        frontend_frame = ctk.CTkFrame(scroll, corner_radius=0)
+        frontend_frame.grid(row=row, column=0, sticky="ew", padx=10, pady=10)
+        frontend_frame.grid_columnconfigure(1, weight=1)
+        row += 1
+
+        ctk.CTkLabel(
+            frontend_frame,
+            text=self.loc.get('section_frontend'),
+            font=self.fonts['heading']
+        ).grid(row=0, column=0, columnspan=2, sticky="w", padx=15, pady=(15, 10))
+
+        ctk.CTkLabel(
+            frontend_frame,
+            text=self.loc.get('label_frontend')
+        ).grid(row=1, column=0, sticky="w", padx=15, pady=5)
+
+        webview_label = self.loc.get('option_frontend_webview')
+        ctk_label = self.loc.get('option_frontend_ctk')
+        self._frontend_label_map = {webview_label: 'webview', ctk_label: 'ctk'}
+        self._frontend_code_map = {v: k for k, v in self._frontend_label_map.items()}
+        self.frontend_var = ctk.StringVar(
+            value=self._frontend_code_map.get(self.loc.get_frontend(), webview_label)
+        )
+        frontend_segment = ctk.CTkSegmentedButton(
+            frontend_frame,
+            values=[webview_label, ctk_label],
+            variable=self.frontend_var,
+            command=self.change_frontend,
+        )
+        frontend_segment.grid(row=1, column=1, sticky="ew", padx=15, pady=5)
+
+        ctk.CTkLabel(
+            frontend_frame,
+            text=self.loc.get('tooltip_frontend'),
+            font=self.fonts['small'],
+            text_color="gray",
+        ).grid(row=2, column=0, columnspan=2, sticky="w", padx=15, pady=(0, 5))
+
+        ctk.CTkLabel(
+            frontend_frame,
+            text=self.loc.get('label_ctk_deprecation'),
+            font=self.fonts['small'],
+            text_color="gray",
+            wraplength=560,
+            justify="left",
+        ).grid(row=3, column=0, columnspan=2, sticky="w", padx=15, pady=(0, 15))
+
         # === Language Section ===
         lang_frame = ctk.CTkFrame(scroll, corner_radius=0)
         lang_frame.grid(row=row, column=0, sticky="ew", padx=10, pady=10)
@@ -202,6 +250,11 @@ class SettingsTab:
                 self.loc.get('message_info'),
                 self.loc.get('message_language_changed', language=language_name)
             )
+
+    def change_frontend(self, frontend_label: str) -> None:
+        """Persist the gui_main launcher default; applies from the next launch."""
+        code = self._frontend_label_map.get(frontend_label, 'webview')
+        self.loc.set_frontend(code)
 
     def change_skin(self, skin_label: str) -> None:
         """Publish a skin change event.

--- a/gui_main.py
+++ b/gui_main.py
@@ -5,9 +5,9 @@
 기본값은 WebView 프론트엔드다(2.10+, 바로가기/Velopack 실행 포함).
 CustomTkinter는 ``--frontend=ctk`` 또는 설정(~/.impulcifer/settings.json의
 ``frontend`` 키)으로 계속 사용할 수 있으며, 버전 2 동안 유지보수와 기능
-추가를 포함해 완전히 지원된다(버전 3에서 제거 예정). WebView 스택을 쓸 수
-없는 환경(pywebview 미설치, 시스템 WebKit 부재 등)에서는 자동으로
-CustomTkinter로 폴백한다.
+추가를 포함해 완전히 지원된다(버전 3부터는 지금의 레거시 GUI처럼 업데이트
+없이 동결 유지 — 제거 아님). WebView 스택을 쓸 수 없는 환경(pywebview
+미설치, 시스템 WebKit 부재 등)에서는 자동으로 CustomTkinter로 폴백한다.
 """
 
 import sys

--- a/gui_main.py
+++ b/gui_main.py
@@ -1,6 +1,14 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-"""Impulcifer Modern GUI 엔트리 포인트"""
+"""Impulcifer GUI 엔트리 포인트 (launcher).
+
+기본값은 WebView 프론트엔드다(2.10+, 바로가기/Velopack 실행 포함).
+CustomTkinter는 ``--frontend=ctk`` 또는 설정(~/.impulcifer/settings.json의
+``frontend`` 키)으로 계속 사용할 수 있으며, 버전 2 동안 유지보수와 기능
+추가를 포함해 완전히 지원된다(버전 3에서 제거 예정). WebView 스택을 쓸 수
+없는 환경(pywebview 미설치, 시스템 WebKit 부재 등)에서는 자동으로
+CustomTkinter로 폴백한다.
+"""
 
 import sys
 
@@ -58,7 +66,7 @@ def _smoke_test():
     prefer_distribution_root()
     import importlib
 
-    for mod in (
+    smoke_modules = (
         "gui.modern_gui",
         "gui.tabs.impulcifer_tab",
         "gui.tabs.recorder_tab",
@@ -80,8 +88,25 @@ def _smoke_test():
         "updater.update_checker",
         "updater.updater_core",
         "infra.logger",
-    ):
+        # WebView frontend stack (default since 2.10). ``webview`` proves
+        # pywebview and its backend shims survived the Nuitka trim.
+        "webview",
+        "application.impulcifer_service",
+        "impulcifer_webview",
+    )
+    for mod in smoke_modules:
         importlib.import_module(mod)
+
+    # WebView UI assets — without index.html the default frontend would
+    # silently fall back to CustomTkinter on every launch.
+    import os as os_mod
+
+    from infra.resource_helper import get_resource_path
+
+    index_html = get_resource_path("webview_ui/index.html")
+    if not os_mod.path.isfile(index_html):
+        print(f"smoke-test FAIL: webview_ui/index.html missing from bundle ({index_html})")
+        sys.exit(2)
 
     # Pulse redesign assets — verify the bundle ships logo + CTk theme JSON.
     # If a packaging change drops these, the GUI silently falls back to a
@@ -172,9 +197,53 @@ def _smoke_test():
         tk_root.destroy()
 
     print(
-        f"smoke-test OK (imports=18, font.matplotlib={result['source']}, "
+        f"smoke-test OK (imports={len(smoke_modules)}, "
+        f"font.matplotlib={result['source']}, "
         f"font.gui={gui_family!r}, font.path={result['path']})"
     )
+
+
+def _resolve_frontend() -> str:
+    """Pick the frontend: CLI flag > persisted setting > webview default."""
+    for arg in sys.argv[1:]:
+        if arg.startswith("--frontend="):
+            value = arg.split("=", 1)[1].strip().lower()
+            if value in ("webview", "ctk"):
+                return value
+            print(f"Unknown --frontend value {value!r}; using 'webview'.")
+            return "webview"
+    try:
+        from i18n.localization import get_localization_manager
+
+        return get_localization_manager().get_frontend()
+    except Exception:
+        return "webview"
+
+
+def _launch_frontend() -> None:
+    frontend = _resolve_frontend()
+    if frontend == "webview":
+        try:
+            import webview  # noqa: F401
+            from impulcifer_webview import main as webview_main, select_gui_backend
+
+            select_gui_backend()
+        except (SystemExit, Exception) as exc:
+            # SystemExit comes from select_gui_backend on unsupported
+            # platforms; ImportError from a missing pywebview install.
+            print(f"WebView frontend unavailable ({exc}); falling back to CustomTkinter.")
+        else:
+            try:
+                webview_main()
+                return
+            except Exception as exc:
+                # Backend initialization can fail inside webview.start()
+                # (missing WebView2 runtime / system WebKit). Fall back so a
+                # broken WebView stack never leaves the user with nothing.
+                print(f"WebView frontend failed to start ({exc}); falling back to CustomTkinter.")
+    from gui.modern_gui import main_gui
+
+    main_gui()
 
 
 if __name__ == "__main__":
@@ -183,5 +252,4 @@ if __name__ == "__main__":
         _smoke_test()
         sys.exit(0)
     prefer_distribution_root()
-    from gui.modern_gui import main_gui
-    main_gui()
+    _launch_frontend()

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -385,5 +385,5 @@
   "option_frontend_webview": "WebView (recommended)",
   "option_frontend_ctk": "CustomTkinter (legacy)",
   "tooltip_frontend": "Which interface opens when the app starts. Takes effect on the next launch.",
-  "label_ctk_deprecation": "Notice: the CustomTkinter interface is planned for removal in version 3. It remains fully supported — including new features — for the rest of version 2. WebView is the new default interface."
+  "label_ctk_deprecation": "Notice: the CustomTkinter interface remains fully supported — including new features — for the rest of version 2. From version 3 it will be kept as a frozen legacy interface without further updates (only the old legacy GUI is removed in version 3). WebView is the new default interface."
 }

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -379,5 +379,11 @@
   "webview_status_cancel_requested": "Cancelling…",
   "button_check_updates": "Check for Updates",
   "update_checking": "Checking for updates...",
-  "update_up_to_date": "You are up to date (latest: {latest})."
+  "update_up_to_date": "You are up to date (latest: {latest}).",
+  "section_frontend": "Interface",
+  "label_frontend": "Default interface:",
+  "option_frontend_webview": "WebView (recommended)",
+  "option_frontend_ctk": "CustomTkinter (legacy)",
+  "tooltip_frontend": "Which interface opens when the app starts. Takes effect on the next launch.",
+  "label_ctk_deprecation": "Notice: the CustomTkinter interface is planned for removal in version 3. It remains fully supported — including new features — for the rest of version 2. WebView is the new default interface."
 }

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -376,5 +376,8 @@
   "webview_status_succeeded": "Completed",
   "webview_status_failed": "Failed",
   "webview_status_cancelled": "Cancelled",
-  "webview_status_cancel_requested": "Cancelling…"
+  "webview_status_cancel_requested": "Cancelling…",
+  "button_check_updates": "Check for Updates",
+  "update_checking": "Checking for updates...",
+  "update_up_to_date": "You are up to date (latest: {latest})."
 }

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -385,5 +385,5 @@
   "option_frontend_webview": "WebView (recommended)",
   "option_frontend_ctk": "CustomTkinter (legacy)",
   "tooltip_frontend": "Which interface opens when the app starts. Takes effect on the next launch.",
-  "label_ctk_deprecation": "Notice: the CustomTkinter interface is planned for removal in version 3. It remains fully supported — including new features — for the rest of version 2. WebView is the new default interface."
+  "label_ctk_deprecation": "Notice: the CustomTkinter interface remains fully supported — including new features — for the rest of version 2. From version 3 it will be kept as a frozen legacy interface without further updates (only the old legacy GUI is removed in version 3). WebView is the new default interface."
 }

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -379,5 +379,11 @@
   "webview_status_cancel_requested": "Cancelling…",
   "button_check_updates": "Check for Updates",
   "update_checking": "Checking for updates...",
-  "update_up_to_date": "You are up to date (latest: {latest})."
+  "update_up_to_date": "You are up to date (latest: {latest}).",
+  "section_frontend": "Interface",
+  "label_frontend": "Default interface:",
+  "option_frontend_webview": "WebView (recommended)",
+  "option_frontend_ctk": "CustomTkinter (legacy)",
+  "tooltip_frontend": "Which interface opens when the app starts. Takes effect on the next launch.",
+  "label_ctk_deprecation": "Notice: the CustomTkinter interface is planned for removal in version 3. It remains fully supported — including new features — for the rest of version 2. WebView is the new default interface."
 }

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -376,5 +376,8 @@
   "webview_status_succeeded": "Completed",
   "webview_status_failed": "Failed",
   "webview_status_cancelled": "Cancelled",
-  "webview_status_cancel_requested": "Cancelling…"
+  "webview_status_cancel_requested": "Cancelling…",
+  "button_check_updates": "Check for Updates",
+  "update_checking": "Checking for updates...",
+  "update_up_to_date": "You are up to date (latest: {latest})."
 }

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -385,5 +385,5 @@
   "option_frontend_webview": "WebView (recommended)",
   "option_frontend_ctk": "CustomTkinter (legacy)",
   "tooltip_frontend": "Which interface opens when the app starts. Takes effect on the next launch.",
-  "label_ctk_deprecation": "Notice: the CustomTkinter interface is planned for removal in version 3. It remains fully supported — including new features — for the rest of version 2. WebView is the new default interface."
+  "label_ctk_deprecation": "Notice: the CustomTkinter interface remains fully supported — including new features — for the rest of version 2. From version 3 it will be kept as a frozen legacy interface without further updates (only the old legacy GUI is removed in version 3). WebView is the new default interface."
 }

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -379,5 +379,11 @@
   "webview_status_cancel_requested": "Cancelling…",
   "button_check_updates": "Check for Updates",
   "update_checking": "Checking for updates...",
-  "update_up_to_date": "You are up to date (latest: {latest})."
+  "update_up_to_date": "You are up to date (latest: {latest}).",
+  "section_frontend": "Interface",
+  "label_frontend": "Default interface:",
+  "option_frontend_webview": "WebView (recommended)",
+  "option_frontend_ctk": "CustomTkinter (legacy)",
+  "tooltip_frontend": "Which interface opens when the app starts. Takes effect on the next launch.",
+  "label_ctk_deprecation": "Notice: the CustomTkinter interface is planned for removal in version 3. It remains fully supported — including new features — for the rest of version 2. WebView is the new default interface."
 }

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -376,5 +376,8 @@
   "webview_status_succeeded": "Completed",
   "webview_status_failed": "Failed",
   "webview_status_cancelled": "Cancelled",
-  "webview_status_cancel_requested": "Cancelling…"
+  "webview_status_cancel_requested": "Cancelling…",
+  "button_check_updates": "Check for Updates",
+  "update_checking": "Checking for updates...",
+  "update_up_to_date": "You are up to date (latest: {latest})."
 }

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -385,5 +385,5 @@
   "option_frontend_webview": "WebView (recommended)",
   "option_frontend_ctk": "CustomTkinter (legacy)",
   "tooltip_frontend": "Which interface opens when the app starts. Takes effect on the next launch.",
-  "label_ctk_deprecation": "Notice: the CustomTkinter interface is planned for removal in version 3. It remains fully supported — including new features — for the rest of version 2. WebView is the new default interface."
+  "label_ctk_deprecation": "Notice: the CustomTkinter interface remains fully supported — including new features — for the rest of version 2. From version 3 it will be kept as a frozen legacy interface without further updates (only the old legacy GUI is removed in version 3). WebView is the new default interface."
 }

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -379,5 +379,11 @@
   "webview_status_cancel_requested": "Cancelling…",
   "button_check_updates": "Check for Updates",
   "update_checking": "Checking for updates...",
-  "update_up_to_date": "You are up to date (latest: {latest})."
+  "update_up_to_date": "You are up to date (latest: {latest}).",
+  "section_frontend": "Interface",
+  "label_frontend": "Default interface:",
+  "option_frontend_webview": "WebView (recommended)",
+  "option_frontend_ctk": "CustomTkinter (legacy)",
+  "tooltip_frontend": "Which interface opens when the app starts. Takes effect on the next launch.",
+  "label_ctk_deprecation": "Notice: the CustomTkinter interface is planned for removal in version 3. It remains fully supported — including new features — for the rest of version 2. WebView is the new default interface."
 }

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -376,5 +376,8 @@
   "webview_status_succeeded": "Completed",
   "webview_status_failed": "Failed",
   "webview_status_cancelled": "Cancelled",
-  "webview_status_cancel_requested": "Cancelling…"
+  "webview_status_cancel_requested": "Cancelling…",
+  "button_check_updates": "Check for Updates",
+  "update_checking": "Checking for updates...",
+  "update_up_to_date": "You are up to date (latest: {latest})."
 }

--- a/i18n/locales/ja.json
+++ b/i18n/locales/ja.json
@@ -385,5 +385,5 @@
   "option_frontend_webview": "WebView (recommended)",
   "option_frontend_ctk": "CustomTkinter (legacy)",
   "tooltip_frontend": "Which interface opens when the app starts. Takes effect on the next launch.",
-  "label_ctk_deprecation": "Notice: the CustomTkinter interface is planned for removal in version 3. It remains fully supported — including new features — for the rest of version 2. WebView is the new default interface."
+  "label_ctk_deprecation": "Notice: the CustomTkinter interface remains fully supported — including new features — for the rest of version 2. From version 3 it will be kept as a frozen legacy interface without further updates (only the old legacy GUI is removed in version 3). WebView is the new default interface."
 }

--- a/i18n/locales/ja.json
+++ b/i18n/locales/ja.json
@@ -379,5 +379,11 @@
   "webview_status_cancel_requested": "Cancelling…",
   "button_check_updates": "Check for Updates",
   "update_checking": "Checking for updates...",
-  "update_up_to_date": "You are up to date (latest: {latest})."
+  "update_up_to_date": "You are up to date (latest: {latest}).",
+  "section_frontend": "Interface",
+  "label_frontend": "Default interface:",
+  "option_frontend_webview": "WebView (recommended)",
+  "option_frontend_ctk": "CustomTkinter (legacy)",
+  "tooltip_frontend": "Which interface opens when the app starts. Takes effect on the next launch.",
+  "label_ctk_deprecation": "Notice: the CustomTkinter interface is planned for removal in version 3. It remains fully supported — including new features — for the rest of version 2. WebView is the new default interface."
 }

--- a/i18n/locales/ja.json
+++ b/i18n/locales/ja.json
@@ -376,5 +376,8 @@
   "webview_status_succeeded": "Completed",
   "webview_status_failed": "Failed",
   "webview_status_cancelled": "Cancelled",
-  "webview_status_cancel_requested": "Cancelling…"
+  "webview_status_cancel_requested": "Cancelling…",
+  "button_check_updates": "Check for Updates",
+  "update_checking": "Checking for updates...",
+  "update_up_to_date": "You are up to date (latest: {latest})."
 }

--- a/i18n/locales/ko.json
+++ b/i18n/locales/ko.json
@@ -376,5 +376,8 @@
   "webview_status_succeeded": "완료",
   "webview_status_failed": "실패",
   "webview_status_cancelled": "취소됨",
-  "webview_status_cancel_requested": "취소 요청됨…"
+  "webview_status_cancel_requested": "취소 요청됨…",
+  "button_check_updates": "업데이트 확인",
+  "update_checking": "업데이트 확인 중...",
+  "update_up_to_date": "이미 최신 버전입니다 (최신: {latest})."
 }

--- a/i18n/locales/ko.json
+++ b/i18n/locales/ko.json
@@ -379,5 +379,11 @@
   "webview_status_cancel_requested": "취소 요청됨…",
   "button_check_updates": "업데이트 확인",
   "update_checking": "업데이트 확인 중...",
-  "update_up_to_date": "이미 최신 버전입니다 (최신: {latest})."
+  "update_up_to_date": "이미 최신 버전입니다 (최신: {latest}).",
+  "section_frontend": "인터페이스",
+  "label_frontend": "기본 인터페이스:",
+  "option_frontend_webview": "WebView (권장)",
+  "option_frontend_ctk": "CustomTkinter (레거시)",
+  "tooltip_frontend": "앱 시작 시 열리는 인터페이스입니다. 다음 실행부터 적용됩니다.",
+  "label_ctk_deprecation": "안내: CustomTkinter 인터페이스는 버전 3에서 제거될 예정입니다. 버전 2 동안에는 기능 추가를 포함해 계속 완전히 지원됩니다. 새 기본 인터페이스는 WebView입니다."
 }

--- a/i18n/locales/ko.json
+++ b/i18n/locales/ko.json
@@ -385,5 +385,5 @@
   "option_frontend_webview": "WebView (권장)",
   "option_frontend_ctk": "CustomTkinter (레거시)",
   "tooltip_frontend": "앱 시작 시 열리는 인터페이스입니다. 다음 실행부터 적용됩니다.",
-  "label_ctk_deprecation": "안내: CustomTkinter 인터페이스는 버전 3에서 제거될 예정입니다. 버전 2 동안에는 기능 추가를 포함해 계속 완전히 지원됩니다. 새 기본 인터페이스는 WebView입니다."
+  "label_ctk_deprecation": "안내: CustomTkinter 인터페이스는 버전 2 동안 기능 추가를 포함해 계속 완전히 지원됩니다. 버전 3부터는 지금의 레거시 GUI처럼 업데이트 없이 동결 상태로 유지됩니다(버전 3에서 제거되는 것은 구버전 레거시 GUI뿐입니다). 새 기본 인터페이스는 WebView입니다."
 }

--- a/i18n/locales/ru.json
+++ b/i18n/locales/ru.json
@@ -385,5 +385,5 @@
   "option_frontend_webview": "WebView (recommended)",
   "option_frontend_ctk": "CustomTkinter (legacy)",
   "tooltip_frontend": "Which interface opens when the app starts. Takes effect on the next launch.",
-  "label_ctk_deprecation": "Notice: the CustomTkinter interface is planned for removal in version 3. It remains fully supported — including new features — for the rest of version 2. WebView is the new default interface."
+  "label_ctk_deprecation": "Notice: the CustomTkinter interface remains fully supported — including new features — for the rest of version 2. From version 3 it will be kept as a frozen legacy interface without further updates (only the old legacy GUI is removed in version 3). WebView is the new default interface."
 }

--- a/i18n/locales/ru.json
+++ b/i18n/locales/ru.json
@@ -379,5 +379,11 @@
   "webview_status_cancel_requested": "Cancelling…",
   "button_check_updates": "Check for Updates",
   "update_checking": "Checking for updates...",
-  "update_up_to_date": "You are up to date (latest: {latest})."
+  "update_up_to_date": "You are up to date (latest: {latest}).",
+  "section_frontend": "Interface",
+  "label_frontend": "Default interface:",
+  "option_frontend_webview": "WebView (recommended)",
+  "option_frontend_ctk": "CustomTkinter (legacy)",
+  "tooltip_frontend": "Which interface opens when the app starts. Takes effect on the next launch.",
+  "label_ctk_deprecation": "Notice: the CustomTkinter interface is planned for removal in version 3. It remains fully supported — including new features — for the rest of version 2. WebView is the new default interface."
 }

--- a/i18n/locales/ru.json
+++ b/i18n/locales/ru.json
@@ -376,5 +376,8 @@
   "webview_status_succeeded": "Completed",
   "webview_status_failed": "Failed",
   "webview_status_cancelled": "Cancelled",
-  "webview_status_cancel_requested": "Cancelling…"
+  "webview_status_cancel_requested": "Cancelling…",
+  "button_check_updates": "Check for Updates",
+  "update_checking": "Checking for updates...",
+  "update_up_to_date": "You are up to date (latest: {latest})."
 }

--- a/i18n/locales/zh-cn.json
+++ b/i18n/locales/zh-cn.json
@@ -385,5 +385,5 @@
   "option_frontend_webview": "WebView (recommended)",
   "option_frontend_ctk": "CustomTkinter (legacy)",
   "tooltip_frontend": "Which interface opens when the app starts. Takes effect on the next launch.",
-  "label_ctk_deprecation": "Notice: the CustomTkinter interface is planned for removal in version 3. It remains fully supported — including new features — for the rest of version 2. WebView is the new default interface."
+  "label_ctk_deprecation": "Notice: the CustomTkinter interface remains fully supported — including new features — for the rest of version 2. From version 3 it will be kept as a frozen legacy interface without further updates (only the old legacy GUI is removed in version 3). WebView is the new default interface."
 }

--- a/i18n/locales/zh-cn.json
+++ b/i18n/locales/zh-cn.json
@@ -379,5 +379,11 @@
   "webview_status_cancel_requested": "Cancelling…",
   "button_check_updates": "Check for Updates",
   "update_checking": "Checking for updates...",
-  "update_up_to_date": "You are up to date (latest: {latest})."
+  "update_up_to_date": "You are up to date (latest: {latest}).",
+  "section_frontend": "Interface",
+  "label_frontend": "Default interface:",
+  "option_frontend_webview": "WebView (recommended)",
+  "option_frontend_ctk": "CustomTkinter (legacy)",
+  "tooltip_frontend": "Which interface opens when the app starts. Takes effect on the next launch.",
+  "label_ctk_deprecation": "Notice: the CustomTkinter interface is planned for removal in version 3. It remains fully supported — including new features — for the rest of version 2. WebView is the new default interface."
 }

--- a/i18n/locales/zh-cn.json
+++ b/i18n/locales/zh-cn.json
@@ -376,5 +376,8 @@
   "webview_status_succeeded": "Completed",
   "webview_status_failed": "Failed",
   "webview_status_cancelled": "Cancelled",
-  "webview_status_cancel_requested": "Cancelling…"
+  "webview_status_cancel_requested": "Cancelling…",
+  "button_check_updates": "Check for Updates",
+  "update_checking": "Checking for updates...",
+  "update_up_to_date": "You are up to date (latest: {latest})."
 }

--- a/i18n/locales/zh-tw.json
+++ b/i18n/locales/zh-tw.json
@@ -385,5 +385,5 @@
   "option_frontend_webview": "WebView (recommended)",
   "option_frontend_ctk": "CustomTkinter (legacy)",
   "tooltip_frontend": "Which interface opens when the app starts. Takes effect on the next launch.",
-  "label_ctk_deprecation": "Notice: the CustomTkinter interface is planned for removal in version 3. It remains fully supported — including new features — for the rest of version 2. WebView is the new default interface."
+  "label_ctk_deprecation": "Notice: the CustomTkinter interface remains fully supported — including new features — for the rest of version 2. From version 3 it will be kept as a frozen legacy interface without further updates (only the old legacy GUI is removed in version 3). WebView is the new default interface."
 }

--- a/i18n/locales/zh-tw.json
+++ b/i18n/locales/zh-tw.json
@@ -379,5 +379,11 @@
   "webview_status_cancel_requested": "Cancelling…",
   "button_check_updates": "Check for Updates",
   "update_checking": "Checking for updates...",
-  "update_up_to_date": "You are up to date (latest: {latest})."
+  "update_up_to_date": "You are up to date (latest: {latest}).",
+  "section_frontend": "Interface",
+  "label_frontend": "Default interface:",
+  "option_frontend_webview": "WebView (recommended)",
+  "option_frontend_ctk": "CustomTkinter (legacy)",
+  "tooltip_frontend": "Which interface opens when the app starts. Takes effect on the next launch.",
+  "label_ctk_deprecation": "Notice: the CustomTkinter interface is planned for removal in version 3. It remains fully supported — including new features — for the rest of version 2. WebView is the new default interface."
 }

--- a/i18n/locales/zh-tw.json
+++ b/i18n/locales/zh-tw.json
@@ -376,5 +376,8 @@
   "webview_status_succeeded": "Completed",
   "webview_status_failed": "Failed",
   "webview_status_cancelled": "Cancelled",
-  "webview_status_cancel_requested": "Cancelling…"
+  "webview_status_cancel_requested": "Cancelling…",
+  "button_check_updates": "Check for Updates",
+  "update_checking": "Checking for updates...",
+  "update_up_to_date": "You are up to date (latest: {latest})."
 }

--- a/i18n/locales/zh_CN.json
+++ b/i18n/locales/zh_CN.json
@@ -385,5 +385,5 @@
   "option_frontend_webview": "WebView (recommended)",
   "option_frontend_ctk": "CustomTkinter (legacy)",
   "tooltip_frontend": "Which interface opens when the app starts. Takes effect on the next launch.",
-  "label_ctk_deprecation": "Notice: the CustomTkinter interface is planned for removal in version 3. It remains fully supported — including new features — for the rest of version 2. WebView is the new default interface."
+  "label_ctk_deprecation": "Notice: the CustomTkinter interface remains fully supported — including new features — for the rest of version 2. From version 3 it will be kept as a frozen legacy interface without further updates (only the old legacy GUI is removed in version 3). WebView is the new default interface."
 }

--- a/i18n/locales/zh_CN.json
+++ b/i18n/locales/zh_CN.json
@@ -379,5 +379,11 @@
   "webview_status_cancel_requested": "Cancelling…",
   "button_check_updates": "Check for Updates",
   "update_checking": "Checking for updates...",
-  "update_up_to_date": "You are up to date (latest: {latest})."
+  "update_up_to_date": "You are up to date (latest: {latest}).",
+  "section_frontend": "Interface",
+  "label_frontend": "Default interface:",
+  "option_frontend_webview": "WebView (recommended)",
+  "option_frontend_ctk": "CustomTkinter (legacy)",
+  "tooltip_frontend": "Which interface opens when the app starts. Takes effect on the next launch.",
+  "label_ctk_deprecation": "Notice: the CustomTkinter interface is planned for removal in version 3. It remains fully supported — including new features — for the rest of version 2. WebView is the new default interface."
 }

--- a/i18n/locales/zh_CN.json
+++ b/i18n/locales/zh_CN.json
@@ -376,5 +376,8 @@
   "webview_status_succeeded": "Completed",
   "webview_status_failed": "Failed",
   "webview_status_cancelled": "Cancelled",
-  "webview_status_cancel_requested": "Cancelling…"
+  "webview_status_cancel_requested": "Cancelling…",
+  "button_check_updates": "Check for Updates",
+  "update_checking": "Checking for updates...",
+  "update_up_to_date": "You are up to date (latest: {latest})."
 }

--- a/i18n/locales/zh_TW.json
+++ b/i18n/locales/zh_TW.json
@@ -385,5 +385,5 @@
   "option_frontend_webview": "WebView (recommended)",
   "option_frontend_ctk": "CustomTkinter (legacy)",
   "tooltip_frontend": "Which interface opens when the app starts. Takes effect on the next launch.",
-  "label_ctk_deprecation": "Notice: the CustomTkinter interface is planned for removal in version 3. It remains fully supported — including new features — for the rest of version 2. WebView is the new default interface."
+  "label_ctk_deprecation": "Notice: the CustomTkinter interface remains fully supported — including new features — for the rest of version 2. From version 3 it will be kept as a frozen legacy interface without further updates (only the old legacy GUI is removed in version 3). WebView is the new default interface."
 }

--- a/i18n/locales/zh_TW.json
+++ b/i18n/locales/zh_TW.json
@@ -379,5 +379,11 @@
   "webview_status_cancel_requested": "Cancelling…",
   "button_check_updates": "Check for Updates",
   "update_checking": "Checking for updates...",
-  "update_up_to_date": "You are up to date (latest: {latest})."
+  "update_up_to_date": "You are up to date (latest: {latest}).",
+  "section_frontend": "Interface",
+  "label_frontend": "Default interface:",
+  "option_frontend_webview": "WebView (recommended)",
+  "option_frontend_ctk": "CustomTkinter (legacy)",
+  "tooltip_frontend": "Which interface opens when the app starts. Takes effect on the next launch.",
+  "label_ctk_deprecation": "Notice: the CustomTkinter interface is planned for removal in version 3. It remains fully supported — including new features — for the rest of version 2. WebView is the new default interface."
 }

--- a/i18n/locales/zh_TW.json
+++ b/i18n/locales/zh_TW.json
@@ -376,5 +376,8 @@
   "webview_status_succeeded": "Completed",
   "webview_status_failed": "Failed",
   "webview_status_cancelled": "Cancelled",
-  "webview_status_cancel_requested": "Cancelling…"
+  "webview_status_cancel_requested": "Cancelling…",
+  "button_check_updates": "Check for Updates",
+  "update_checking": "Checking for updates...",
+  "update_up_to_date": "You are up to date (latest: {latest})."
 }

--- a/i18n/localization.py
+++ b/i18n/localization.py
@@ -255,7 +255,8 @@ class LocalizationManager:
         ``webview`` is the platform WebView frontend (the default since
         2.10); ``ctk`` keeps the CustomTkinter interface, which stays fully
         supported (maintenance and new features) for the rest of version 2
-        and is planned for removal in version 3.
+        and is kept as a frozen legacy interface from version 3 on (only the
+        old legacy GUI is removed in version 3).
         """
         if frontend not in ('webview', 'ctk'):
             frontend = 'webview'

--- a/i18n/localization.py
+++ b/i18n/localization.py
@@ -249,6 +249,23 @@ class LocalizationManager:
         """Return the persisted skin choice (default ``stable``)."""
         return self.settings.get('skin', 'stable')
 
+    def set_frontend(self, frontend: str):
+        """Persist which GUI frontend gui_main launches by default.
+
+        ``webview`` is the platform WebView frontend (the default since
+        2.10); ``ctk`` keeps the CustomTkinter interface, which stays fully
+        supported (maintenance and new features) for the rest of version 2
+        and is planned for removal in version 3.
+        """
+        if frontend not in ('webview', 'ctk'):
+            frontend = 'webview'
+        self.settings['frontend'] = frontend
+        self.save_settings()
+
+    def get_frontend(self) -> str:
+        """Return the persisted frontend choice (default ``webview``)."""
+        return self.settings.get('frontend', 'webview')
+
     def is_first_run(self) -> bool:
         """Check if this is the first run (no language setting)"""
         return 'language' not in self.settings or not self.settings.get('language_selected', False)

--- a/impulcifer_webview.py
+++ b/impulcifer_webview.py
@@ -106,6 +106,9 @@ class WebviewBridge:
     def set_skin(self, skin: str) -> dict[str, Any]:
         return self._service.set_skin(skin)
 
+    def set_frontend(self, frontend: str) -> dict[str, Any]:
+        return self._service.set_frontend(frontend)
+
     def get_system_info(self) -> dict[str, Any]:
         return self._service.get_system_info()
 

--- a/impulcifer_webview.py
+++ b/impulcifer_webview.py
@@ -123,6 +123,24 @@ class WebviewBridge:
     def open_path(self, path: Any = None) -> dict[str, Any]:
         return self._service.open_path(path)
 
+    def check_for_updates(self) -> dict[str, Any]:
+        return self._service.check_for_updates()
+
+    def start_update(self, request: dict[str, Any]) -> dict[str, Any]:
+        return self._service.start_update(request)
+
+    def apply_pending_update(self) -> dict[str, Any]:
+        response = self._service.apply_pending_update()
+        restarting = bool(response.get("ok") and response["data"].get("restarting"))
+        if restarting and self._window is not None:
+            # Update.exe has taken over; give the JS caller a moment to
+            # receive this response, then close the window so main() returns
+            # and the old process exits for the restart.
+            import threading
+
+            threading.Timer(0.8, self._window.destroy).start()
+        return response
+
     def select_file(self, kind: str = "audio") -> dict[str, Any]:
         return self._create_file_dialog("open", kind)
 

--- a/impulcifer_webview.py
+++ b/impulcifer_webview.py
@@ -20,6 +20,27 @@ _FILE_DIALOG_FILTERS: dict[str, tuple[str, ...]] = {
     "wav": ("WAV files (*.wav)", "All files (*.*)"),
 }
 
+# platform.system() → forced pywebview GUI backend. Forcing keeps startup
+# deterministic (pywebview would otherwise prefer Qt inside a KDE session) and
+# pins exactly the three engines that webview-backend-validation.yml verifies.
+_GUI_BACKENDS: dict[str, str] = {
+    "Windows": "edgechromium",  # Microsoft Edge WebView2
+    "Darwin": "cocoa",  # WKWebView
+    "Linux": "gtk",  # WebKit2GTK
+}
+
+
+def select_gui_backend() -> str:
+    """Return the pywebview ``gui=`` value for the current platform."""
+    backend = _GUI_BACKENDS.get(platform.system())
+    if backend is None:
+        raise SystemExit(
+            "The WebView frontend does not support this platform: "
+            f"{platform.system() or 'unknown'}."
+        )
+    return backend
+
+
 # open_url() is allowlist-only so the JS side can never navigate the host
 # browser to an arbitrary address.
 _PROJECT_URLS = {
@@ -53,7 +74,10 @@ class WebviewBridge:
         self._window = window
 
     def bootstrap(self) -> dict[str, Any]:
-        return self._service.bootstrap()
+        payload = self._service.bootstrap()
+        if payload.get("ok"):
+            payload["data"]["webview_backend"] = _GUI_BACKENDS.get(platform.system())
+        return payload
 
     def list_audio_devices(self, host_api: str | None = None) -> dict[str, Any]:
         return self._service.list_audio_devices(host_api)
@@ -141,10 +165,23 @@ def _index_uri() -> str:
     return Path(get_resource_path("webview_ui/index.html")).resolve().as_uri()
 
 
+def create_app_window(webview_module: Any, bridge: "WebviewBridge") -> Any:
+    """Create the main application window and wire the bridge to it."""
+    window = webview_module.create_window(
+        "Impulcifer",
+        _index_uri(),
+        js_api=bridge,
+        width=1280,
+        height=860,
+        min_size=(980, 640),
+    )
+    bridge.attach_window(window)
+    return window
+
+
 def main() -> None:
-    """Start the Windows Edge WebView2 frontend."""
-    if platform.system() != "Windows":
-        raise SystemExit("The experimental WebView frontend currently supports Windows only.")
+    """Start the platform WebView frontend (WebView2 / WKWebView / WebKit2GTK)."""
+    backend = select_gui_backend()
 
     try:
         import webview
@@ -155,16 +192,8 @@ def main() -> None:
         ) from exc
 
     bridge = WebviewBridge()
-    window = webview.create_window(
-        "Impulcifer WebView Preview",
-        _index_uri(),
-        js_api=bridge,
-        width=1280,
-        height=860,
-        min_size=(980, 640),
-    )
-    bridge.attach_window(window)
-    webview.start(gui="edgechromium", debug=False)
+    create_app_window(webview, bridge)
+    webview.start(gui=backend, debug=False)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,8 +43,12 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# Linux는 pywebview의 [gtk] extra(PyGObject)까지 필요하다 — WebKit2GTK 백엔드.
+# PyGObject는 소스 빌드이므로 시스템에 libgirepository*-dev / libcairo2-dev /
+# gir1.2-webkit2-4.1이 있어야 한다 (README 및 webview-backend-validation.yml 참조).
 webview = [
-    'pywebview>=6.2,<7',
+    'pywebview>=6.2,<7; sys_platform != "linux"',
+    'pywebview[gtk]>=6.2,<7; sys_platform == "linux"',
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "impulcifer-py313"
-version = "2.9.0"
+version = "2.10.0"
 authors = [
   { name="원본 저자: Jaakko Pasanen", email="" },
   { name="Python 3.13/3.14 호환 버전: 115dkk", email="" },
@@ -111,6 +111,12 @@ include = [
     # config.
     "logo/**/*",
     "LICENSE",
+    # 재배포 서드파티 고지: pywebview(BSD-3)/CustomTkinter(MIT)/AutoEQ(MIT)/
+    # Pretendard·JetBrains Mono(OFL 1.1). OFL·MIT는 재배포 사본에 라이선스
+    # 동봉을 요구하므로 wheel과 standalone 모두에 포함된다.
+    "THIRD_PARTY_LICENSES.md",
+    "autoeq/LICENSE",
+    "font/OFL-*.txt",
     "README.md",
     "CHANGELOG.md",
     "pyproject.toml",

--- a/tests/test_application_service.py
+++ b/tests/test_application_service.py
@@ -514,3 +514,139 @@ def test_recording_jobs_reject_cancellation(monkeypatch, tmp_path: Path) -> None
     assert response["error"]["code"] == "JOB_NOT_CANCELLABLE"
     release.set()
     _wait_for_terminal(service, job_id)
+
+
+def test_check_for_updates_reports_available(monkeypatch) -> None:
+    import updater.update_checker as checker_module
+
+    class _FakeChecker:
+        def __init__(self, current_version):
+            self.current_version = current_version
+
+        def check_for_updates(self):
+            return True, "99.0.0", "https://example.invalid/Impulcifer-win-Setup.exe"
+
+        def get_release_notes(self):
+            return "notes"
+
+        def get_release_url(self):
+            return "https://example.invalid/releases/latest"
+
+    monkeypatch.setattr(checker_module, "UpdateChecker", _FakeChecker)
+    response = ImpulciferApplicationService().check_for_updates()
+    assert response["ok"]
+    data = response["data"]
+    assert data["update_available"] is True
+    assert data["latest_version"] == "99.0.0"
+    assert data["download_url"].endswith("Setup.exe")
+    assert data["release_notes"] == "notes"
+    assert data["release_url"].endswith("latest")
+
+
+def test_check_for_updates_handles_constructor_failure(monkeypatch) -> None:
+    import updater.update_checker as checker_module
+
+    class _Boom:
+        def __init__(self, current_version):
+            raise OSError("offline")
+
+    monkeypatch.setattr(checker_module, "UpdateChecker", _Boom)
+    response = ImpulciferApplicationService().check_for_updates()
+    assert not response["ok"]
+    assert response["error"]["code"] == "UPDATE_CHECK_FAILED"
+    assert response["error"]["retryable"] is True
+
+
+def test_start_update_requires_latest_version() -> None:
+    response = ImpulciferApplicationService().start_update({})
+    assert not response["ok"]
+    assert response["error"]["code"] == "INVALID_REQUEST"
+
+
+def test_start_update_job_stages_restart_action(monkeypatch) -> None:
+    import updater.updater_core as updater_core
+    from updater.updater_core import UpdateExecutionResult
+
+    applied = []
+
+    class _FakeExecutor:
+        def execute(self, progress_callback):
+            progress_callback(0.5, "update_downloading")
+            return UpdateExecutionResult(
+                status_key="update_installing",
+                status_default="Applying update...",
+                title_key="update_ready_title",
+                title_default="Update Ready",
+                message_key="update_restart_message",
+                message_default="The application will close to apply the update.",
+                progress=0.9,
+                close_delay_ms=0,
+                after_message=lambda: applied.append(True) or True,
+            )
+
+    monkeypatch.setattr(
+        updater_core, "create_update_executor", lambda url, version: _FakeExecutor()
+    )
+    service = ImpulciferApplicationService()
+    started = service.start_update(
+        {"latest_version": "99.0.0", "download_url": "https://example.invalid/pkg"}
+    )
+    assert started["ok"]
+    assert started["data"]["job"]["kind"] == "update"
+
+    data = _wait_for_terminal(service, started["data"]["job"]["job_id"])
+    job = data["job"]
+    assert job["status"] == "succeeded"
+    assert job["result"]["requires_restart"] is True
+    assert job["result"]["message_key"] == "update_restart_message"
+    progress_events = [event for event in data["events"] if event["type"] == "progress"]
+    assert progress_events
+    assert progress_events[0]["payload"]["message"] == "update_downloading"
+
+    response = service.apply_pending_update()
+    assert response["ok"]
+    assert response["data"]["restarting"] is True
+    assert applied == [True]
+
+    # The staged action is single-use: a second apply has nothing to run.
+    again = service.apply_pending_update()
+    assert not again["ok"]
+    assert again["error"]["code"] == "INVALID_REQUEST"
+
+
+def test_start_update_failure_is_structured(monkeypatch) -> None:
+    import updater.updater_core as updater_core
+    from updater.updater_core import UpdateExecutionError
+
+    class _FailingExecutor:
+        def execute(self, progress_callback):
+            raise UpdateExecutionError("Failed to download update")
+
+    monkeypatch.setattr(
+        updater_core, "create_update_executor", lambda url, version: _FailingExecutor()
+    )
+    service = ImpulciferApplicationService()
+    started = service.start_update({"latest_version": "99.0.0"})
+    assert started["ok"]
+    data = _wait_for_terminal(service, started["data"]["job"]["job_id"])
+    assert data["job"]["status"] == "failed"
+    assert data["job"]["error"]["code"] == "UPDATE_FAILED"
+    assert data["job"]["error"]["retryable"] is True
+
+
+def test_apply_pending_update_treats_sys_exit_as_success() -> None:
+    # VelopackUpdater.apply_and_restart exits the process after handing over
+    # to Update.exe; on a bridge worker thread that must read as success.
+    service = ImpulciferApplicationService()
+    service._pending_update_apply = lambda: (_ for _ in ()).throw(SystemExit(0))
+    response = service.apply_pending_update()
+    assert response["ok"]
+    assert response["data"]["restarting"] is True
+
+
+def test_apply_pending_update_reports_false_return() -> None:
+    service = ImpulciferApplicationService()
+    service._pending_update_apply = lambda: False
+    response = service.apply_pending_update()
+    assert not response["ok"]
+    assert response["error"]["code"] == "UPDATE_FAILED"

--- a/tests/test_application_service.py
+++ b/tests/test_application_service.py
@@ -391,6 +391,7 @@ class _FakeLocalization:
         self.locales_dir = locales_dir
         self.theme = "dark"
         self.skin = "stable"
+        self.frontend = "webview"
         self.marked = False
 
     def get_theme(self) -> str:
@@ -404,6 +405,12 @@ class _FakeLocalization:
 
     def set_skin(self, skin: str) -> None:
         self.skin = skin
+
+    def get_frontend(self) -> str:
+        return self.frontend
+
+    def set_frontend(self, frontend: str) -> None:
+        self.frontend = frontend
 
     def set_language(self, code: str) -> None:
         self.current_language = code
@@ -441,6 +448,11 @@ def test_ui_settings_language_and_theme_roundtrip(monkeypatch) -> None:
     assert service.set_skin("studio")["ok"]
     assert fake.skin == "studio"
     assert service.set_skin("neon")["error"]["code"] == "INVALID_REQUEST"
+
+    assert settings["data"]["frontend"] == "webview"
+    assert service.set_frontend("ctk")["ok"]
+    assert fake.frontend == "ctk"
+    assert service.set_frontend("qt")["error"]["code"] == "INVALID_REQUEST"
 
 
 def test_system_info_reports_environment() -> None:

--- a/tests/test_gui_launcher.py
+++ b/tests/test_gui_launcher.py
@@ -1,0 +1,116 @@
+"""Tests for the gui_main frontend launcher (webview default + CTk fallback)."""
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+import gui_main
+
+
+def test_resolve_frontend_cli_flag_wins(monkeypatch) -> None:
+    monkeypatch.setattr(gui_main.sys, "argv", ["gui_main.py", "--frontend=ctk"])
+    assert gui_main._resolve_frontend() == "ctk"
+
+
+def test_resolve_frontend_rejects_unknown_flag_value(monkeypatch) -> None:
+    monkeypatch.setattr(gui_main.sys, "argv", ["gui_main.py", "--frontend=qt"])
+    assert gui_main._resolve_frontend() == "webview"
+
+
+def test_resolve_frontend_reads_persisted_setting(monkeypatch) -> None:
+    monkeypatch.setattr(gui_main.sys, "argv", ["gui_main.py"])
+    fake_loc = SimpleNamespace(get_frontend=lambda: "ctk")
+    monkeypatch.setitem(
+        sys.modules,
+        "i18n.localization",
+        SimpleNamespace(get_localization_manager=lambda: fake_loc),
+    )
+    assert gui_main._resolve_frontend() == "ctk"
+
+
+def test_resolve_frontend_defaults_to_webview_when_settings_unavailable(monkeypatch) -> None:
+    monkeypatch.setattr(gui_main.sys, "argv", ["gui_main.py"])
+
+    def _boom():
+        raise OSError("settings unreadable")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "i18n.localization",
+        SimpleNamespace(get_localization_manager=_boom),
+    )
+    assert gui_main._resolve_frontend() == "webview"
+
+
+def test_launch_frontend_runs_webview_by_default(monkeypatch) -> None:
+    monkeypatch.setattr(gui_main.sys, "argv", ["gui_main.py", "--frontend=webview"])
+    launched: list[str] = []
+    monkeypatch.setitem(sys.modules, "webview", SimpleNamespace())
+    monkeypatch.setitem(
+        sys.modules,
+        "impulcifer_webview",
+        SimpleNamespace(
+            main=lambda: launched.append("webview"),
+            select_gui_backend=lambda: "edgechromium",
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "gui.modern_gui",
+        SimpleNamespace(main_gui=lambda: launched.append("ctk")),
+    )
+
+    gui_main._launch_frontend()
+    assert launched == ["webview"]
+
+
+def test_launch_frontend_falls_back_when_pywebview_missing(monkeypatch) -> None:
+    monkeypatch.setattr(gui_main.sys, "argv", ["gui_main.py", "--frontend=webview"])
+    launched: list[str] = []
+    # A None entry in sys.modules makes ``import webview`` raise ImportError.
+    monkeypatch.setitem(sys.modules, "webview", None)
+    monkeypatch.setitem(
+        sys.modules,
+        "gui.modern_gui",
+        SimpleNamespace(main_gui=lambda: launched.append("ctk")),
+    )
+
+    gui_main._launch_frontend()
+    assert launched == ["ctk"]
+
+
+def test_launch_frontend_falls_back_when_webview_start_fails(monkeypatch) -> None:
+    monkeypatch.setattr(gui_main.sys, "argv", ["gui_main.py", "--frontend=webview"])
+    launched: list[str] = []
+
+    def _failing_main() -> None:
+        raise RuntimeError("system WebKit missing")
+
+    monkeypatch.setitem(sys.modules, "webview", SimpleNamespace())
+    monkeypatch.setitem(
+        sys.modules,
+        "impulcifer_webview",
+        SimpleNamespace(main=_failing_main, select_gui_backend=lambda: "gtk"),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "gui.modern_gui",
+        SimpleNamespace(main_gui=lambda: launched.append("ctk")),
+    )
+
+    gui_main._launch_frontend()
+    assert launched == ["ctk"]
+
+
+def test_launch_frontend_honours_ctk_choice(monkeypatch) -> None:
+    monkeypatch.setattr(gui_main.sys, "argv", ["gui_main.py", "--frontend=ctk"])
+    launched: list[str] = []
+    monkeypatch.setitem(
+        sys.modules,
+        "gui.modern_gui",
+        SimpleNamespace(main_gui=lambda: launched.append("ctk")),
+    )
+
+    gui_main._launch_frontend()
+    assert launched == ["ctk"]

--- a/tests/test_nuitka_flags.py
+++ b/tests/test_nuitka_flags.py
@@ -173,3 +173,75 @@ def test_cli_emits_one_flag_per_line(capsys):
     assert any(ln.startswith("--output-dir=") for ln in lines)
     assert any(ln == "--standalone" for ln in lines)
     assert any(ln.endswith(".py") for ln in lines), "Entry point line missing"
+
+
+def test_webview_frontend_is_bundled():
+    """The WebView frontend (launcher default since 2.10) must ship in the
+    standalone bundle — but WITHOUT explicit module includes.
+
+    Any ``--include-module=webview`` / ``--include-package=webview`` entry
+    feeds Nuitka's follow patterns for the whole subtree and conflicts with
+    the auto-enabled 'pywebview' plugin, which excludes the other platforms'
+    backend modules (observed FATAL: "Conflict between user and plugin
+    decision for module 'webview.platforms.android'"). The static
+    ``import webview`` chain in gui_main → impulcifer_webview is traced
+    automatically instead.
+    """
+    mod = _flags_module()
+    assert "webview" not in mod.INCLUDED_PACKAGES
+    assert "webview" not in mod.INCLUDED_MODULES
+    # Data-file flags do not feed follow patterns — safe belt-and-suspenders.
+    assert "webview" in mod.INCLUDED_PACKAGE_DATA
+    pairs = dict(mod.INCLUDED_DATA_DIRS)
+    assert pairs.get("webview_ui") == "webview_ui", (
+        "webview_ui must be bundled at the same relative path so "
+        "get_resource_path('webview_ui/index.html') resolves at runtime."
+    )
+
+
+def test_no_explicit_pythonnet_flags():
+    """pythonnet/clr_loader are followed from webview.platforms.winforms and
+    their DLLs come from Nuitka's package config ('clr', 'clr_loader.ffi',
+    'pythonnet' entries); explicit includes are unnecessary on Windows and
+    would fail macOS/Linux builds where those wheels don't exist."""
+    mod = _flags_module()
+    for plat in ("windows", "macos", "linux"):
+        flags = mod.platform_specific_flags(plat)
+        assert not any(
+            "pythonnet" in flag or "clr" in flag for flag in flags
+        ), f"{plat} flags must not reference the pythonnet stack: {flags}"
+
+
+def test_pywebview_plugin_patch_source():
+    """The build-time hotfix inserts webview.platforms.win32 into Nuitka's
+    pywebview plugin whitelist (idempotent, anchor-guarded)."""
+    from build_scripts.patch_nuitka_pywebview import patch_source
+
+    stale = (
+        "                result = module_name in (\n"
+        '                    "webview.platforms.winforms",\n'
+        '                    "webview.platforms.edgechromium",\n'
+        "                )\n"
+    )
+    patched, status = patch_source(stale)
+    assert status == "patched"
+    lines = patched.splitlines()
+    idx = next(i for i, line in enumerate(lines) if "winforms" in line)
+    assert lines[idx + 1].strip() == '"webview.platforms.win32",'
+    assert lines[idx + 1].startswith("                    ")
+
+    again, status2 = patch_source(patched)
+    assert status2 == "already-ok"
+    assert again == patched
+
+    assert patch_source("unrelated file contents")[1] == "anchor-missing"
+
+
+def test_third_party_license_notices_are_bundled():
+    """OFL/MIT/BSD-3 재배포 조건: 고지 파일이 standalone 번들에 실려야 한다."""
+    mod = _flags_module()
+    files = dict(mod.INCLUDED_DATA_FILES)
+    assert files.get("THIRD_PARTY_LICENSES.md") == "THIRD_PARTY_LICENSES.md"
+    assert files.get("autoeq/LICENSE") == "autoeq/LICENSE"
+    # font/OFL-*.txt는 font 데이터 디렉토리 전체 포함으로 함께 실린다.
+    assert dict(mod.INCLUDED_DATA_DIRS).get("font") == "font"

--- a/tests/test_webview_bridge.py
+++ b/tests/test_webview_bridge.py
@@ -129,7 +129,15 @@ def test_open_url_is_allowlist_only(monkeypatch) -> None:
     assert opened == ["https://github.com/115dkk/Impulcifer-pip313"]
 
 
-def test_main_forces_edgechromium_backend(monkeypatch) -> None:
+@pytest.mark.parametrize(
+    ("system", "expected_backend"),
+    [
+        ("Windows", "edgechromium"),
+        ("Darwin", "cocoa"),
+        ("Linux", "gtk"),
+    ],
+)
+def test_main_forces_platform_backend(monkeypatch, system, expected_backend) -> None:
     import impulcifer_webview
 
     calls = []
@@ -137,22 +145,33 @@ def test_main_forces_edgechromium_backend(monkeypatch) -> None:
         create_window=lambda *args, **kwargs: calls.append(("create", args, kwargs)),
         start=lambda **kwargs: calls.append(("start", kwargs)),
     )
-    monkeypatch.setattr(impulcifer_webview.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(impulcifer_webview.platform, "system", lambda: system)
     monkeypatch.setattr(impulcifer_webview, "_index_uri", lambda: "file:///index.html")
     monkeypatch.setitem(sys.modules, "webview", fake_webview)
 
     impulcifer_webview.main()
 
     assert calls[0][0] == "create"
-    assert calls[1] == ("start", {"gui": "edgechromium", "debug": False})
+    assert calls[1] == ("start", {"gui": expected_backend, "debug": False})
 
 
-def test_main_rejects_non_windows_platform(monkeypatch) -> None:
+def test_main_rejects_unsupported_platform(monkeypatch) -> None:
     import impulcifer_webview
 
-    monkeypatch.setattr(impulcifer_webview.platform, "system", lambda: "Linux")
-    with pytest.raises(SystemExit, match="Windows only"):
+    monkeypatch.setattr(impulcifer_webview.platform, "system", lambda: "Java")
+    with pytest.raises(SystemExit, match="does not support"):
         impulcifer_webview.main()
+
+
+def test_bootstrap_reports_webview_backend(monkeypatch) -> None:
+    import impulcifer_webview
+    from impulcifer_webview import WebviewBridge
+
+    monkeypatch.setattr(impulcifer_webview.platform, "system", lambda: "Darwin")
+    bridge = WebviewBridge(_FakeService())
+    response = bridge.bootstrap()
+    assert response["ok"]
+    assert response["data"]["webview_backend"] == "cocoa"
 
 
 def test_webview_entrypoint_contains_no_qt_backend() -> None:
@@ -163,4 +182,8 @@ def test_webview_entrypoint_contains_no_qt_backend() -> None:
     for forbidden in ("PySide", "PyQt", "QtWebEngine", 'gui="qt"'):
         assert forbidden not in source
         assert forbidden not in pyproject
-    assert 'webview.start(gui="edgechromium"' in source
+    # Only the three natively-validated engines may appear in the backend map.
+    assert '"Windows": "edgechromium"' in source
+    assert '"Darwin": "cocoa"' in source
+    assert '"Linux": "gtk"' in source
+    assert "webview.start(gui=backend" in source

--- a/tests/test_webview_bridge.py
+++ b/tests/test_webview_bridge.py
@@ -39,6 +39,9 @@ def test_module_import_does_not_require_pywebview(monkeypatch) -> None:
         ("resolve_recording_paths", ("dir", "play.wav", "speakers")),
         ("generate_sweep_set", ("dir",)),
         ("open_path", ("dir",)),
+        ("check_for_updates", ()),
+        ("start_update", ({"latest_version": "9.9.9"},)),
+        ("apply_pending_update", ()),
     ],
 )
 def test_bridge_delegates_only_public_service_methods(method, args) -> None:
@@ -172,6 +175,52 @@ def test_bootstrap_reports_webview_backend(monkeypatch) -> None:
     response = bridge.bootstrap()
     assert response["ok"]
     assert response["data"]["webview_backend"] == "cocoa"
+
+
+def test_apply_pending_update_closes_window_on_restart(monkeypatch) -> None:
+    import threading
+
+    from impulcifer_webview import WebviewBridge
+
+    class _RestartingService:
+        def apply_pending_update(self):
+            return {"ok": True, "data": {"restarting": True}}
+
+    timers: list[tuple[float, object]] = []
+
+    class _FakeTimer:
+        def __init__(self, interval, function):
+            timers.append((interval, function))
+
+        def start(self):
+            pass
+
+    monkeypatch.setattr(threading, "Timer", _FakeTimer)
+
+    destroyed: list[bool] = []
+    window = SimpleNamespace(destroy=lambda: destroyed.append(True))
+    bridge = WebviewBridge(_RestartingService())
+    bridge.attach_window(window)
+
+    response = bridge.apply_pending_update()
+    assert response["ok"]
+    assert len(timers) == 1
+
+    _interval, close_window = timers[0]
+    close_window()
+    assert destroyed == [True]
+
+
+def test_apply_pending_update_without_window_does_not_crash(monkeypatch) -> None:
+    from impulcifer_webview import WebviewBridge
+
+    class _RestartingService:
+        def apply_pending_update(self):
+            return {"ok": True, "data": {"restarting": True}}
+
+    bridge = WebviewBridge(_RestartingService())
+    response = bridge.apply_pending_update()
+    assert response["ok"]
 
 
 def test_webview_entrypoint_contains_no_qt_backend() -> None:

--- a/tests/test_webview_bridge.py
+++ b/tests/test_webview_bridge.py
@@ -35,6 +35,7 @@ def test_module_import_does_not_require_pywebview(monkeypatch) -> None:
         ("set_language", ("ko",)),
         ("set_theme", ("light",)),
         ("set_skin", ("stable",)),
+        ("set_frontend", ("ctk",)),
         ("get_system_info", ()),
         ("resolve_recording_paths", ("dir", "play.wav", "speakers")),
         ("generate_sweep_set", ("dir",)),

--- a/webview_ui/app.js
+++ b/webview_ui/app.js
@@ -1049,6 +1049,11 @@ function wireEvents() {
   $("sf-skin").addEventListener("change", (event) => changeSkin(event.target.value));
   $("sf-theme").addEventListener("change", (event) => changeTheme(event.target.value));
   $("sf-language").addEventListener("change", (event) => changeLanguage(event.target.value));
+  $("sf-frontend").addEventListener("change", async (event) => {
+    // Persisted for the next launch; the current session keeps running.
+    const response = await api().set_frontend(event.target.value);
+    if (!response.ok) appendLog(errorText(response));
+  });
 
   $("btn-check-updates").addEventListener("click", () => checkForUpdates(true));
   $("update-now").addEventListener("click", beginUpdate);
@@ -1088,6 +1093,7 @@ async function boot() {
     applyTheme(data.ui.theme || "dark");
     $("sf-skin").value = data.ui.skin === "stable" ? "stable" : "studio";
     applySkin(data.ui.skin);
+    $("sf-frontend").value = data.ui.frontend === "ctk" ? "ctk" : "webview";
   }
   applyStrings();
   const backendLabels = { edgechromium: "WebView2", cocoa: "WKWebView", gtk: "WebKitGTK" };

--- a/webview_ui/app.js
+++ b/webview_ui/app.js
@@ -487,6 +487,178 @@ async function pollJob() {
   schedulePoll();
 }
 
+/* ----------------------------------------------------------- auto-update */
+
+/* Port of the CTk flow: background check 2s after startup →
+   UpdateDialog (notes + Update Now / Remind / Skip) → UpdateExecutor with
+   progress → completion message → optional apply-and-restart (Velopack). */
+
+const updateState = {
+  info: null,
+  jobId: null,
+  nextSeq: 0,
+  pollTimer: null,
+};
+
+function tOr(key, fallback) {
+  return (key && state.strings[key]) || fallback || key || "";
+}
+
+function setUpdateProgress(value) {
+  $("update-progress").style.width = `${Math.round(Math.max(0, Math.min(1, value)) * 100)}%`;
+}
+
+function showUpdateModal(info) {
+  updateState.info = info;
+  $("update-version-line").textContent = fmt(t("update_version_info"), {
+    current: info.current_version,
+    latest: info.latest_version,
+  });
+  $("update-notes").textContent = info.release_notes || t("update_no_notes");
+  $("update-progress-row").hidden = true;
+  setUpdateProgress(0);
+  $("update-status").textContent = "";
+  $("update-result").hidden = true;
+  $("update-now").hidden = false;
+  $("update-now").disabled = false;
+  $("update-remind").hidden = false;
+  $("update-skip").hidden = false;
+  $("update-restart").hidden = true;
+  $("update-close").hidden = true;
+  $("update-modal").hidden = false;
+}
+
+function showUpdateProgressOnly() {
+  // Resume path: an update job survived a frontend reload — no check info,
+  // just live progress until the terminal state arrives.
+  updateState.info = null;
+  $("update-version-line").textContent = "";
+  $("update-notes").textContent = "";
+  $("update-progress-row").hidden = false;
+  $("update-result").hidden = true;
+  $("update-now").hidden = true;
+  $("update-remind").hidden = true;
+  $("update-skip").hidden = true;
+  $("update-restart").hidden = true;
+  $("update-close").hidden = true;
+  $("update-modal").hidden = false;
+}
+
+function hideUpdateModal() {
+  window.clearTimeout(updateState.pollTimer);
+  $("update-modal").hidden = true;
+}
+
+async function checkForUpdates(manual) {
+  const statusLine = $("update-check-status");
+  if (manual) {
+    statusLine.hidden = false;
+    statusLine.textContent = t("update_checking");
+  }
+  let response;
+  try {
+    response = await api().check_for_updates();
+  } catch (error) {
+    response = null;
+  }
+  if (!response || !response.ok) {
+    // Startup checks fail silently, mirroring the CTk background check.
+    if (manual) statusLine.textContent = response ? errorText(response) : t("update_error_apply");
+    return;
+  }
+  const data = response.data;
+  if (data.update_available) {
+    if (manual) statusLine.hidden = true;
+    showUpdateModal(data);
+  } else if (manual) {
+    statusLine.textContent = fmt(t("update_up_to_date"), {
+      latest: data.latest_version || data.current_version,
+    });
+  }
+}
+
+async function beginUpdate() {
+  const info = updateState.info;
+  if (!info) return;
+  $("update-now").disabled = true;
+  $("update-remind").hidden = true;
+  $("update-skip").hidden = true;
+  $("update-progress-row").hidden = false;
+  $("update-status").textContent = t("update_downloading");
+  const response = await api().start_update({
+    download_url: info.download_url,
+    latest_version: info.latest_version,
+  });
+  if (!response.ok) {
+    finishUpdate(errorText(response), false);
+    return;
+  }
+  updateState.jobId = response.data.job.job_id;
+  updateState.nextSeq = 0;
+  pollUpdateJob();
+}
+
+async function pollUpdateJob() {
+  if (!updateState.jobId) return;
+  const response = await api().poll_job(updateState.jobId, updateState.nextSeq);
+  if (!response.ok) {
+    finishUpdate(errorText(response), false);
+    return;
+  }
+  const { job, events, next_seq: nextSeq } = response.data;
+  updateState.nextSeq = nextSeq;
+  for (const event of events) {
+    const payload = event.payload || {};
+    if (event.type === "progress") {
+      if (typeof payload.progress === "number") setUpdateProgress(payload.progress);
+      // The executor sends either an i18n key ("update_downloading") or
+      // preformatted text ("Downloading: 42%").
+      if (payload.message) $("update-status").textContent = tOr(payload.message, payload.message);
+    }
+  }
+  if (["succeeded", "failed", "cancelled"].includes(job.status)) {
+    updateState.jobId = null;
+    if (job.status === "succeeded") {
+      const result = job.result || {};
+      setUpdateProgress(typeof result.progress === "number" ? result.progress : 1);
+      $("update-status").textContent = tOr(result.status_key, result.status_default);
+      finishUpdate(
+        tOr(result.message_key, result.message_default),
+        true,
+        Boolean(result.requires_restart),
+      );
+    } else {
+      finishUpdate(job.error ? job.error.message : t("update_error_apply"), false);
+    }
+    return;
+  }
+  updateState.pollTimer = window.setTimeout(pollUpdateJob, 250);
+}
+
+function finishUpdate(message, success, requiresRestart = false) {
+  $("update-result").hidden = false;
+  $("update-result").textContent = message;
+  $("update-now").hidden = true;
+  $("update-remind").hidden = true;
+  $("update-skip").hidden = true;
+  // Velopack stages an apply-and-restart: confirming OK hands over to
+  // Update.exe and the window closes. pip/legacy end with a plain Close.
+  $("update-restart").hidden = !(success && requiresRestart);
+  $("update-close").hidden = success && requiresRestart;
+}
+
+async function applyStagedUpdate() {
+  $("update-restart").disabled = true;
+  const response = await api().apply_pending_update();
+  if (!response.ok) {
+    $("update-restart").disabled = false;
+    finishUpdate(errorText(response), false);
+    return;
+  }
+  $("update-result").hidden = false;
+  $("update-result").textContent = t("update_restart_message");
+}
+
 /* --------------------------------------------------------------- devices */
 
 async function loadDevices(hostApi = "") {
@@ -877,6 +1049,13 @@ function wireEvents() {
   $("sf-skin").addEventListener("change", (event) => changeSkin(event.target.value));
   $("sf-theme").addEventListener("change", (event) => changeTheme(event.target.value));
   $("sf-language").addEventListener("change", (event) => changeLanguage(event.target.value));
+
+  $("btn-check-updates").addEventListener("click", () => checkForUpdates(true));
+  $("update-now").addEventListener("click", beginUpdate);
+  $("update-remind").addEventListener("click", hideUpdateModal);
+  $("update-skip").addEventListener("click", hideUpdateModal);
+  $("update-close").addEventListener("click", hideUpdateModal);
+  $("update-restart").addEventListener("click", applyStagedUpdate);
 }
 
 /* ------------------------------------------------------------------ boot */
@@ -917,18 +1096,32 @@ async function boot() {
   $("runtime-status").textContent = `v${data.version} · ${data.platform} · ${backendLabel}`;
   appendLog(t("webview_bridge_connected"));
 
-  renderJobState(data.active_job);
-  if (data.active_job && !["succeeded", "failed", "cancelled"].includes(data.active_job.status)) {
-    state.jobId = data.active_job.job_id;
-    state.jobKind = data.active_job.kind;
-    state.nextSeq = 0;
-    resetSteps(data.active_job.kind === "brir");
-    resetRecorderStatus();
-    schedulePoll(0);
+  const activeJob = data.active_job;
+  if (activeJob && activeJob.kind === "update") {
+    if (!["succeeded", "failed", "cancelled"].includes(activeJob.status)) {
+      updateState.jobId = activeJob.job_id;
+      updateState.nextSeq = 0;
+      showUpdateProgressOnly();
+      pollUpdateJob();
+    }
+  } else {
+    renderJobState(activeJob);
+    if (activeJob && !["succeeded", "failed", "cancelled"].includes(activeJob.status)) {
+      state.jobId = activeJob.job_id;
+      state.jobKind = activeJob.kind;
+      state.nextSeq = 0;
+      resetSteps(activeJob.kind === "brir");
+      resetRecorderStatus();
+      schedulePoll(0);
+    }
   }
 
   await Promise.all([loadDevices(), loadSystemInfo()]);
   refreshResolvedPath();
+
+  // Mirror the CTk root.after(2000) startup update check; failures stay
+  // silent and never block the UI.
+  window.setTimeout(() => checkForUpdates(false), 2000);
 }
 
 buildDecayGrid();

--- a/webview_ui/app.js
+++ b/webview_ui/app.js
@@ -911,8 +911,10 @@ async function boot() {
     applySkin(data.ui.skin);
   }
   applyStrings();
+  const backendLabels = { edgechromium: "WebView2", cocoa: "WKWebView", gtk: "WebKitGTK" };
+  const backendLabel = backendLabels[data.webview_backend] || "WebView";
   $("brand-version").textContent = `v${data.version}`;
-  $("runtime-status").textContent = `v${data.version} · ${data.platform} · WebView2`;
+  $("runtime-status").textContent = `v${data.version} · ${data.platform} · ${backendLabel}`;
   appendLog(t("webview_bridge_connected"));
 
   renderJobState(data.active_job);

--- a/webview_ui/index.html
+++ b/webview_ui/index.html
@@ -502,7 +502,9 @@
               <div class="actions-row">
                 <button class="btn btn-secondary" data-open-url="license" data-i18n="button_view_license">View License</button>
                 <button class="btn btn-secondary" data-open-url="report_bug" data-i18n="button_report_bug">Report Bug</button>
+                <button class="btn btn-secondary" id="btn-check-updates" data-i18n="button_check_updates">Check for Updates</button>
               </div>
+              <p class="hint" id="update-check-status" hidden></p>
             </div>
           </div>
 
@@ -564,6 +566,32 @@
         <div class="actions-row modal-actions">
           <button class="btn btn-secondary" id="job-modal-cancel" data-i18n="button_cancel">Cancel</button>
           <button class="btn btn-primary" id="job-modal-close" data-i18n="button_close" hidden>Close</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Auto-update prompt, mirroring the CTk UpdateDialog: release notes,
+         Update Now / Remind Later / Skip, then in-place download progress. -->
+    <div class="modal-backdrop" id="update-modal" hidden>
+      <div class="modal" role="dialog" aria-modal="true" aria-labelledby="update-modal-title">
+        <div class="modal-head">
+          <h3 id="update-modal-title" data-i18n="update_available_title">Update Available</h3>
+          <span class="card-meta mono" id="update-version-line"></span>
+        </div>
+        <p class="hint" data-i18n="update_available_message">A new version is available!</p>
+        <p class="hint" data-i18n="update_release_notes">Release Notes:</p>
+        <pre class="log update-notes" id="update-notes"></pre>
+        <div id="update-progress-row" hidden>
+          <div class="progress"><i id="update-progress"></i></div>
+          <p class="hint" id="update-status"></p>
+        </div>
+        <p class="hint" id="update-result" hidden></p>
+        <div class="actions-row modal-actions">
+          <button class="btn btn-secondary" id="update-skip" data-i18n="update_button_skip">Skip This Version</button>
+          <button class="btn btn-secondary" id="update-remind" data-i18n="update_button_remind">Remind Me Later</button>
+          <button class="btn btn-primary" id="update-now" data-i18n="update_button_update">Update Now</button>
+          <button class="btn btn-primary" id="update-restart" data-i18n="button_ok" hidden>OK</button>
+          <button class="btn btn-secondary" id="update-close" data-i18n="button_close" hidden>Close</button>
         </div>
       </div>
     </div>

--- a/webview_ui/index.html
+++ b/webview_ui/index.html
@@ -461,6 +461,14 @@
                 <label for="sf-language" data-i18n="label_select_language">Select Language:</label>
                 <select id="sf-language"></select>
               </div>
+              <div class="field-row">
+                <label for="sf-frontend" data-i18n="label_frontend">Default Interface:</label>
+                <select id="sf-frontend">
+                  <option value="webview" data-i18n="option_frontend_webview">WebView (recommended)</option>
+                  <option value="ctk" data-i18n="option_frontend_ctk">CustomTkinter (legacy)</option>
+                </select>
+              </div>
+              <p class="hint" data-i18n="tooltip_frontend">Which interface opens when the app starts. Takes effect on the next launch.</p>
             </div>
           </div>
 


### PR DESCRIPTION
## 개요

WebView 프론트엔드를 차기 기본 인터페이스로 승격하는 3단계 작업 + 서드파티 라이선스 고지 정비. **버전 2.10.0 (MINOR)**

### 1단계 ✅: 플랫폼별 백엔드 + 실기 검증 게이트
- Windows 전용 게이트 제거, 백엔드 강제 맵 (Windows→edgechromium, macOS→cocoa, Linux→gtk)
- `webview-backend-validation.yml`: 3-플랫폼에서 **실제 렌더링 엔진 + 실제 브리지**로 DOM/boot()/브리지 왕복 검증 — **첫 실행에서 3-플랫폼 모두 그린**:
  - macOS: `gui=cocoa guilib=webview.platforms.cocoa brand=v2.9.0`
  - Linux: `gui=gtk guilib=webview.platforms.gtk brand=v2.9.0` (xvfb + WebKit2GTK)
  - Windows: `gui=edgechromium guilib=webview.platforms.winforms brand=v2.9.0`

### 2단계 ✅: 웹뷰 자동 업데이트
- CTk UpdateDialog/UpdateExecutor 흐름을 service job으로 이식: 부팅 2초 후 확인 → 릴리스 노트 모달(지금/나중에/건너뛰기) → 진행률 → Velopack은 OK 시 Update.exe 인계 + 창 자동 종료
- Info 탭 수동 '업데이트 확인' 버튼, 갤러리에 update-available 샷 2종 추가 (EXPECTED_SHOTS 39)

### 3단계 ✅: Nuitka standalone 기본 = WebView
- `gui_main.py` 런처화: `--frontend` 인자 > settings.json > 기본 webview, 실패 시 CTk 자동 폴백
- **로컬 Windows standalone 빌드로 실검증 완료**: 기본 실행 → WebView 창(WebView2 자식 프로세스 +6), `--frontend=ctk` → CTk 창, `--smoke-test` OK (imports=24)
- 이 과정에서 Nuitka 이슈 2건 발견·해결 (둘 다 테스트로 고정):
  1. 명시적 `--include-module/package=webview`는 내장 pywebview 플러그인의 타 플랫폼 제외 결정과 충돌 → FATAL. 정적 import 추적에 위임.
  2. 플러그인의 Windows 화이트리스트가 pywebview 6.x의 `webview.platforms.win32`를 누락(업스트림 버그) → 패키징된 앱이 조용히 CTk로 폴백. `build_scripts/patch_nuitka_pywebview.py` idempotent 핫픽스로 해결.
- CTk deprecation 고지 (v3 제거 예정, **v2 동안 기능 추가 포함 완전 지원**): CTk 설정 탭 + README
- 수동 build-linux/build-macos 워크플로를 이 브랜치에서 dispatch하여 3-플랫폼 Nuitka 번들 사전 검증 중

### 서드파티 라이선스 고지 (추가 요청)
- `THIRD_PARTY_LICENSES.md` (pywebview BSD-3 / CustomTkinter MIT / AutoEQ MIT / Pretendard·JetBrains Mono OFL 1.1 전문)
- `autoeq/LICENSE`, `font/OFL-Pretendard.txt`, `font/OFL-JetBrainsMono.txt`
- wheel(`hatch include`) + standalone(`INCLUDED_DATA_FILES`) 양쪽 포함

🤖 Generated with [Claude Code](https://claude.com/claude-code)