### PR TITLE
fix: 2.10.0 standalone 기동 사망(scipy 번들 누락) 긴급 수정 + WebView 마감 손질 (v2.10.1)

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -43,6 +43,7 @@ jobs:
             desktop-file-utils \
             libfuse2 \
             imagemagick \
+            xvfb \
             portaudio19-dev \
             python3-tk \
             python3-dev \
@@ -105,6 +106,13 @@ jobs:
           python build_scripts/build_nuitka.py
 
           echo "Successfully built with Nuitka for Linux."
+        env:
+          PYTHONIOENCODING: UTF-8
+
+      # 번들 기동 결함(누락 모듈 등)을 패키징 전에 잡는 스모크 게이트.
+      - name: Smoke test built binary
+        run: |
+          xvfb-run -a ./dist/linux/gui_main.dist/Impulcifer --smoke-test
         env:
           PYTHONIOENCODING: UTF-8
 

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -81,6 +81,15 @@ jobs:
         env:
           PYTHONIOENCODING: UTF-8
 
+      # 번들 기동 결함(누락 모듈 등)을 패키징 전에 잡는 스모크 게이트.
+      - name: Smoke test built app bundle
+        run: |
+          APP="dist/macos/Impulcifer.app"
+          [ -d "$APP" ] || APP="dist/macos/gui_main.app"
+          "./$APP/Contents/MacOS/Impulcifer" --smoke-test
+        env:
+          PYTHONIOENCODING: UTF-8
+
       - name: Create DMG installer (optional)
         run: |
           echo "[3/3] Creating DMG installer..."

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -181,6 +181,16 @@ jobs:
         env:
           PYTHONIOENCODING: UTF-8
 
+      # 2.10.0 회귀 재발 방지: scipy 벤더링 모듈 누락처럼 "빌드는 성공하지만
+      # 기동이 죽는" 번들 결함은 이 스모크(전체 import 체인 + webview 스택 +
+      # 폰트/자산 검증)가 릴리스 전에 잡는다.
+      - name: Smoke test built binary
+        run: |
+          ./dist/Impulcifer_Distribution/ImpulciferGUI/gui_main.dist/ImpulciferGUI.exe --smoke-test
+        shell: bash
+        env:
+          PYTHONIOENCODING: UTF-8
+
       - name: Install Velopack CLI
         run: |
           dotnet tool install -g vpk
@@ -296,6 +306,13 @@ jobs:
         env:
           PYTHONIOENCODING: UTF-8
 
+      # 번들 기동 결함(누락 모듈 등)을 릴리스 전에 잡는 스모크 게이트.
+      - name: Smoke test built app bundle
+        run: |
+          ./dist/macos/Impulcifer.app/Contents/MacOS/Impulcifer --smoke-test
+        env:
+          PYTHONIOENCODING: UTF-8
+
       - name: Create DMG installer
         run: |
           echo "Creating DMG installer..."
@@ -367,6 +384,7 @@ jobs:
             desktop-file-utils \
             libfuse2 \
             imagemagick \
+            xvfb \
             portaudio19-dev \
             python3-tk \
             python3-dev \
@@ -420,6 +438,14 @@ jobs:
 
           echo "Checking Linux build output:"
           ls -la dist/linux/
+        env:
+          PYTHONIOENCODING: UTF-8
+
+      # 번들 기동 결함(누락 모듈 등)을 릴리스 전에 잡는 스모크 게이트.
+      # 스모크의 Tk 단계 때문에 가상 디스플레이(xvfb)가 필요하다.
+      - name: Smoke test built binary
+        run: |
+          xvfb-run -a ./dist/linux/gui_main.dist/Impulcifer --smoke-test
         env:
           PYTHONIOENCODING: UTF-8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ first number changes, something has broken and you need to check your commands a
 changes there are only new features available and nothing old has broken and when the last number changes, old bugs have
 been fixed and old features improved.
 
+## 2.10.1 - 2026-07-12
+### 2.10.0 standalone 긴급 수정 — scipy 번들 누락으로 인한 기동 사망 + WebView 마감 손질
+
+#### 🐛 버그 수정
+- **standalone의 모든 scipy import 즉사 수정 (2.10.0 회귀)**: CI가 설치한 scipy 1.18이 벤더링 array-api-compat을 `scipy._external`로 옮겼는데 그 lazy import 서브모듈(`numpy.fft` 등)을 Nuitka가 추적하지 못해, 설치본에서 scipy를 import하는 모든 경로가 `ModuleNotFoundError`로 죽었다 — CTk 기동 즉사("웹뷰에서 CTk 전환 시 실행 불가"의 원인), WebView `bootstrap()` 사망(언어 목록 공백 + 원시 i18n 키 노출의 원인). `build_scripts/nuitka_flags.py`가 빌드 환경에 존재하는 쪽(`scipy._external` 또는 구버전의 `scipy._lib.array_api_compat`)을 통째로 `--include-package`한다. 설치본과 동일한 scipy 1.18 환경의 로컬 빌드로 재현·수정 검증.
+- **bootstrap 방어화**: DSP 스택(impulcifer→core→scipy) import 실패가 UI 셸 전체를 죽이지 못하게 bootstrap/get_system_info의 버전·스레딩 정보 조회를 개별 가드로 감쌌다. 패키징 결함이 나도 언어/테마/설정 UI는 살아서 원인이 읽히는 오류로 표면화된다.
+- **부트 전 오류 문자열 i18n 폴백**: bootstrap이 죽으면 로케일 테이블이 없어 `t()`가 원시 키(`webview_bridge_failed`)를 그대로 노출하던 것을, OS 로케일 기반 내장 en/ko 폴백(`PREBOOT_STRINGS`)으로 교체.
+- **Windows 제목 표시줄 다크 모드**: WebView 창이 기본 흰색 제목 표시줄을 쓰던 것을 CTk처럼 DWM `DWMWA_USE_IMMERSIVE_DARK_MODE`로 앱 테마(설정의 dark/light/system, system은 레지스트리 조회)와 동기화. 테마 변경 시 즉시 재적용되고, 창 배경색도 Pulse `--bg-0`으로 지정해 로드 전 흰 플래시를 제거.
+
+#### ⭐ 새로운 기능 / 개선
+- **첫 실행 언어 선택 (CTk 패리티)**: 첫 실행 시 WebView에도 언어 선택 모달이 뜬다(`ui.first_run`, CTk `LanguageSelectionDialog` 이식). 갤러리에 리뷰 샷 추가(총 40샷).
+- **'실험적 WebView 프론트엔드' 딱지 제거**: 사이드바 배지·`webview_experimental_badge` 키(11개 로케일)·창/문서 제목의 Preview 표기를 제거했다. WebView는 기본 인터페이스다.
+
+#### 🔧 빌드 / 설정 변경
+- **릴리스 파이프라인에 스모크 게이트 추가**: 3-플랫폼 빌드 잡(publish.yml)과 수동 빌드 워크플로가 패키징 전에 빌드된 바이너리로 `--smoke-test`(전체 import 체인 + webview 스택 + 자산)를 실행한다. 이번 scipy 회귀 같은 "빌드는 성공하지만 기동이 죽는" 결함은 이제 릴리스 전에 차단된다(Linux는 xvfb).
+
 ## 2.10.0 - 2026-07-12
 ### WebView 표준화 — 3-플랫폼 백엔드 검증, 자동 업데이트, standalone 기본 인터페이스 전환
 

--- a/application/impulcifer_service.py
+++ b/application/impulcifer_service.py
@@ -179,14 +179,24 @@ class ImpulciferApplicationService:
 
     def bootstrap(self) -> dict[str, Any]:
         from i18n.localization import get_localization_manager
-        from impulcifer import __version__
+
+        # The DSP stack (impulcifer → core → scipy …) must never be able to
+        # kill the UI shell: a packaging regression there should surface as a
+        # readable job/system-info error, not as a dead bootstrap that leaves
+        # raw i18n keys and an empty language list on screen (observed with
+        # the 2.10.0 standalone, whose bundle was missing a lazy scipy
+        # vendored module).
+        try:
+            from impulcifer import __version__ as version
+        except Exception:
+            version = "unknown"
 
         with self._lock:
             active_job = self._jobs.get(self._active_job_id or "")
             active = active_job.snapshot() if active_job is not None else None
         return _ok(
             {
-                "version": __version__,
+                "version": version,
                 "platform": platform.system().lower(),
                 "capabilities": {
                     "recording": True,
@@ -449,6 +459,8 @@ class ImpulciferApplicationService:
             # Older LocalizationManager instances (or test fakes) may predate
             # the frontend setting; default matches get_frontend().
             "frontend": loc.get_frontend() if hasattr(loc, "get_frontend") else "webview",
+            # First run → the frontend shows a language picker (CTk parity).
+            "first_run": bool(loc.is_first_run()) if hasattr(loc, "is_first_run") else False,
             "languages": [
                 {"code": code, "name": name} for code, name in SUPPORTED_LANGUAGES.items()
             ],
@@ -456,8 +468,10 @@ class ImpulciferApplicationService:
         }
 
     def get_system_info(self) -> dict[str, Any]:
-        from core.parallel_processing import get_python_threading_info
-        from impulcifer import __version__
+        try:
+            from impulcifer import __version__ as version
+        except Exception:
+            version = "unknown"
 
         install_kind = "dev"
         try:
@@ -470,10 +484,15 @@ class ImpulciferApplicationService:
         except Exception:
             pass
 
-        threading_info = get_python_threading_info()
+        try:
+            from core.parallel_processing import get_python_threading_info
+
+            threading_info = get_python_threading_info()
+        except Exception:
+            threading_info = {}
         return _ok(
             {
-                "version": __version__,
+                "version": version,
                 "install_kind": install_kind,
                 "python_version": threading_info.get("python_version"),
                 "os": f"{platform.system()} {platform.release()}",

--- a/build_scripts/nuitka_flags.py
+++ b/build_scripts/nuitka_flags.py
@@ -153,6 +153,38 @@ METADATA_TEMPLATE: tuple[str, ...] = (
 )
 
 
+def _package_exists(name: str) -> bool:
+    """Build-time probe: is ``name`` importable in the build environment?"""
+    try:
+        import importlib.util
+
+        return importlib.util.find_spec(name) is not None
+    except (ImportError, ValueError):
+        return False
+
+
+# scipy가 벤더링한 array-api-compat은 백엔드 서브모듈(numpy.fft 등)을 lazy
+# import해 Nuitka의 정적 추적에서 누락된다. 2.10.0 릴리스의 standalone이
+# 모든 scipy import에서 "No module named 'scipy._external.array_api_compat.
+# numpy.fft'"로 즉사한 원인(설치본 실검증으로 발견) — CTk 기동과 WebView
+# bootstrap이 함께 죽어 UI 문자열/언어 목록까지 사라졌다. scipy 1.18+는
+# scipy._external 아래, 그 이전(1.12~1.17)은 scipy._lib 아래에 있으므로
+# 존재하는 쪽을 통째로 포함한다(없는 패키지를 include하면 Nuitka가 에러
+# 내므로 빌드 환경 기준으로 조건부).
+SCIPY_VENDORED_COMPAT_CANDIDATES: tuple[str, ...] = (
+    "scipy._external",
+    "scipy._lib.array_api_compat",
+)
+
+
+def scipy_vendored_compat_flags(package_exists=_package_exists) -> List[str]:
+    return [
+        f"--include-package={name}"
+        for name in SCIPY_VENDORED_COMPAT_CANDIDATES
+        if package_exists(name)
+    ]
+
+
 def platform_specific_flags(target_platform: str, project_root: str = ".") -> List[str]:
     """Return platform-conditional Nuitka flags.
 
@@ -236,6 +268,7 @@ def build_nuitka_args(
         args.append(f"--include-package-data={pkg}")
     for mod in INCLUDED_MODULES:
         args.append(f"--include-module={mod}")
+    args.extend(scipy_vendored_compat_flags())
 
     for src, dst in INCLUDED_DATA_DIRS:
         full_src = os.path.join(project_root, src)

--- a/build_scripts/webview_gallery.py
+++ b/build_scripts/webview_gallery.py
@@ -32,8 +32,9 @@ VIEWS = ("recorder", "processing", "settings", "info")
 # 2 skins x 2 themes x 2 languages x 4 views + 3 busy-state shots
 # (studio checklist BRIR run, studio recording run, stable modal dialog)
 # + 2 failure shots (studio checklist abort, stable modal error)
-# + 2 auto-update prompt shots (studio en, stable ko).
-EXPECTED_SHOTS = len(SKINS) * len(LANGUAGES) * len(THEMES) * len(VIEWS) + 3 + 2 + 2
+# + 2 auto-update prompt shots (studio en, stable ko)
+# + 1 first-run language picker shot.
+EXPECTED_SHOTS = len(SKINS) * len(LANGUAGES) * len(THEMES) * len(VIEWS) + 3 + 2 + 2 + 1
 
 VIEWPORT_WIDTH = 1280
 MIN_HEIGHT = 860
@@ -96,6 +97,7 @@ def _mock_bridge_js(language: str, theme: str, scenario: str, version: str, skin
       capabilities: {{ recording: true, brir: true, recording_cancel: false, brir_cancel: true }},
       active_job: activeKind ? runningJob(activeKind) : null,
       ui: {{ language: LANGUAGE, theme: THEME, skin: SKIN, frontend: "webview",
+             first_run: SCENARIO === "first-run",
              languages: LANGUAGES, strings: STRINGS }},
     }}),
     list_audio_devices: () => respond({{
@@ -294,6 +296,13 @@ def render_gallery(out_dir: Path) -> list[Path]:
         page.eval_on_selector(".nav-item[data-view='processing']", "node => node.click()")
         page.wait_for_timeout(400)
         shots.append(_shoot(page, out_dir, "processing-stable-en-dark-failed"))
+        context.close()
+
+        # First-run language picker (CTk LanguageSelectionDialog port).
+        context, page = _open_page(browser, index_uri, "en", "dark", "first-run", version)
+        page.wait_for_selector("#language-modal:not([hidden])")
+        page.wait_for_timeout(200)
+        shots.append(_shoot(page, out_dir, "firstrun-studio-en-dark"))
         context.close()
 
         # Auto-update prompt (CTk UpdateDialog port): version line, release

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -364,7 +364,6 @@
   "studio_disclosure_virtual_bass_desc": "Idealisierte Tieftonantwort hinzufügen, wo Bass fehlt",
   "studio_toggle_plot_desc": "Diagramme erzeugen (längere Verarbeitung)",
   "label_force_channels_custom": "Benutzerwert:",
-  "webview_experimental_badge": "Experimental WebView frontend",
   "webview_card_activity": "Activity",
   "webview_job_idle": "Idle",
   "webview_open_output_folder": "Open output folder",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -364,7 +364,6 @@
   "studio_disclosure_virtual_bass_desc": "Add an idealized low-frequency response where bass is lacking",
   "studio_toggle_plot_desc": "Generate graphs (longer processing)",
   "label_force_channels_custom": "Custom value:",
-  "webview_experimental_badge": "Experimental WebView frontend",
   "webview_card_activity": "Activity",
   "webview_job_idle": "Idle",
   "webview_open_output_folder": "Open output folder",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -364,7 +364,6 @@
   "studio_disclosure_virtual_bass_desc": "Añade una respuesta idealizada de bajas frecuencias donde falte bajo",
   "studio_toggle_plot_desc": "Generar gráficas (procesamiento más largo)",
   "label_force_channels_custom": "Valor personalizado:",
-  "webview_experimental_badge": "Experimental WebView frontend",
   "webview_card_activity": "Activity",
   "webview_job_idle": "Idle",
   "webview_open_output_folder": "Open output folder",

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -364,7 +364,6 @@
   "studio_disclosure_virtual_bass_desc": "Ajouter une réponse grave idéalisée quand le grave manque",
   "studio_toggle_plot_desc": "Générer des graphiques (traitement plus long)",
   "label_force_channels_custom": "Valeur personnalisée :",
-  "webview_experimental_badge": "Experimental WebView frontend",
   "webview_card_activity": "Activity",
   "webview_job_idle": "Idle",
   "webview_open_output_folder": "Open output folder",

--- a/i18n/locales/ja.json
+++ b/i18n/locales/ja.json
@@ -364,7 +364,6 @@
   "studio_disclosure_virtual_bass_desc": "低音が不足する部分に理想化した低域応答を追加します",
   "studio_toggle_plot_desc": "グラフを生成（処理時間が長くなります）",
   "label_force_channels_custom": "カスタム値:",
-  "webview_experimental_badge": "Experimental WebView frontend",
   "webview_card_activity": "Activity",
   "webview_job_idle": "Idle",
   "webview_open_output_folder": "Open output folder",

--- a/i18n/locales/ko.json
+++ b/i18n/locales/ko.json
@@ -364,7 +364,6 @@
   "studio_disclosure_virtual_bass_desc": "저음이 부족한 구간에 이상적인 저역 응답을 더합니다",
   "studio_toggle_plot_desc": "그래프 생성(처리 시간이 늘어납니다)",
   "label_force_channels_custom": "직접 입력:",
-  "webview_experimental_badge": "실험적 WebView 프론트엔드",
   "webview_card_activity": "작업 상태",
   "webview_job_idle": "대기 중",
   "webview_open_output_folder": "출력 폴더 열기",

--- a/i18n/locales/ru.json
+++ b/i18n/locales/ru.json
@@ -364,7 +364,6 @@
   "studio_disclosure_virtual_bass_desc": "Добавить идеализированный низкочастотный отклик там, где не хватает баса",
   "studio_toggle_plot_desc": "Создавать графики (дольше обрабатывается)",
   "label_force_channels_custom": "Произвольное значение:",
-  "webview_experimental_badge": "Experimental WebView frontend",
   "webview_card_activity": "Activity",
   "webview_job_idle": "Idle",
   "webview_open_output_folder": "Open output folder",

--- a/i18n/locales/zh-cn.json
+++ b/i18n/locales/zh-cn.json
@@ -364,7 +364,6 @@
   "studio_disclosure_virtual_bass_desc": "在低音不足的位置添加理想化的低频响应",
   "studio_toggle_plot_desc": "生成图表（处理时间更长）",
   "label_force_channels_custom": "自定义值:",
-  "webview_experimental_badge": "Experimental WebView frontend",
   "webview_card_activity": "Activity",
   "webview_job_idle": "Idle",
   "webview_open_output_folder": "Open output folder",

--- a/i18n/locales/zh-tw.json
+++ b/i18n/locales/zh-tw.json
@@ -364,7 +364,6 @@
   "studio_disclosure_virtual_bass_desc": "在低音不足的位置加入理想化的低頻響應",
   "studio_toggle_plot_desc": "產生圖表（處理時間較長）",
   "label_force_channels_custom": "自訂值:",
-  "webview_experimental_badge": "Experimental WebView frontend",
   "webview_card_activity": "Activity",
   "webview_job_idle": "Idle",
   "webview_open_output_folder": "Open output folder",

--- a/i18n/locales/zh_CN.json
+++ b/i18n/locales/zh_CN.json
@@ -364,7 +364,6 @@
   "studio_disclosure_virtual_bass_desc": "在低音不足的位置添加理想化的低频响应",
   "studio_toggle_plot_desc": "生成图表（处理时间更长）",
   "label_force_channels_custom": "自定义值:",
-  "webview_experimental_badge": "Experimental WebView frontend",
   "webview_card_activity": "Activity",
   "webview_job_idle": "Idle",
   "webview_open_output_folder": "Open output folder",

--- a/i18n/locales/zh_TW.json
+++ b/i18n/locales/zh_TW.json
@@ -364,7 +364,6 @@
   "studio_disclosure_virtual_bass_desc": "在低音不足的位置加入理想化的低頻響應",
   "studio_toggle_plot_desc": "產生圖表（處理時間較長）",
   "label_force_channels_custom": "自訂值:",
-  "webview_experimental_badge": "Experimental WebView frontend",
   "webview_card_activity": "Activity",
   "webview_job_idle": "Idle",
   "webview_open_output_folder": "Open output folder",

--- a/impulcifer_webview.py
+++ b/impulcifer_webview.py
@@ -1,9 +1,10 @@
-"""Experimental pywebview frontend for the Impulcifer application service."""
+"""Platform WebView frontend for the Impulcifer application service."""
 
 from __future__ import annotations
 
 from pathlib import Path
 import platform
+import time
 from typing import Any
 
 from application import ImpulciferApplicationService
@@ -39,6 +40,70 @@ def select_gui_backend() -> str:
             f"{platform.system() or 'unknown'}."
         )
     return backend
+
+
+# Pulse --bg-0 tokens (webview_ui/styles.css). Passed as the window's own
+# background so the pre-load flash matches the UI instead of blinding white.
+_WINDOW_BACKGROUNDS = {"dark": "#101214", "light": "#f3f5f7"}
+
+
+def resolve_effective_theme() -> str:
+    """Resolve the persisted theme to ``dark``/``light`` (``system`` → OS)."""
+    theme = "dark"
+    try:
+        from i18n.localization import get_localization_manager
+
+        theme = get_localization_manager().get_theme()
+    except Exception:
+        pass
+    if theme == "system":
+        if platform.system() == "Windows":
+            try:
+                import winreg
+
+                with winreg.OpenKey(
+                    winreg.HKEY_CURRENT_USER,
+                    r"Software\Microsoft\Windows\CurrentVersion\Themes\Personalize",
+                ) as key:
+                    light, _ = winreg.QueryValueEx(key, "AppsUseLightTheme")
+                return "light" if light else "dark"
+            except Exception:
+                return "dark"
+        return "dark"
+    return theme if theme in ("dark", "light") else "dark"
+
+
+def apply_windows_titlebar_theme(window: Any, dark: bool) -> bool:
+    """Match the OS title bar to the app theme via DWM, like CustomTkinter.
+
+    Without this the WebView window wears the default white Windows title
+    bar over the dark Pulse UI. Returns False only when the native handle
+    is not available yet (caller may retry); True otherwise (done or no-op).
+    """
+    if platform.system() != "Windows":
+        return True
+    try:
+        import ctypes
+        from ctypes import wintypes
+
+        handle = getattr(getattr(window, "native", None), "Handle", None)
+        if handle is None:
+            return False
+        hwnd = int(handle.ToInt64()) if hasattr(handle, "ToInt64") else int(str(handle))
+        set_attribute = ctypes.windll.dwmapi.DwmSetWindowAttribute
+        set_attribute.argtypes = [wintypes.HWND, wintypes.DWORD, ctypes.c_void_p, wintypes.DWORD]
+        set_attribute.restype = ctypes.c_long
+        value = ctypes.c_int(1 if dark else 0)
+        # 20 = DWMWA_USE_IMMERSIVE_DARK_MODE (19 on pre-20H1 Windows 10).
+        for attribute in (20, 19):
+            if set_attribute(hwnd, attribute, ctypes.byref(value), ctypes.sizeof(value)) == 0:
+                break
+        # SWP_NOSIZE|NOMOVE|NOZORDER|FRAMECHANGED — repaint the frame so the
+        # new title bar color shows without waiting for a resize.
+        ctypes.windll.user32.SetWindowPos(hwnd, 0, 0, 0, 0, 0, 0x0001 | 0x0002 | 0x0004 | 0x0020)
+    except Exception:
+        pass
+    return True
 
 
 # open_url() is allowlist-only so the JS side can never navigate the host
@@ -101,7 +166,26 @@ class WebviewBridge:
         return self._service.set_language(language_code)
 
     def set_theme(self, theme: str) -> dict[str, Any]:
-        return self._service.set_theme(theme)
+        response = self._service.set_theme(theme)
+        if response.get("ok"):
+            self.apply_titlebar_theme()
+        return response
+
+    def apply_titlebar_theme(self) -> None:
+        """Sync the native title bar with the current app theme (Windows).
+
+        The webview.start callback can fire before the native window handle
+        exists, so poll briefly instead of silently doing nothing (observed:
+        the packaged app kept the default white title bar).
+        """
+        window = self._window
+        if window is None:
+            return
+        dark = resolve_effective_theme() == "dark"
+        for _ in range(25):
+            if apply_windows_titlebar_theme(window, dark):
+                return
+            time.sleep(0.2)
 
     def set_skin(self, skin: str) -> dict[str, Any]:
         return self._service.set_skin(skin)
@@ -195,6 +279,7 @@ def create_app_window(webview_module: Any, bridge: "WebviewBridge") -> Any:
         width=1280,
         height=860,
         min_size=(980, 640),
+        background_color=_WINDOW_BACKGROUNDS[resolve_effective_theme()],
     )
     bridge.attach_window(window)
     return window
@@ -214,7 +299,8 @@ def main() -> None:
 
     bridge = WebviewBridge()
     create_app_window(webview, bridge)
-    webview.start(gui=backend, debug=False)
+    # Runs once the window is shown: the native handle exists only then.
+    webview.start(bridge.apply_titlebar_theme, gui=backend, debug=False)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "impulcifer-py313"
-version = "2.10.0"
+version = "2.10.1"
 authors = [
   { name="원본 저자: Jaakko Pasanen", email="" },
   { name="Python 3.13/3.14 호환 버전: 115dkk", email="" },

--- a/tests/test_nuitka_flags.py
+++ b/tests/test_nuitka_flags.py
@@ -245,3 +245,34 @@ def test_third_party_license_notices_are_bundled():
     assert files.get("autoeq/LICENSE") == "autoeq/LICENSE"
     # font/OFL-*.txt는 font 데이터 디렉토리 전체 포함으로 함께 실린다.
     assert dict(mod.INCLUDED_DATA_DIRS).get("font") == "font"
+
+
+def test_scipy_vendored_compat_is_included_conditionally():
+    """scipy의 벤더링 array-api-compat(lazy import 서브모듈)은 존재하는
+    경로만 --include-package 되어야 한다 — 2.10.0 standalone에서 모든
+    scipy import를 죽인 회귀(scipy 1.18의 scipy._external 누락)의 방지책."""
+    from build_scripts.nuitka_flags import scipy_vendored_compat_flags
+
+    # scipy 1.18+ 환경
+    flags = scipy_vendored_compat_flags(package_exists=lambda n: n == "scipy._external")
+    assert flags == ["--include-package=scipy._external"]
+
+    # scipy 1.12~1.17 환경
+    flags = scipy_vendored_compat_flags(
+        package_exists=lambda n: n == "scipy._lib.array_api_compat"
+    )
+    assert flags == ["--include-package=scipy._lib.array_api_compat"]
+
+    # 어느 쪽도 없으면(미래 재배치) 존재하지 않는 include를 만들지 않는다.
+    assert scipy_vendored_compat_flags(package_exists=lambda n: False) == []
+
+
+def test_build_args_include_scipy_compat_in_this_environment():
+    """실제 빌드 환경 기준으로 최소 한 경로는 포함되어야 한다(requirements의
+    scipy>=1.12는 모두 array-api-compat을 벤더링한다)."""
+    mod = _flags_module()
+    args = mod.build_nuitka_args(target_platform="windows", version="9.9.9")
+    assert any(
+        a in ("--include-package=scipy._external", "--include-package=scipy._lib.array_api_compat")
+        for a in args
+    ), "scipy vendored array-api-compat include missing from build args"

--- a/tests/test_webview_bridge.py
+++ b/tests/test_webview_bridge.py
@@ -147,7 +147,7 @@ def test_main_forces_platform_backend(monkeypatch, system, expected_backend) -> 
     calls = []
     fake_webview = SimpleNamespace(
         create_window=lambda *args, **kwargs: calls.append(("create", args, kwargs)),
-        start=lambda **kwargs: calls.append(("start", kwargs)),
+        start=lambda *args, **kwargs: calls.append(("start", args, kwargs)),
     )
     monkeypatch.setattr(impulcifer_webview.platform, "system", lambda: system)
     monkeypatch.setattr(impulcifer_webview, "_index_uri", lambda: "file:///index.html")
@@ -156,7 +156,13 @@ def test_main_forces_platform_backend(monkeypatch, system, expected_backend) -> 
     impulcifer_webview.main()
 
     assert calls[0][0] == "create"
-    assert calls[1] == ("start", {"gui": expected_backend, "debug": False})
+    # The pre-load window background matches the resolved Pulse theme token.
+    assert calls[0][2]["background_color"] in ("#101214", "#f3f5f7")
+    start_name, start_args, start_kwargs = calls[1]
+    assert start_name == "start"
+    assert start_kwargs == {"gui": expected_backend, "debug": False}
+    # First positional arg is the on-shown callback that themes the title bar.
+    assert len(start_args) == 1 and callable(start_args[0])
 
 
 def test_main_rejects_unsupported_platform(monkeypatch) -> None:
@@ -236,4 +242,4 @@ def test_webview_entrypoint_contains_no_qt_backend() -> None:
     assert '"Windows": "edgechromium"' in source
     assert '"Darwin": "cocoa"' in source
     assert '"Linux": "gtk"' in source
-    assert "webview.start(gui=backend" in source
+    assert "webview.start(bridge.apply_titlebar_theme, gui=backend" in source

--- a/webview_ui/app.js
+++ b/webview_ui/app.js
@@ -56,6 +56,27 @@ function t(key) {
   return state.strings[key] || key;
 }
 
+/* Strings needed BEFORE bootstrap delivers the locale table. If bootstrap
+   itself dies (e.g. a packaging regression on the Python side), t() would
+   render raw keys — 2.10.0 shipped exactly that. Language comes from the
+   OS/browser locale since the persisted choice is unreachable then. */
+const PREBOOT_STRINGS = {
+  en: {
+    webview_bridge_failed: "Python bridge unavailable.",
+    webview_bridge_connecting: "Connecting to Python…",
+  },
+  ko: {
+    webview_bridge_failed: "Python 브리지를 사용할 수 없습니다.",
+    webview_bridge_connecting: "Python 브리지에 연결하는 중…",
+  },
+};
+
+function tPreboot(key) {
+  if (state.strings[key]) return state.strings[key];
+  const lang = String(navigator.language || "en").toLowerCase().startsWith("ko") ? "ko" : "en";
+  return PREBOOT_STRINGS[lang][key] || PREBOOT_STRINGS.en[key] || key;
+}
+
 function fmt(text, vars) {
   return text.replace(/\{(\w+)\}/g, (match, name) =>
     Object.prototype.hasOwnProperty.call(vars, name) ? String(vars[name]) : match,
@@ -1073,12 +1094,12 @@ async function boot() {
   try {
     response = await api().bootstrap();
   } catch (error) {
-    $("runtime-status").textContent = t("webview_bridge_failed");
+    $("runtime-status").textContent = tPreboot("webview_bridge_failed");
     appendLog(String(error));
     return;
   }
   if (!response.ok) {
-    $("runtime-status").textContent = t("webview_bridge_failed");
+    $("runtime-status").textContent = tPreboot("webview_bridge_failed");
     appendLog(errorText(response));
     return;
   }
@@ -1125,9 +1146,33 @@ async function boot() {
   await Promise.all([loadDevices(), loadSystemInfo()]);
   refreshResolvedPath();
 
+  // First run: ask for the language before anything else (CTk parity).
+  if (data.ui && data.ui.first_run) {
+    showFirstRunLanguageModal(data.ui.languages || []);
+  }
+
   // Mirror the CTk root.after(2000) startup update check; failures stay
   // silent and never block the UI.
   window.setTimeout(() => checkForUpdates(false), 2000);
+}
+
+function showFirstRunLanguageModal(languages) {
+  const list = $("language-modal-list");
+  list.replaceChildren();
+  languages.forEach(({ code, name }) => {
+    const button = document.createElement("button");
+    button.className = "btn btn-secondary";
+    button.type = "button";
+    button.textContent = name;
+    button.addEventListener("click", async () => {
+      // set_language persists the choice and marks language_selected.
+      await changeLanguage(code);
+      $("sf-language").value = code;
+      $("language-modal").hidden = true;
+    });
+    list.appendChild(button);
+  });
+  if (list.childElementCount > 0) $("language-modal").hidden = false;
 }
 
 buildDecayGrid();

--- a/webview_ui/index.html
+++ b/webview_ui/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Impulcifer WebView Preview</title>
+    <title>Impulcifer</title>
     <link rel="stylesheet" href="styles.css">
   </head>
   <body>
@@ -32,7 +32,6 @@
           </button>
         </nav>
         <div class="sidebar-footer">
-          <span class="badge" data-i18n="webview_experimental_badge">Experimental WebView frontend</span>
           <span class="runtime mono" id="runtime-status" data-i18n="webview_bridge_connecting">Connecting to Python…</span>
         </div>
       </aside>
@@ -575,6 +574,18 @@
           <button class="btn btn-secondary" id="job-modal-cancel" data-i18n="button_cancel">Cancel</button>
           <button class="btn btn-primary" id="job-modal-close" data-i18n="button_close" hidden>Close</button>
         </div>
+      </div>
+    </div>
+
+    <!-- First-run language selection, mirroring the CTk
+         LanguageSelectionDialog. Shown once when ui.first_run is true. -->
+    <div class="modal-backdrop" id="language-modal" hidden>
+      <div class="modal" role="dialog" aria-modal="true" aria-labelledby="language-modal-title">
+        <div class="modal-head">
+          <h3 id="language-modal-title" data-i18n="dialog_select_language_title">Select Language</h3>
+        </div>
+        <p class="hint" data-i18n="dialog_select_language_message">Please select your language.</p>
+        <div class="lang-list" id="language-modal-list"></div>
       </div>
     </div>
 

--- a/webview_ui/styles.css
+++ b/webview_ui/styles.css
@@ -155,19 +155,14 @@ h1, h2, p { margin: 0; }
   padding: 14px;
 }
 
-.badge {
-  justify-self: start;
-  padding: 4px 8px;
-  border: 1px solid var(--line);
-  border-radius: 999px;
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: var(--fg-2);
-}
-
 .runtime { font-size: 11px; color: var(--fg-2); overflow-wrap: anywhere; }
+
+/* First-run language picker: two-column grid of language buttons. */
+.lang-list {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
 
 .content {
   overflow-y: auto;


### PR DESCRIPTION
## 사용자 보고 5건 → 근본 원인 1건 + UI 3건

### 근본 원인 (설치본 실검증으로 재현·확정)
CI가 설치한 **scipy 1.18**이 벤더링 array-api-compat을 `scipy._external`로 이동했고, lazy import 서브모듈(`numpy.fft` 등)을 Nuitka가 추적하지 못해 **설치본의 모든 scipy import가 즉사**했습니다.

```
ModuleNotFoundError: No module named 'scipy._external.array_api_compat.numpy.fft'
```

여기서 파생된 증상:
- **#3 CTk 전환 시 실행 불가**: CTk 기동이 scipy 체인에서 exit 1
- **#2 언어 선택 없음 / #5 원시 키 노출**: WebView `bootstrap()`이 같은 체인으로 사망 → 문자열 로드 전이라 `t()`가 `webview_bridge_failed` 키를 그대로 표시, populateLanguages 미실행 (설치본 CDP 프로브로 재현: `runtime: 'webview_bridge_failed', lang: 0`)

### 수정 (scipy 1.18 로컬 빌드로 전부 검증)
| 수정 | 검증 |
|---|---|
| `nuitka_flags`: `scipy._external`/`scipy._lib.array_api_compat` 조건부 통포함 | CTk 기동 OK · bootstrap OK(언어 9종) · 스모크 OK |
| **릴리스 파이프라인 스모크 게이트** (3-플랫폼 + 수동 워크플로, 패키징 전 `--smoke-test`) | 이런 '빌드 성공·기동 사망' 결함의 재발 차단 |
| bootstrap/get_system_info 방어화 | DSP 실패해도 UI/언어/설정 생존 |
| 부트 전 en/ko 폴백(`PREBOOT_STRINGS`, OS 로케일) | 원시 키 노출 원천 차단 |
| **#1 다크 제목 표시줄**: DWM IMMERSIVE_DARK_MODE + 핸들 폴링 + 테마 연동 + `--bg-0` 창 배경 | DWM 속성 조회 = 1 확인 |
| **#2 첫 실행 언어 선택 모달** (CTk 이식) | 갤러리 40샷에 리뷰 샷 추가 |
| **#4 '실험적' 딱지 제거** (배지/키 11로케일/Preview 타이틀) | — |

버전 **2.10.1** (PATCH)

🤖 Generated with [Claude Code](https://claude.com/claude-code)