### PR TITLE
fix: audit #138 round 1 — quick-win fixes and default unification (2.10.2)

### DIFF
--- a/.github/workflows/biweekly-audit.yml
+++ b/.github/workflows/biweekly-audit.yml
@@ -159,23 +159,31 @@ jobs:
             echo "::warning::Ignoring ANTHROPIC_* credentials so Claude Code uses CLAUDE_CODE_OAUTH_TOKEN."
           fi
 
+      # 워크플로 자체 산출물은 $RUNNER_TEMP/audit에 쓴다 — 체크아웃 작업
+      # 트리에 남으면 감사 세션이 untracked 파일로 오인해 finding으로 잡거나
+      # 실수로 커밋될 수 있다(특히 .txt는 release gate의 EXCLUDE에 없음).
+      # ARCHITECTURE_AUDIT.md/TECH_DEBT_AUDIT.md는 스킬이 repo 루트에 쓰는
+      # 규약이므로 그대로 두고 .gitignore로 커밋만 차단한다.
       - name: Generate change summary
         id: changes
         run: |
+          mkdir -p "$RUNNER_TEMP/audit"
+          SUMMARY="$RUNNER_TEMP/audit/change-summary.txt"
           LAST_REF="${{ needs.check-changes.outputs.last_audit_ref }}"
           if [ -n "$LAST_REF" ]; then
-            echo "## 변경된 파일 목록" > change-summary.txt
-            echo "" >> change-summary.txt
+            echo "## 변경된 파일 목록" > "$SUMMARY"
+            echo "" >> "$SUMMARY"
             git diff --stat "$LAST_REF"..HEAD \
               -- '.' ':!*.md' ':!*.txt' ':!*.rst' ':!*.ipynb' ':!docs/**' \
-              >> change-summary.txt 2>/dev/null || true
+              >> "$SUMMARY" 2>/dev/null || true
           else
-            echo "첫 감사 실행입니다." > change-summary.txt
+            echo "첫 감사 실행입니다." > "$SUMMARY"
           fi
 
       - name: Run combined audit
         run: |
           unset ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN
+          REPORT="$RUNNER_TEMP/audit/combined-audit-report.md"
 
           set +e
           claude \
@@ -208,19 +216,19 @@ jobs:
           Produce the full TECH_DEBT_AUDIT.md content with severity,
           effort estimates, and the required 'looks bad but is
           actually fine' section.
-          " > combined-audit-report.md 2>&1
+          " > "$REPORT" 2>&1
           CLAUDE_EXIT=$?
           set -e
 
           if [ "$CLAUDE_EXIT" -eq 0 ] && [ ! -s ARCHITECTURE_AUDIT.md ]; then
             echo "::error::Claude audit completed without ARCHITECTURE_AUDIT.md."
-            cat combined-audit-report.md
+            cat "$REPORT"
             exit 1
           fi
 
           if [ "$CLAUDE_EXIT" -eq 0 ] && [ ! -s TECH_DEBT_AUDIT.md ]; then
             echo "::error::Claude audit completed without TECH_DEBT_AUDIT.md."
-            cat combined-audit-report.md
+            cat "$REPORT"
             exit 1
           fi
 
@@ -232,7 +240,7 @@ jobs:
               echo "# ARCHITECTURE_AUDIT.md"
               echo ""
               cat ARCHITECTURE_AUDIT.md
-            } >> combined-audit-report.md
+            } >> "$REPORT"
           fi
 
           if [ -f TECH_DEBT_AUDIT.md ]; then
@@ -243,18 +251,18 @@ jobs:
               echo "# TECH_DEBT_AUDIT.md"
               echo ""
               cat TECH_DEBT_AUDIT.md
-            } >> combined-audit-report.md
+            } >> "$REPORT"
           fi
 
-          if [ ! -s combined-audit-report.md ]; then
-            echo "Audit produced no output." > combined-audit-report.md
-            cat combined-audit-report.md
+          if [ ! -s "$REPORT" ]; then
+            echo "Audit produced no output." > "$REPORT"
+            cat "$REPORT"
             exit 1
           fi
 
           if [ "$CLAUDE_EXIT" -ne 0 ]; then
             echo "Claude audit failed with exit code $CLAUDE_EXIT."
-            cat combined-audit-report.md
+            cat "$REPORT"
             exit "$CLAUDE_EXIT"
           fi
 
@@ -280,7 +288,7 @@ jobs:
             echo "- \`ARCHITECTURE_AUDIT.md\` - 댓글"
             echo "- \`combined-audit-report.md\` - 댓글"
             echo "- \`TECH_DEBT_AUDIT.md\` - 댓글"
-          } > issue-body.md
+          } > "$RUNNER_TEMP/audit/issue-body.md"
 
           post_file_comments() {
             local issue_number="$1"
@@ -318,11 +326,14 @@ jobs:
             total=$(find "$comment_dir" -type f -name 'part-*' | wc -l | tr -d ' ')
             local index=1
 
+            local display_name
+            display_name=$(basename "$file_path")
+
             for part in "$comment_dir"/part-*; do
               {
                 echo "## ${title} (${index}/${total})"
                 echo ""
-                echo "Source file: \`${file_path}\`"
+                echo "Source file: \`${display_name}\`"
                 echo ""
                 echo '````markdown'
                 cat "$part"
@@ -353,28 +364,27 @@ jobs:
           ISSUE_URL=$(gh issue create \
             --repo "${GITHUB_REPOSITORY}" \
             --title "Biweekly Audit: ${DATE}" \
-            --body-file issue-body.md \
+            --body-file "$RUNNER_TEMP/audit/issue-body.md" \
             --label audit \
             --label maintenance)
 
           echo "Created issue: ${ISSUE_URL}"
           ISSUE_NUMBER="${ISSUE_URL##*/}"
 
-          post_file_comments "$ISSUE_NUMBER" change-summary.txt "Change summary"
+          post_file_comments "$ISSUE_NUMBER" "$RUNNER_TEMP/audit/change-summary.txt" "Change summary"
           post_file_comments "$ISSUE_NUMBER" ARCHITECTURE_AUDIT.md "Architecture audit"
-          post_file_comments "$ISSUE_NUMBER" combined-audit-report.md "Combined audit report"
+          post_file_comments "$ISSUE_NUMBER" "$RUNNER_TEMP/audit/combined-audit-report.md" "Combined audit report"
           post_file_comments "$ISSUE_NUMBER" TECH_DEBT_AUDIT.md "Tech debt audit"
+
+      - name: Collect report artifacts
+        run: |
+          cp ARCHITECTURE_AUDIT.md TECH_DEBT_AUDIT.md "$RUNNER_TEMP/audit/" 2>/dev/null || true
 
       - name: Upload report artifact
         uses: actions/upload-artifact@v4
         with:
           name: "audit-report-${{ github.run_id }}"
-          path: |
-            combined-audit-report.md
-            change-summary.txt
-            ARCHITECTURE_AUDIT.md
-            TECH_DEBT_AUDIT.md
-            issue-body.md
+          path: ${{ runner.temp }}/audit/
           retention-days: 90
 
       - name: Tag audit checkpoint

--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,11 @@ Impulcifer_Distribution/*
 
 # WebView gallery local render output (CI publishes to the webview-gallery branch)
 webview-gallery/
+
+# Biweekly-audit outputs (published to the audit issue, never committed;
+# change-summary.txt is .txt so the release gate would treat it as shippable)
+ARCHITECTURE_AUDIT.md
+TECH_DEBT_AUDIT.md
+combined-audit-report.md
+change-summary.txt
+issue-body.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ first number changes, something has broken and you need to check your commands a
 changes there are only new features available and nothing old has broken and when the last number changes, old bugs have
 been fixed and old features improved.
 
+## 2.10.2 - 2026-08-01
+### 격주 감사(#138) 1라운드 — Quick-win 버그 수정 및 기본값 단일화
+
+#### 🐛 버그 수정
+- **`LocalizationManager.get()`이 `default=`를 무시하던 문제 수정 (F031/F055)**: 19개 이상의 호출부(gui/dialogs.py에만 27곳)가 넘기던 `default=` 폴백이 `**kwargs`로 빨려 들어가 죽은 코드였고, 누락 키는 원시 키 이름으로 렌더링됐다. 이제 번역이 없으면 `default`를 반환하고, 누락 키는 키당 1회 stdlib logging WARNING으로 기록한다.
+- **톱레이어 스피커 측정 경고 침묵 수정 (F024/F009)**: `speaker[1] == "R"` 방식의 위치 기반 분류가 3글자 이름(`TFL`)에서 틀려 상단 6개 스피커의 측정 정합성 경고가 조용히 비활성화돼 있었다. `core.constants.speaker_side()` 단일 분류기로 5곳의 좌/우/중앙 판정을 통일하고, 죽은 `_classify_speaker`/ILD 셸프 헬퍼를 삭제했다. DSP 경로는 비트 동일(해시 중립).
+- **FFmpeg lazy 초기화 경쟁 조건 수정 (F049)**: `ensure_ffmpeg_available()`의 check-then-act가 free-threaded 빌드에서 동시 자동 설치(무인 `sudo apt install` 포함)를 두 번 띄울 수 있었다. `threading.Lock`으로 직렬화.
+- **WebView→CTk 조용한 폴백 가시화 (F053)**: 패키징된 앱은 콘솔이 없어 폴백 사유가 완전히 사라졌다(pywebview 화이트리스트 회귀가 그렇게 출하됐다). 이제 사유+traceback을 `~/.impulcifer/webview-fallback.log`에 남기고 CTk 기동 직후 1회 경고 다이얼로그로 알린다.
+- **Studio 설정탭에 프론트엔드 선택기 추가 (F022)**: Studio 스킨 사용자는 UI에서 WebView로 되돌아갈 방법이 없었다(CLI 플래그만 가능). stable 탭과 동일한 WebView/CTk 선택기를 이식.
+
+#### ⭐ 개선
+- **파이프라인 기본값 단일화 (F019/F020)**: bass-boost Fc/Q(105/0.76)의 CLI·GUI 하드코딩을 `ProcessingConfig` 참조로 교체하고, WebView `bootstrap()`이 `brir_defaults` 맵을 제공해 app.js의 하드코딩 기본값(specific/generic limit 400/300 등)을 제거했다. 새 파이프라인 파라미터 기본값은 이제 dataclass 한 곳에만 존재한다.
+- **빌드 안전화 (F016)**: `gui_main.py` 부재 시 13줄짜리 stale CTk 전용 stub을 조용히 생성하던 폴백을 제거하고 빌드를 즉시 실패시킨다.
+
+#### 🔧 빌드 / 설정 변경
+- **감사 아티팩트 작업 트리 격리 (F046)**: biweekly-audit 워크플로 산출물을 `$RUNNER_TEMP/audit`으로 옮기고 5개 파일명을 `.gitignore`에 추가했다. `.txt`는 release gate EXCLUDE에 없어 `change-summary.txt`를 실수로 커밋하면 자동 릴리스가 트리거될 수 있었다.
+- **테스트 추가 (F041/F042)**: `updater/environment.py` probe ladder 첫 유닛 테스트(마커 우선순위, 번들 pip 배제), WebView `index.html`의 `data-i18n` 키 ⊆ `en.json` 계약 테스트.
+
 ## 2.10.1 - 2026-07-12
 ### 2.10.0 standalone 긴급 수정 — scipy 번들 누락으로 인한 기동 사망 + WebView 마감 손질
 

--- a/application/impulcifer_service.py
+++ b/application/impulcifer_service.py
@@ -105,6 +105,33 @@ def _brir_field_kinds() -> dict[str, str]:
     return _brir_field_kinds_cache
 
 
+_brir_field_defaults_cache: dict[str, Any] | None = None
+
+
+def _brir_field_defaults() -> dict[str, Any]:
+    """Map every defaulted ``ProcessingConfig`` field to its canonical default.
+
+    Shipped to frontends via ``bootstrap()`` so they never hardcode copies of
+    pipeline defaults (audit #138 F020).
+    """
+    global _brir_field_defaults_cache
+    if _brir_field_defaults_cache is None:
+        from dataclasses import MISSING, fields as dataclass_fields
+
+        from core.pipeline import ProcessingConfig
+
+        defaults: dict[str, Any] = {}
+        for config_field in dataclass_fields(ProcessingConfig):
+            if config_field.name == "dir_path":
+                continue
+            if config_field.default is not MISSING:
+                defaults[config_field.name] = config_field.default
+            elif config_field.default_factory is not MISSING:
+                defaults[config_field.name] = config_field.default_factory()
+        _brir_field_defaults_cache = defaults
+    return _brir_field_defaults_cache
+
+
 def _json_safe(value: Any) -> Any:
     if is_dataclass(value):
         value = asdict(value)
@@ -191,6 +218,15 @@ class ImpulciferApplicationService:
         except Exception:
             version = "unknown"
 
+        # Same isolation rule as the version probe above: pipeline defaults
+        # come from core.pipeline, and a broken DSP bundle must degrade to
+        # missing defaults (frontends keep their literal fallbacks), not to a
+        # dead bootstrap.
+        try:
+            brir_defaults = _brir_field_defaults()
+        except Exception:
+            brir_defaults = {}
+
         with self._lock:
             active_job = self._jobs.get(self._active_job_id or "")
             active = active_job.snapshot() if active_job is not None else None
@@ -198,6 +234,7 @@ class ImpulciferApplicationService:
             {
                 "version": version,
                 "platform": platform.system().lower(),
+                "brir_defaults": brir_defaults,
                 "capabilities": {
                     "recording": True,
                     "brir": True,

--- a/build_scripts/build_nuitka.py
+++ b/build_scripts/build_nuitka.py
@@ -181,21 +181,12 @@ def main():
     _generate_build_info(current_version)
 
     if not os.path.exists("gui_main.py"):
-        print("\n엔트리 포인트 파일 생성 중...", flush=True)
-        with open("gui_main.py", "w", encoding="utf-8") as f:
-            f.write("""#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-\"\"\"Impulcifer Modern GUI 엔트리 포인트\"\"\"
-import sys
-
-if __name__ == "__main__":
-    # Velopack lifecycle hooks (https://docs.velopack.io/integrating/hooks)
-    for arg in sys.argv[1:]:
-        if arg.startswith('--veloapp-'):
-            sys.exit(0)
-    from gui.modern_gui import main_gui
-    main_gui()
-""")
+        # 과거에는 여기서 13줄짜리 stub 엔트리 포인트를 생성했지만, 실제
+        # gui_main.py(스모크 테스트·프론트엔드 해석·WebView 포함)와 다른
+        # 앱이 조용히 패키징되는 위험만 남기므로 즉시 실패한다.
+        print("\n✗ 엔트리 포인트 gui_main.py를 찾을 수 없습니다. "
+              "저장소 루트에서 빌드를 실행했는지 확인하세요.", flush=True)
+        sys.exit(1)
 
     if build_impulcifer(project_version=current_version, output_base_dir="dist"):
         print("\n빌드가 완료되었습니다!", flush=True)

--- a/core/constants.py
+++ b/core/constants.py
@@ -7,6 +7,24 @@ SPEAKER_NAMES = ['FL', 'FR', 'FC', 'BL', 'BR', 'SL', 'SR', 'WL', 'WR', 'TFL', 'T
 SPEAKER_PATTERN = f'({"|".join(SPEAKER_NAMES + ["X"])})'
 SPEAKER_LIST_PATTERN = r'([A-Z]{2,3}(,[A-Z]{2,3})*)'
 
+# Left/right/center partition of the speaker layout. Includes LFE (present in
+# HEXADECAGONAL_TRACK_ORDER but not SPEAKER_NAMES). Single source of truth for
+# "which side of the head is this speaker on" — positional checks like
+# speaker[1] == 'R' break on 3-letter top-layer names ('TFL'[1] == 'F').
+LEFT_SIDE_SPEAKERS = frozenset({'FL', 'SL', 'BL', 'WL', 'TFL', 'TSL', 'TBL'})
+RIGHT_SIDE_SPEAKERS = frozenset({'FR', 'SR', 'BR', 'WR', 'TFR', 'TSR', 'TBR'})
+CENTER_SPEAKERS = frozenset({'FC', 'LFE'})
+
+
+def speaker_side(name: str) -> str:
+    """Classify a speaker name as 'left', 'right' or 'center'."""
+    name_upper = name.upper()
+    if name_upper in LEFT_SIDE_SPEAKERS:
+        return 'left'
+    if name_upper in RIGHT_SIDE_SPEAKERS:
+        return 'right'
+    return 'center'
+
 TRUEHD_11CH_ORDER = ['FL', 'FR', 'FC', 'BL', 'BR', 'SL', 'SR', 'TFL', 'TFR', 'TBL', 'TBR']  # 7.0.4
 TRUEHD_13CH_ORDER = ['FL', 'FR', 'FC', 'BL', 'BR', 'SL', 'SR', 'TFL', 'TFR', 'TSL', 'TSR', 'TBL', 'TBR']  # 7.0.6
 

--- a/core/ffmpeg_discovery.py
+++ b/core/ffmpeg_discovery.py
@@ -12,6 +12,7 @@ import os
 import platform
 import shutil
 import subprocess
+import threading
 from pathlib import Path
 
 
@@ -275,6 +276,10 @@ _FFMPEG_AUTO_INSTALL_ATTEMPTED = False
 # Backward-compatible state name for older tests/importers. It mirrors whether
 # any detection/install path has already been attempted.
 _FFMPEG_SETUP_DONE = False
+# The lazy init is reachable from the audio read path on multiple threads
+# (free-threaded builds especially); without the lock two threads could both
+# pass the detection check and launch concurrent auto-installs.
+_FFMPEG_LOCK = threading.Lock()
 
 
 def ensure_ffmpeg_available(auto_install=True):
@@ -291,25 +296,26 @@ def ensure_ffmpeg_available(auto_install=True):
     global FFMPEG_PATH, FFPROBE_PATH
     global _FFMPEG_DETECTION_DONE, _FFMPEG_AUTO_INSTALL_ATTEMPTED, _FFMPEG_SETUP_DONE
 
-    if FFMPEG_PATH is not None and FFPROBE_PATH is not None:
-        return True
-
-    if not _FFMPEG_DETECTION_DONE:
-        _FFMPEG_DETECTION_DONE = True
-        _FFMPEG_SETUP_DONE = True
-        FFMPEG_PATH, FFPROBE_PATH = setup_ffmpeg(auto_install=False)
+    with _FFMPEG_LOCK:
         if FFMPEG_PATH is not None and FFPROBE_PATH is not None:
             return True
 
-    if auto_install and not _FFMPEG_AUTO_INSTALL_ATTEMPTED:
-        _FFMPEG_AUTO_INSTALL_ATTEMPTED = True
-        _FFMPEG_SETUP_DONE = True
-        FFMPEG_PATH, FFPROBE_PATH = setup_ffmpeg(auto_install=True)
-        if FFMPEG_PATH is not None and FFPROBE_PATH is not None:
-            return True
-        print("FFmpeg를 찾거나 설치할 수 없습니다. TrueHD/MLP 지원이 비활성화됩니다.")
+        if not _FFMPEG_DETECTION_DONE:
+            _FFMPEG_DETECTION_DONE = True
+            _FFMPEG_SETUP_DONE = True
+            FFMPEG_PATH, FFPROBE_PATH = setup_ffmpeg(auto_install=False)
+            if FFMPEG_PATH is not None and FFPROBE_PATH is not None:
+                return True
 
-    return False
+        if auto_install and not _FFMPEG_AUTO_INSTALL_ATTEMPTED:
+            _FFMPEG_AUTO_INSTALL_ATTEMPTED = True
+            _FFMPEG_SETUP_DONE = True
+            FFMPEG_PATH, FFPROBE_PATH = setup_ffmpeg(auto_install=True)
+            if FFMPEG_PATH is not None and FFPROBE_PATH is not None:
+                return True
+            print("FFmpeg를 찾거나 설치할 수 없습니다. TrueHD/MLP 지원이 비활성화됩니다.")
+
+        return False
 
 
 def check_ffmpeg_available(auto_install=False):

--- a/core/hrir.py
+++ b/core/hrir.py
@@ -10,7 +10,7 @@ from scipy.interpolate import InterpolatedUnivariateSpline
 from autoeq.frequency_response import FrequencyResponse
 from core.impulse_response import ImpulseResponse
 from core.utils import read_wav, write_wav, magnitude_response
-from core.constants import SPEAKER_NAMES, SPEAKER_DELAYS, HEXADECAGONAL_TRACK_ORDER, IPSILATERAL_PAIRS
+from core.constants import SPEAKER_NAMES, SPEAKER_DELAYS, HEXADECAGONAL_TRACK_ORDER, IPSILATERAL_PAIRS, speaker_side
 from core.plotting.hrir_plotter import HRIRPlotter
 
 try:
@@ -574,8 +574,8 @@ class HRIR(HRIRPlotter):
             )  # Channel delay in samples
 
             if peak_left < peak_right:
-                # Delay to left ear is smaller, this is must left side speaker
-                if speaker[1] == "R":
+                # Delay to left ear is smaller, this must be a left side speaker
+                if speaker_side(speaker) == "right":
                     # Speaker name indicates this is right side speaker but delay to left ear is smaller than to right.
                     # There is something wrong with the measurement
                     warnings.warn(
@@ -592,8 +592,8 @@ class HRIR(HRIRPlotter):
                 pair["left"].data = pair["left"].data[crop_index:]
                 pair["right"].data = pair["right"].data[crop_index:]
             else:
-                # Delay to right ear is smaller, this is must right side speaker
-                if speaker[1] == "L":
+                # Delay to right ear is smaller, this must be a right side speaker
+                if speaker_side(speaker) == "left":
                     # Speaker name indicates this is left side speaker but delay to right ear is smaller than to left.
                     # There si something wrong with the measurement
                     warnings.warn(

--- a/core/virtual_bass.py
+++ b/core/virtual_bass.py
@@ -12,36 +12,9 @@ from typing import Optional
 
 import numpy as np
 from scipy import signal
-from scipy.signal import butter, sosfilt
 
+from core.constants import speaker_side
 from infra.logger import get_logger
-
-
-_LEFT_SIDE_SPEAKERS = frozenset({
-    "FL", "SL", "BL", "WL", "TFL", "TSL", "TBL",
-})
-_RIGHT_SIDE_SPEAKERS = frozenset({
-    "FR", "SR", "BR", "WR", "TFR", "TSR", "TBR",
-})
-_CENTER_SPEAKERS = frozenset({
-    "FC", "LFE",
-})
-
-_ILD_SHELF_TABLE = [
-    (80, 50.0, 3.0),
-    (160, 100.0, 4.5),
-    (250, 150.0, 6.0),
-]
-
-
-def _classify_speaker(name: str) -> str:
-    """Classify a speaker name into 'left', 'right', or 'center'."""
-    name_upper = name.upper()
-    if name_upper in _LEFT_SIDE_SPEAKERS:
-        return "left"
-    if name_upper in _RIGHT_SIDE_SPEAKERS:
-        return "right"
-    return "center"
 
 
 def _detect_polarity(ir: np.ndarray) -> float:
@@ -104,35 +77,6 @@ def _rbj_high_shelf(fc: float, fs: int, gain_db: float, q: float) -> np.ndarray:
     a2 = (a + 1) - (a - 1) * cos_w0 - 2 * np.sqrt(a) * alpha
 
     return signal.tf2sos([b0, b1, b2], [a0, a1, a2])
-
-
-def _build_ild_shelf(xo_hz: float, fs: int):
-    """Build the legacy low-shelf descriptor kept for API/tests."""
-    best = None
-    for threshold, shelf_freq, shelf_gain_db in _ILD_SHELF_TABLE:
-        if xo_hz >= threshold:
-            best = (shelf_freq, shelf_gain_db)
-    if best is None:
-        return None
-    shelf_freq, shelf_gain_db = best
-    gain_linear = 10 ** (shelf_gain_db / 20.0)
-    sos_lp = butter(2, shelf_freq, btype="low", fs=fs, output="sos")
-    return sos_lp, gain_linear, shelf_gain_db
-
-
-def _apply_ild_shelf(ir: np.ndarray, shelf_info, side: str, speaker_class: str) -> np.ndarray:
-    """Legacy low-shelf helper kept for compatibility with older callers."""
-    if shelf_info is None or speaker_class == "center":
-        return ir
-
-    sos_lp, gain_linear, _ = shelf_info
-    lf_component = sosfilt(sos_lp, ir)
-    if speaker_class == side:
-        boost = (gain_linear - 1.0) * 0.5
-        return ir + boost * lf_component
-
-    cut = (1.0 - 1.0 / gain_linear) * 0.5
-    return ir - cut * lf_component
 
 
 def synthesize_virtual_bass(
@@ -201,7 +145,7 @@ def synthesize_virtual_bass(
         if "left" not in pair or "right" not in pair:
             continue
 
-        speaker_on_left = speaker.upper().endswith("L")
+        speaker_on_left = speaker_side(speaker) == "left"
         left_peak = pair["left"].peak_index()
         right_peak = pair["right"].peak_index()
         if not isinstance(left_peak, (int, np.integer, float, np.floating)):

--- a/gui/brir_args.py
+++ b/gui/brir_args.py
@@ -100,8 +100,12 @@ def build_brir_args(tab: Any, loc: Any) -> dict:
         bass_gain = safe_get_double(tab.bass_boost_gain_var, 0.0)
         if bass_gain:
             args["bass_boost_gain"] = bass_gain
-            args["bass_boost_fc"] = safe_get_int(tab.bass_boost_fc_var, 105)
-            args["bass_boost_q"] = safe_get_double(tab.bass_boost_q_var, 0.76)
+            args["bass_boost_fc"] = safe_get_int(
+                tab.bass_boost_fc_var, int(processing_default("bass_boost_fc"))
+            )
+            args["bass_boost_q"] = safe_get_double(
+                tab.bass_boost_q_var, float(processing_default("bass_boost_q"))
+            )
 
         tilt_val = safe_get_double(tab.tilt_var, 0.0)
         if tilt_val:

--- a/gui/modern_gui.py
+++ b/gui/modern_gui.py
@@ -36,8 +36,13 @@ else:
 class ModernImpulciferGUI:
     """Top-level orchestrator for the modern GUI."""
 
-    def __init__(self) -> None:
-        """Initialize localization, theme, root window, and tabs."""
+    def __init__(self, startup_notice: str | None = None) -> None:
+        """Initialize localization, theme, root window, and tabs.
+
+        ``startup_notice`` is a pre-localized message shown once shortly
+        after launch — used by the launcher to surface a WebView→CTk
+        fallback that would otherwise be invisible in packaged apps.
+        """
         self.loc = get_localization_manager()
         self.current_theme = self.loc.get_theme()
         self.bus = EventBus()
@@ -85,6 +90,12 @@ class ModernImpulciferGUI:
             self.root.after(1000, lambda: messagebox.showinfo(
                 self.loc.get('update_complete_title', default="Update Complete"),
                 self.loc.get('update_restart_done', default="The new version has been installed successfully.")
+            ))
+
+        if startup_notice:
+            self.root.after(1500, lambda: messagebox.showwarning(
+                self.loc.get('message_webview_fallback_title', default="WebView Unavailable"),
+                startup_notice,
             ))
 
         window_width, window_height = WINDOW_MAIN_SIZE
@@ -421,9 +432,9 @@ class ModernImpulciferGUI:
         self.root.mainloop()
 
 
-def main_gui() -> None:
+def main_gui(startup_notice: str | None = None) -> None:
     """Start the modern GUI application."""
-    app = ModernImpulciferGUI()
+    app = ModernImpulciferGUI(startup_notice=startup_notice)
     app.run()
 
 

--- a/gui/skins/studio_settings_tab.py
+++ b/gui/skins/studio_settings_tab.py
@@ -73,6 +73,14 @@ class StudioSettingsTab:
         self._build_setting_row(
             body,
             row=1,
+            label=self.loc.get("section_frontend"),
+            description=self.loc.get("tooltip_frontend"),
+            make_control=self._make_frontend_segment,
+        )
+
+        self._build_setting_row(
+            body,
+            row=2,
             label=self.loc.get("section_language"),
             description=self.loc.get("label_select_language"),
             make_control=self._make_language_dropdown,
@@ -80,7 +88,7 @@ class StudioSettingsTab:
 
         self._build_setting_row(
             body,
-            row=2,
+            row=3,
             label=self.loc.get("section_theme"),
             description=self.loc.get("label_select_theme"),
             make_control=self._make_theme_dropdown,
@@ -161,6 +169,32 @@ class StudioSettingsTab:
             width=200,
         )
         seg.set(skin_value_map.get(current, self.loc.get("option_skin_stable")))
+        return seg
+
+    def _make_frontend_segment(self, parent: ctk.CTkBaseClass) -> ctk.CTkSegmentedButton:
+        """gui_main launcher default (WebView/CTk) — applies on next launch.
+
+        Mirrors the stable Settings tab's frontend selector; without it a
+        Studio-skin user had no way back to the WebView frontend from the UI.
+        """
+        current = self.loc.get_frontend()
+        frontend_label_map = {
+            self.loc.get("option_frontend_webview"): "webview",
+            self.loc.get("option_frontend_ctk"): "ctk",
+        }
+        frontend_value_map = {v: k for k, v in frontend_label_map.items()}
+
+        def _on_change(value: str) -> None:
+            self.loc.set_frontend(frontend_label_map.get(value, "webview"))
+
+        seg = ctk.CTkSegmentedButton(
+            parent,
+            values=list(frontend_label_map.keys()),
+            command=_on_change,
+            font=ctk.CTkFont(family=self.app.font_family, size=12, weight="bold"),
+            width=200,
+        )
+        seg.set(frontend_value_map.get(current, self.loc.get("option_frontend_webview")))
         return seg
 
     def _make_language_dropdown(self, parent: ctk.CTkBaseClass) -> ctk.CTkOptionMenu:

--- a/gui_main.py
+++ b/gui_main.py
@@ -220,8 +220,50 @@ def _resolve_frontend() -> str:
         return "webview"
 
 
+def _record_webview_fallback(stage: str, exc: BaseException) -> str:
+    """Persist the WebView→CTk fallback reason and return the user notice.
+
+    Packaged apps have no console, so a bare ``print`` makes the fallback
+    invisible — the exact failure mode that already shipped once with the
+    Nuitka pywebview-whitelist bug. The reason goes to a file under
+    ``~/.impulcifer`` and a localized summary is handed to the CTk GUI for a
+    one-time warning dialog.
+    """
+    import datetime
+    import traceback
+    from pathlib import Path
+
+    reason = f"{type(exc).__name__}: {exc}"
+    log_path = Path.home() / ".impulcifer" / "webview-fallback.log"
+    try:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(log_path, "a", encoding="utf-8") as fh:
+            fh.write(f"[{datetime.datetime.now():%Y-%m-%d %H:%M:%S}] {stage}: {reason}\n")
+            fh.write(traceback.format_exc())
+            fh.write("\n")
+    except Exception:
+        pass
+
+    try:
+        from i18n.localization import t
+
+        return t(
+            "message_webview_fallback_body",
+            default=(
+                "The WebView interface could not be started, so the CustomTkinter "
+                "interface is shown instead.\n\nReason: {reason}\n\n"
+                "A detailed log was written to:\n{log_path}"
+            ),
+            reason=reason,
+            log_path=str(log_path),
+        )
+    except Exception:
+        return f"WebView unavailable: {reason}\nLog: {log_path}"
+
+
 def _launch_frontend() -> None:
     frontend = _resolve_frontend()
+    fallback_notice = None
     if frontend == "webview":
         try:
             import webview  # noqa: F401
@@ -232,6 +274,7 @@ def _launch_frontend() -> None:
             # SystemExit comes from select_gui_backend on unsupported
             # platforms; ImportError from a missing pywebview install.
             print(f"WebView frontend unavailable ({exc}); falling back to CustomTkinter.")
+            fallback_notice = _record_webview_fallback("unavailable", exc)
         else:
             try:
                 webview_main()
@@ -241,9 +284,10 @@ def _launch_frontend() -> None:
                 # (missing WebView2 runtime / system WebKit). Fall back so a
                 # broken WebView stack never leaves the user with nothing.
                 print(f"WebView frontend failed to start ({exc}); falling back to CustomTkinter.")
+                fallback_notice = _record_webview_fallback("failed to start", exc)
     from gui.modern_gui import main_gui
 
-    main_gui()
+    main_gui(startup_notice=fallback_notice)
 
 
 if __name__ == "__main__":

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -384,5 +384,7 @@
   "option_frontend_webview": "WebView (recommended)",
   "option_frontend_ctk": "CustomTkinter (legacy)",
   "tooltip_frontend": "Which interface opens when the app starts. Takes effect on the next launch.",
-  "label_ctk_deprecation": "Notice: the CustomTkinter interface remains fully supported — including new features — for the rest of version 2. From version 3 it will be kept as a frozen legacy interface without further updates (only the old legacy GUI is removed in version 3). WebView is the new default interface."
+  "label_ctk_deprecation": "Notice: the CustomTkinter interface remains fully supported — including new features — for the rest of version 2. From version 3 it will be kept as a frozen legacy interface without further updates (only the old legacy GUI is removed in version 3). WebView is the new default interface.",
+  "message_webview_fallback_title": "WebView Unavailable",
+  "message_webview_fallback_body": "The WebView interface could not be started, so the CustomTkinter interface is shown instead.\n\nReason: {reason}\n\nA detailed log was written to:\n{log_path}"
 }

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -384,5 +384,7 @@
   "option_frontend_webview": "WebView (recommended)",
   "option_frontend_ctk": "CustomTkinter (legacy)",
   "tooltip_frontend": "Which interface opens when the app starts. Takes effect on the next launch.",
-  "label_ctk_deprecation": "Notice: the CustomTkinter interface remains fully supported — including new features — for the rest of version 2. From version 3 it will be kept as a frozen legacy interface without further updates (only the old legacy GUI is removed in version 3). WebView is the new default interface."
+  "label_ctk_deprecation": "Notice: the CustomTkinter interface remains fully supported — including new features — for the rest of version 2. From version 3 it will be kept as a frozen legacy interface without further updates (only the old legacy GUI is removed in version 3). WebView is the new default interface.",
+  "message_webview_fallback_title": "WebView Unavailable",
+  "message_webview_fallback_body": "The WebView interface could not be started, so the CustomTkinter interface is shown instead.\n\nReason: {reason}\n\nA detailed log was written to:\n{log_path}"
 }

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -384,5 +384,7 @@
   "option_frontend_webview": "WebView (recommended)",
   "option_frontend_ctk": "CustomTkinter (legacy)",
   "tooltip_frontend": "Which interface opens when the app starts. Takes effect on the next launch.",
-  "label_ctk_deprecation": "Notice: the CustomTkinter interface remains fully supported — including new features — for the rest of version 2. From version 3 it will be kept as a frozen legacy interface without further updates (only the old legacy GUI is removed in version 3). WebView is the new default interface."
+  "label_ctk_deprecation": "Notice: the CustomTkinter interface remains fully supported — including new features — for the rest of version 2. From version 3 it will be kept as a frozen legacy interface without further updates (only the old legacy GUI is removed in version 3). WebView is the new default interface.",
+  "message_webview_fallback_title": "WebView Unavailable",
+  "message_webview_fallback_body": "The WebView interface could not be started, so the CustomTkinter interface is shown instead.\n\nReason: {reason}\n\nA detailed log was written to:\n{log_path}"
 }

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -384,5 +384,7 @@
   "option_frontend_webview": "WebView (recommended)",
   "option_frontend_ctk": "CustomTkinter (legacy)",
   "tooltip_frontend": "Which interface opens when the app starts. Takes effect on the next launch.",
-  "label_ctk_deprecation": "Notice: the CustomTkinter interface remains fully supported — including new features — for the rest of version 2. From version 3 it will be kept as a frozen legacy interface without further updates (only the old legacy GUI is removed in version 3). WebView is the new default interface."
+  "label_ctk_deprecation": "Notice: the CustomTkinter interface remains fully supported — including new features — for the rest of version 2. From version 3 it will be kept as a frozen legacy interface without further updates (only the old legacy GUI is removed in version 3). WebView is the new default interface.",
+  "message_webview_fallback_title": "WebView Unavailable",
+  "message_webview_fallback_body": "The WebView interface could not be started, so the CustomTkinter interface is shown instead.\n\nReason: {reason}\n\nA detailed log was written to:\n{log_path}"
 }

--- a/i18n/locales/ja.json
+++ b/i18n/locales/ja.json
@@ -384,5 +384,7 @@
   "option_frontend_webview": "WebView (recommended)",
   "option_frontend_ctk": "CustomTkinter (legacy)",
   "tooltip_frontend": "Which interface opens when the app starts. Takes effect on the next launch.",
-  "label_ctk_deprecation": "Notice: the CustomTkinter interface remains fully supported — including new features — for the rest of version 2. From version 3 it will be kept as a frozen legacy interface without further updates (only the old legacy GUI is removed in version 3). WebView is the new default interface."
+  "label_ctk_deprecation": "Notice: the CustomTkinter interface remains fully supported — including new features — for the rest of version 2. From version 3 it will be kept as a frozen legacy interface without further updates (only the old legacy GUI is removed in version 3). WebView is the new default interface.",
+  "message_webview_fallback_title": "WebView Unavailable",
+  "message_webview_fallback_body": "The WebView interface could not be started, so the CustomTkinter interface is shown instead.\n\nReason: {reason}\n\nA detailed log was written to:\n{log_path}"
 }

--- a/i18n/locales/ko.json
+++ b/i18n/locales/ko.json
@@ -384,5 +384,7 @@
   "option_frontend_webview": "WebView (권장)",
   "option_frontend_ctk": "CustomTkinter (레거시)",
   "tooltip_frontend": "앱 시작 시 열리는 인터페이스입니다. 다음 실행부터 적용됩니다.",
-  "label_ctk_deprecation": "안내: CustomTkinter 인터페이스는 버전 2 동안 기능 추가를 포함해 계속 완전히 지원됩니다. 버전 3부터는 지금의 레거시 GUI처럼 업데이트 없이 동결 상태로 유지됩니다(버전 3에서 제거되는 것은 구버전 레거시 GUI뿐입니다). 새 기본 인터페이스는 WebView입니다."
+  "label_ctk_deprecation": "안내: CustomTkinter 인터페이스는 버전 2 동안 기능 추가를 포함해 계속 완전히 지원됩니다. 버전 3부터는 지금의 레거시 GUI처럼 업데이트 없이 동결 상태로 유지됩니다(버전 3에서 제거되는 것은 구버전 레거시 GUI뿐입니다). 새 기본 인터페이스는 WebView입니다.",
+  "message_webview_fallback_title": "WebView 사용 불가",
+  "message_webview_fallback_body": "WebView 인터페이스를 시작할 수 없어 CustomTkinter 인터페이스로 대신 실행했습니다.\n\n원인: {reason}\n\n자세한 로그가 다음 파일에 기록되었습니다:\n{log_path}"
 }

--- a/i18n/locales/ru.json
+++ b/i18n/locales/ru.json
@@ -384,5 +384,7 @@
   "option_frontend_webview": "WebView (recommended)",
   "option_frontend_ctk": "CustomTkinter (legacy)",
   "tooltip_frontend": "Which interface opens when the app starts. Takes effect on the next launch.",
-  "label_ctk_deprecation": "Notice: the CustomTkinter interface remains fully supported — including new features — for the rest of version 2. From version 3 it will be kept as a frozen legacy interface without further updates (only the old legacy GUI is removed in version 3). WebView is the new default interface."
+  "label_ctk_deprecation": "Notice: the CustomTkinter interface remains fully supported — including new features — for the rest of version 2. From version 3 it will be kept as a frozen legacy interface without further updates (only the old legacy GUI is removed in version 3). WebView is the new default interface.",
+  "message_webview_fallback_title": "WebView Unavailable",
+  "message_webview_fallback_body": "The WebView interface could not be started, so the CustomTkinter interface is shown instead.\n\nReason: {reason}\n\nA detailed log was written to:\n{log_path}"
 }

--- a/i18n/locales/zh-cn.json
+++ b/i18n/locales/zh-cn.json
@@ -384,5 +384,7 @@
   "option_frontend_webview": "WebView (recommended)",
   "option_frontend_ctk": "CustomTkinter (legacy)",
   "tooltip_frontend": "Which interface opens when the app starts. Takes effect on the next launch.",
-  "label_ctk_deprecation": "Notice: the CustomTkinter interface remains fully supported — including new features — for the rest of version 2. From version 3 it will be kept as a frozen legacy interface without further updates (only the old legacy GUI is removed in version 3). WebView is the new default interface."
+  "label_ctk_deprecation": "Notice: the CustomTkinter interface remains fully supported — including new features — for the rest of version 2. From version 3 it will be kept as a frozen legacy interface without further updates (only the old legacy GUI is removed in version 3). WebView is the new default interface.",
+  "message_webview_fallback_title": "WebView Unavailable",
+  "message_webview_fallback_body": "The WebView interface could not be started, so the CustomTkinter interface is shown instead.\n\nReason: {reason}\n\nA detailed log was written to:\n{log_path}"
 }

--- a/i18n/locales/zh-tw.json
+++ b/i18n/locales/zh-tw.json
@@ -384,5 +384,7 @@
   "option_frontend_webview": "WebView (recommended)",
   "option_frontend_ctk": "CustomTkinter (legacy)",
   "tooltip_frontend": "Which interface opens when the app starts. Takes effect on the next launch.",
-  "label_ctk_deprecation": "Notice: the CustomTkinter interface remains fully supported — including new features — for the rest of version 2. From version 3 it will be kept as a frozen legacy interface without further updates (only the old legacy GUI is removed in version 3). WebView is the new default interface."
+  "label_ctk_deprecation": "Notice: the CustomTkinter interface remains fully supported — including new features — for the rest of version 2. From version 3 it will be kept as a frozen legacy interface without further updates (only the old legacy GUI is removed in version 3). WebView is the new default interface.",
+  "message_webview_fallback_title": "WebView Unavailable",
+  "message_webview_fallback_body": "The WebView interface could not be started, so the CustomTkinter interface is shown instead.\n\nReason: {reason}\n\nA detailed log was written to:\n{log_path}"
 }

--- a/i18n/locales/zh_CN.json
+++ b/i18n/locales/zh_CN.json
@@ -384,5 +384,7 @@
   "option_frontend_webview": "WebView (recommended)",
   "option_frontend_ctk": "CustomTkinter (legacy)",
   "tooltip_frontend": "Which interface opens when the app starts. Takes effect on the next launch.",
-  "label_ctk_deprecation": "Notice: the CustomTkinter interface remains fully supported — including new features — for the rest of version 2. From version 3 it will be kept as a frozen legacy interface without further updates (only the old legacy GUI is removed in version 3). WebView is the new default interface."
+  "label_ctk_deprecation": "Notice: the CustomTkinter interface remains fully supported — including new features — for the rest of version 2. From version 3 it will be kept as a frozen legacy interface without further updates (only the old legacy GUI is removed in version 3). WebView is the new default interface.",
+  "message_webview_fallback_title": "WebView Unavailable",
+  "message_webview_fallback_body": "The WebView interface could not be started, so the CustomTkinter interface is shown instead.\n\nReason: {reason}\n\nA detailed log was written to:\n{log_path}"
 }

--- a/i18n/locales/zh_TW.json
+++ b/i18n/locales/zh_TW.json
@@ -384,5 +384,7 @@
   "option_frontend_webview": "WebView (recommended)",
   "option_frontend_ctk": "CustomTkinter (legacy)",
   "tooltip_frontend": "Which interface opens when the app starts. Takes effect on the next launch.",
-  "label_ctk_deprecation": "Notice: the CustomTkinter interface remains fully supported — including new features — for the rest of version 2. From version 3 it will be kept as a frozen legacy interface without further updates (only the old legacy GUI is removed in version 3). WebView is the new default interface."
+  "label_ctk_deprecation": "Notice: the CustomTkinter interface remains fully supported — including new features — for the rest of version 2. From version 3 it will be kept as a frozen legacy interface without further updates (only the old legacy GUI is removed in version 3). WebView is the new default interface.",
+  "message_webview_fallback_title": "WebView Unavailable",
+  "message_webview_fallback_body": "The WebView interface could not be started, so the CustomTkinter interface is shown instead.\n\nReason: {reason}\n\nA detailed log was written to:\n{log_path}"
 }

--- a/i18n/localization.py
+++ b/i18n/localization.py
@@ -7,6 +7,7 @@ Supports multiple languages with automatic system language detection
 
 import json
 import locale
+import logging
 from pathlib import Path
 from typing import Dict, Optional
 
@@ -22,6 +23,11 @@ SUPPORTED_LANGUAGES = {
     'zh_TW': '繁體中文',
     'ru': 'Русский'
 }
+
+# Missing-key warnings are deduplicated process-wide so a key that renders on
+# every GUI refresh does not flood the log.
+_missing_key_log = logging.getLogger(__name__)
+_MISSING_KEYS_WARNED: set = set()
 
 # Mapping from system locale to our language codes
 LOCALE_MAPPING = {
@@ -202,9 +208,22 @@ class LocalizationManager:
         else:
             self.translations = {}
 
-    def get(self, key: str, **kwargs) -> str:
-        """Get translated text for a key"""
-        text = self.translations.get(key, key)
+    def get(self, key: str, default: Optional[str] = None, **kwargs) -> str:
+        """Get translated text for a key.
+
+        Returns ``default`` when the key has no translation; without a
+        default the key itself is returned (legacy behavior for call sites
+        that pass none).
+        """
+        text = self.translations.get(key)
+        if text is None:
+            if key not in _MISSING_KEYS_WARNED:
+                _MISSING_KEYS_WARNED.add(key)
+                _missing_key_log.warning(
+                    "Missing translation key '%s' (language '%s')",
+                    key, self.current_language,
+                )
+            text = key if default is None else default
 
         if kwargs:
             try:
@@ -289,6 +308,6 @@ def get_localization_manager() -> LocalizationManager:
     return _localization_manager
 
 
-def t(key: str, **kwargs) -> str:
+def t(key: str, default: Optional[str] = None, **kwargs) -> str:
     """Shorthand for getting translated text"""
-    return get_localization_manager().get(key, **kwargs)
+    return get_localization_manager().get(key, default=default, **kwargs)

--- a/impulcifer.py
+++ b/impulcifer.py
@@ -838,7 +838,14 @@ def create_cli():
     arguments (``--info``, ``--version``, the ``--bass_boost`` shelf splitter)
     and post-processing remain here.
     """
+    from dataclasses import fields as _dataclass_fields
+
     from core.cli_builder import add_processing_config_arguments
+    from core.pipeline import ProcessingConfig
+
+    _config_defaults = {f.name: f.default for f in _dataclass_fields(ProcessingConfig)}
+    _bass_fc_default = _config_defaults["bass_boost_fc"]
+    _bass_q_default = _config_defaults["bass_boost_q"]
 
     arg_parser = argparse.ArgumentParser()
     arg_parser.add_argument(
@@ -866,7 +873,8 @@ def create_cli():
         "either a single value for a gain in dB or a comma separated list of three values for "
         "parameters of a low shelf filter, where the first is gain in dB, second is center "
         "frequency (Fc) in Hz and the last is quality (Q). When only a single value (gain) is "
-        "given, default values for Fc and Q are used which are 105 Hz and 0.76, respectively. "
+        f"given, default values for Fc and Q are used which are {_bass_fc_default:g} Hz and "
+        f"{_bass_q_default:g}, respectively. "
         'For example "--bass_boost=6" or "--bass_boost=6,150,0.69".',
     )
 
@@ -884,8 +892,8 @@ def create_cli():
         bass_boost = args["bass_boost"].split(",")
         if len(bass_boost) == 1:
             args["bass_boost_gain"] = float(bass_boost[0])
-            args["bass_boost_fc"] = 105
-            args["bass_boost_q"] = 0.76
+            args["bass_boost_fc"] = _bass_fc_default
+            args["bass_boost_q"] = _bass_q_default
         elif len(bass_boost) == 3:
             args["bass_boost_gain"] = float(bass_boost[0])
             args["bass_boost_fc"] = float(bass_boost[1])

--- a/impulcifer.py
+++ b/impulcifer.py
@@ -74,6 +74,7 @@ from core.constants import (
     SPEAKER_LIST_PATTERN,
     TEST_SIGNALS,
     get_data_path,
+    speaker_side,
 )
 from core.eqapo import looks_like_eqapo_config, parse_eqapo_config
 from infra.logger import get_logger
@@ -663,9 +664,9 @@ def write_readme(file_path, hrir, fs, estimator, applied_gain):
         for side, ir_obj in pair.items():
             current_itd = 0.0
             if not np.isnan(itd):
-                if speaker.endswith("L") and side == "right":
+                if speaker_side(speaker) == "left" and side == "right":
                     current_itd = itd
-                elif speaker.endswith("R") and side == "left":
+                elif speaker_side(speaker) == "right" and side == "left":
                     current_itd = itd
 
             pnr_val = np.nan

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "impulcifer-py313"
-version = "2.10.1"
+version = "2.10.2"
 authors = [
   { name="원본 저자: Jaakko Pasanen", email="" },
   { name="Python 3.13/3.14 호환 버전: 115dkk", email="" },

--- a/tests/test_application_service.py
+++ b/tests/test_application_service.py
@@ -455,6 +455,26 @@ def test_ui_settings_language_and_theme_roundtrip(monkeypatch) -> None:
     assert service.set_frontend("qt")["error"]["code"] == "INVALID_REQUEST"
 
 
+def test_bootstrap_ships_processing_config_defaults() -> None:
+    """bootstrap() must publish ProcessingConfig defaults so frontends never
+    hardcode drifting copies (audit #138 F020)."""
+    from dataclasses import MISSING, fields
+
+    from core.pipeline import ProcessingConfig
+
+    response = ImpulciferApplicationService().bootstrap()
+    assert response["ok"]
+    shipped = response["data"]["brir_defaults"]
+
+    for config_field in fields(ProcessingConfig):
+        if config_field.name == "dir_path" or config_field.default is MISSING:
+            continue
+        assert shipped[config_field.name] == config_field.default, config_field.name
+
+    assert shipped["specific_limit"] == 400
+    assert shipped["generic_limit"] == 300
+
+
 def test_system_info_reports_environment() -> None:
     import impulcifer
 

--- a/tests/test_gui_launcher.py
+++ b/tests/test_gui_launcher.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pathlib
 import sys
 from types import SimpleNamespace
 
@@ -58,31 +59,46 @@ def test_launch_frontend_runs_webview_by_default(monkeypatch) -> None:
     monkeypatch.setitem(
         sys.modules,
         "gui.modern_gui",
-        SimpleNamespace(main_gui=lambda: launched.append("ctk")),
+        SimpleNamespace(main_gui=lambda startup_notice=None: launched.append("ctk")),
     )
 
     gui_main._launch_frontend()
     assert launched == ["webview"]
 
 
-def test_launch_frontend_falls_back_when_pywebview_missing(monkeypatch) -> None:
+def test_launch_frontend_falls_back_when_pywebview_missing(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(gui_main.sys, "argv", ["gui_main.py", "--frontend=webview"])
+    monkeypatch.setattr(pathlib.Path, "home", lambda: tmp_path)
     launched: list[str] = []
+    notices: list[str | None] = []
     # A None entry in sys.modules makes ``import webview`` raise ImportError.
     monkeypatch.setitem(sys.modules, "webview", None)
     monkeypatch.setitem(
         sys.modules,
         "gui.modern_gui",
-        SimpleNamespace(main_gui=lambda: launched.append("ctk")),
+        SimpleNamespace(
+            main_gui=lambda startup_notice=None: (
+                launched.append("ctk"),
+                notices.append(startup_notice),
+            )
+        ),
     )
 
     gui_main._launch_frontend()
     assert launched == ["ctk"]
+    # F053: the fallback must be surfaced to the CTk GUI and logged to a file.
+    assert notices and notices[0]
+    assert "webview-fallback.log" in notices[0]
+    log_file = tmp_path / ".impulcifer" / "webview-fallback.log"
+    assert log_file.is_file()
+    assert "unavailable" in log_file.read_text(encoding="utf-8")
 
 
-def test_launch_frontend_falls_back_when_webview_start_fails(monkeypatch) -> None:
+def test_launch_frontend_falls_back_when_webview_start_fails(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(gui_main.sys, "argv", ["gui_main.py", "--frontend=webview"])
+    monkeypatch.setattr(pathlib.Path, "home", lambda: tmp_path)
     launched: list[str] = []
+    notices: list[str | None] = []
 
     def _failing_main() -> None:
         raise RuntimeError("system WebKit missing")
@@ -96,21 +112,38 @@ def test_launch_frontend_falls_back_when_webview_start_fails(monkeypatch) -> Non
     monkeypatch.setitem(
         sys.modules,
         "gui.modern_gui",
-        SimpleNamespace(main_gui=lambda: launched.append("ctk")),
+        SimpleNamespace(
+            main_gui=lambda startup_notice=None: (
+                launched.append("ctk"),
+                notices.append(startup_notice),
+            )
+        ),
     )
 
     gui_main._launch_frontend()
     assert launched == ["ctk"]
+    assert notices and notices[0]
+    assert "system WebKit missing" in notices[0]
+    log_file = tmp_path / ".impulcifer" / "webview-fallback.log"
+    assert "RuntimeError" in log_file.read_text(encoding="utf-8")
 
 
 def test_launch_frontend_honours_ctk_choice(monkeypatch) -> None:
     monkeypatch.setattr(gui_main.sys, "argv", ["gui_main.py", "--frontend=ctk"])
     launched: list[str] = []
+    notices: list[str | None] = []
     monkeypatch.setitem(
         sys.modules,
         "gui.modern_gui",
-        SimpleNamespace(main_gui=lambda: launched.append("ctk")),
+        SimpleNamespace(
+            main_gui=lambda startup_notice=None: (
+                launched.append("ctk"),
+                notices.append(startup_notice),
+            )
+        ),
     )
 
     gui_main._launch_frontend()
     assert launched == ["ctk"]
+    # An explicit CTk choice is not a fallback — no notice dialog.
+    assert notices == [None]

--- a/tests/test_i18n_locales.py
+++ b/tests/test_i18n_locales.py
@@ -108,3 +108,21 @@ def test_visible_locale_strings_are_not_english_fallbacks() -> None:
             continue
         for key in visible_keys:
             assert locale[key] != english[key], f"{locale_file.name}:{key} is English fallback"
+
+
+def test_webview_html_i18n_keys_exist_in_english() -> None:
+    """Every data-i18n key in the WebView HTML must exist in en.json.
+
+    A typo'd key silently renders as the raw key name in the WebView UI,
+    so pin the HTML → locale linkage here (audit #138 F042).
+    """
+    _locale_dir, english, _locales = _load_locales()
+    index_html = (
+        Path(__file__).parent.parent / "webview_ui" / "index.html"
+    ).read_text(encoding="utf-8")
+
+    html_keys = set(re.findall(r'data-i18n="([^"]+)"', index_html))
+    assert html_keys, "no data-i18n keys found — extraction regex is broken"
+
+    missing = sorted(html_keys - set(english))
+    assert not missing, f"index.html data-i18n keys missing from en.json: {missing}"

--- a/tests/test_localization_manager.py
+++ b/tests/test_localization_manager.py
@@ -1,0 +1,46 @@
+"""Tests for the ``LocalizationManager.get()`` fallback contract (audit #138 F031/F055).
+
+Managers are built via ``__new__`` to skip ``__init__``'s filesystem side
+effects (settings dir creation and ``settings.json`` write).
+"""
+
+import logging
+
+from i18n import localization
+from i18n.localization import LocalizationManager
+
+
+def _manager_with(translations):
+    mgr = LocalizationManager.__new__(LocalizationManager)
+    mgr.translations = dict(translations)
+    mgr.current_language = 'en'
+    return mgr
+
+
+def test_get_returns_translation_when_key_exists():
+    mgr = _manager_with({'button_close': 'Close'})
+    assert mgr.get('button_close', default='ignored') == 'Close'
+
+
+def test_get_returns_default_on_missing_key():
+    mgr = _manager_with({})
+    assert mgr.get('dialog_recording_title', default='Recording') == 'Recording'
+
+
+def test_get_returns_key_on_missing_key_without_default():
+    mgr = _manager_with({})
+    assert mgr.get('some_missing_key') == 'some_missing_key'
+
+
+def test_get_formats_kwargs_into_default():
+    mgr = _manager_with({})
+    assert mgr.get('missing_fmt', default='Hello {name}', name='World') == 'Hello World'
+
+
+def test_missing_key_warns_once(caplog):
+    localization._MISSING_KEYS_WARNED.discard('warn_once_key')
+    mgr = _manager_with({})
+    with caplog.at_level(logging.WARNING, logger='i18n.localization'):
+        mgr.get('warn_once_key')
+        mgr.get('warn_once_key')
+    assert sum('warn_once_key' in record.getMessage() for record in caplog.records) == 1

--- a/tests/test_updater_environment.py
+++ b/tests/test_updater_environment.py
@@ -1,0 +1,85 @@
+"""First unit tests for the ``updater.environment`` probe ladder (audit #138 F041).
+
+Every install-kind decision in the app branches on these probes, but they had
+zero direct tests. The ``infra._build_info`` marker is faked through
+``sys.modules``: a ``SimpleNamespace`` stands in for the generated module, and
+``None`` forces ``from infra._build_info import BUILD_TYPE`` to raise
+``ImportError`` (the no-marker dev/py-source case).
+"""
+
+import sys
+import types
+
+import pytest
+
+from updater import environment
+
+
+@pytest.fixture
+def no_marker(monkeypatch):
+    """Simulate a checkout without the build-time infra/_build_info.py marker."""
+    monkeypatch.setitem(sys.modules, 'infra._build_info', None)
+    monkeypatch.delattr(sys, 'frozen', raising=False)
+    sys.modules.pop('__nuitka__', None)
+
+
+def _set_marker(monkeypatch, build_type):
+    monkeypatch.setitem(
+        sys.modules, 'infra._build_info', types.SimpleNamespace(BUILD_TYPE=build_type)
+    )
+
+
+class TestIsStandaloneBuild:
+    def test_marker_standalone_wins(self, monkeypatch):
+        _set_marker(monkeypatch, 'standalone')
+        assert environment._is_standalone_build() is True
+
+    def test_marker_pip_wins_over_frozen(self, monkeypatch):
+        """The build marker has precedence over the sys.frozen fallback probe."""
+        _set_marker(monkeypatch, 'pip')
+        monkeypatch.setattr(sys, 'frozen', True, raising=False)
+        assert environment._is_standalone_build() is False
+
+    def test_no_marker_frozen_fallback(self, no_marker, monkeypatch):
+        monkeypatch.setattr(sys, 'frozen', True, raising=False)
+        assert environment._is_standalone_build() is True
+
+    def test_no_marker_nuitka_module_fallback(self, no_marker, monkeypatch):
+        monkeypatch.setitem(sys.modules, '__nuitka__', types.ModuleType('__nuitka__'))
+        assert environment._is_standalone_build() is True
+
+    def test_no_marker_plain_python(self, no_marker):
+        assert environment._is_standalone_build() is False
+
+
+class TestIsPipEnvironment:
+    def test_marker_pip_wins(self, monkeypatch):
+        _set_marker(monkeypatch, 'pip')
+        assert environment.is_pip_environment() is True
+
+    def test_marker_standalone_is_not_pip(self, monkeypatch):
+        _set_marker(monkeypatch, 'standalone')
+        assert environment.is_pip_environment() is False
+
+    def test_no_marker_standalone_probe_blocks_bundled_pip(self, no_marker, monkeypatch):
+        """A standalone build's bundled pip module must not count as pip install."""
+        monkeypatch.setattr(sys, 'frozen', True, raising=False)
+        assert environment.is_pip_environment() is False
+
+    def test_no_marker_falls_back_to_pip_probe(self, no_marker):
+        expected = True
+        try:
+            import pip  # noqa: F401
+        except ImportError:
+            expected = None  # probe falls through to the subprocess check
+        if expected is None:
+            pytest.skip('pip module not importable; subprocess fallback not pinned here')
+        assert environment.is_pip_environment() is True
+
+
+class TestVelopackGate:
+    def test_not_standalone_is_not_velopack(self, no_marker):
+        assert environment.is_velopack_environment() is False
+
+    def test_not_standalone_has_no_update_exe(self, no_marker):
+        assert environment.get_velopack_update_exe() is None

--- a/tests/test_virtual_bass.py
+++ b/tests/test_virtual_bass.py
@@ -6,43 +6,57 @@ import pytest
 from unittest.mock import MagicMock
 
 
-class TestClassifySpeaker:
-    """Test _classify_speaker() returns correct classification."""
+class TestSpeakerSide:
+    """Test core.constants.speaker_side() returns correct classification."""
 
     def test_left_speakers(self):
-        from core.virtual_bass import _classify_speaker
-        assert _classify_speaker('FL') == 'left'
-        assert _classify_speaker('SL') == 'left'
-        assert _classify_speaker('BL') == 'left'
-        assert _classify_speaker('WL') == 'left'
-        assert _classify_speaker('TFL') == 'left'
-        assert _classify_speaker('TSL') == 'left'
-        assert _classify_speaker('TBL') == 'left'
+        from core.constants import speaker_side
+        assert speaker_side('FL') == 'left'
+        assert speaker_side('SL') == 'left'
+        assert speaker_side('BL') == 'left'
+        assert speaker_side('WL') == 'left'
+        assert speaker_side('TFL') == 'left'
+        assert speaker_side('TSL') == 'left'
+        assert speaker_side('TBL') == 'left'
 
     def test_right_speakers(self):
-        from core.virtual_bass import _classify_speaker
-        assert _classify_speaker('FR') == 'right'
-        assert _classify_speaker('SR') == 'right'
-        assert _classify_speaker('BR') == 'right'
-        assert _classify_speaker('WR') == 'right'
-        assert _classify_speaker('TFR') == 'right'
-        assert _classify_speaker('TSR') == 'right'
-        assert _classify_speaker('TBR') == 'right'
+        from core.constants import speaker_side
+        assert speaker_side('FR') == 'right'
+        assert speaker_side('SR') == 'right'
+        assert speaker_side('BR') == 'right'
+        assert speaker_side('WR') == 'right'
+        assert speaker_side('TFR') == 'right'
+        assert speaker_side('TSR') == 'right'
+        assert speaker_side('TBR') == 'right'
 
     def test_center_speakers(self):
-        from core.virtual_bass import _classify_speaker
-        assert _classify_speaker('FC') == 'center'
-        assert _classify_speaker('LFE') == 'center'
+        from core.constants import speaker_side
+        assert speaker_side('FC') == 'center'
+        assert speaker_side('LFE') == 'center'
 
     def test_unknown_defaults_to_center(self):
-        from core.virtual_bass import _classify_speaker
-        assert _classify_speaker('UNKNOWN') == 'center'
+        from core.constants import speaker_side
+        assert speaker_side('UNKNOWN') == 'center'
 
     def test_case_insensitive(self):
-        from core.virtual_bass import _classify_speaker
-        assert _classify_speaker('fl') == 'left'
-        assert _classify_speaker('fr') == 'right'
-        assert _classify_speaker('fc') == 'center'
+        from core.constants import speaker_side
+        assert speaker_side('fl') == 'left'
+        assert speaker_side('fr') == 'right'
+        assert speaker_side('fc') == 'center'
+
+    def test_covers_every_speaker_name(self):
+        """The frozenset partition must cover SPEAKER_NAMES exactly."""
+        from core.constants import (
+            CENTER_SPEAKERS,
+            LEFT_SIDE_SPEAKERS,
+            RIGHT_SIDE_SPEAKERS,
+            SPEAKER_NAMES,
+        )
+        partition = LEFT_SIDE_SPEAKERS | RIGHT_SIDE_SPEAKERS | CENTER_SPEAKERS
+        assert set(SPEAKER_NAMES) <= partition
+        assert not (LEFT_SIDE_SPEAKERS & RIGHT_SIDE_SPEAKERS)
+        assert not (LEFT_SIDE_SPEAKERS & CENTER_SPEAKERS)
+        assert not (RIGHT_SIDE_SPEAKERS & CENTER_SPEAKERS)
 
 
 class TestDetectPolarity:
@@ -73,33 +87,6 @@ class TestDetectPolarity:
         ir[10] = 0.3
         ir[20] = -0.9
         assert _detect_polarity(ir) == -1.0
-
-
-class TestBuildIldShelf:
-    """Test ILD shelf building."""
-
-    def test_high_crossover_returns_shelf(self):
-        from core.virtual_bass import _build_ild_shelf
-        # xo_hz=250 >= 160 threshold, so 150Hz shelf should be active
-        result = _build_ild_shelf(250, 48000)
-        assert result is not None
-        sos_lp, gain_linear, shelf_gain_db = result
-        assert shelf_gain_db == 6.0  # 150 Hz shelf at 6 dB
-        assert gain_linear == pytest.approx(10 ** (6.0 / 20.0), rel=1e-6)
-
-    def test_low_crossover_returns_none(self):
-        from core.virtual_bass import _build_ild_shelf
-        # xo_hz=50 < 80 (minimum threshold), so no shelf
-        result = _build_ild_shelf(50, 48000)
-        assert result is None
-
-    def test_medium_crossover(self):
-        from core.virtual_bass import _build_ild_shelf
-        # xo_hz=100 >= 80 threshold
-        result = _build_ild_shelf(100, 48000)
-        assert result is not None
-        _, _, shelf_gain_db = result
-        assert shelf_gain_db == 3.0  # 50 Hz shelf at 3 dB
 
 
 class TestSynthesizeVirtualBass:

--- a/webview_ui/app.js
+++ b/webview_ui/app.js
@@ -11,6 +11,7 @@ const state = {
   version: "",
   platform: "",
   strings: {},
+  brirDefaults: {},
   language: "en",
   theme: "dark",
   skin: "studio",
@@ -146,6 +147,13 @@ function numOrNull(id) {
 function numOr(id, fallback) {
   const parsed = numOrNull(id);
   return parsed === null ? fallback : parsed;
+}
+
+/* Canonical pipeline default shipped by bootstrap(); the literal fallback
+   only applies when bootstrap itself failed to load ProcessingConfig. */
+function brirDefault(name, fallback) {
+  const value = state.brirDefaults[name];
+  return typeof value === "number" ? value : fallback;
 }
 
 function isOpen(id) {
@@ -835,8 +843,8 @@ function gatherBrirPayload() {
   if (isOpen("dis-room")) {
     args.room_target = val("bf-room-target") || null;
     args.room_mic_calibration = val("bf-mic-calibration") || null;
-    args.specific_limit = numOr("bf-specific-limit", 400);
-    args.generic_limit = numOr("bf-generic-limit", 300);
+    args.specific_limit = numOr("bf-specific-limit", brirDefault("specific_limit", 400));
+    args.generic_limit = numOr("bf-generic-limit", brirDefault("generic_limit", 300));
     args.fr_combination_method = val("bf-fr-combination");
   }
   if (isOpen("dis-headphone")) {
@@ -861,8 +869,8 @@ function gatherBrirPayload() {
     const bassGain = numOr("bf-bass-gain", 0);
     if (bassGain) {
       args.bass_boost_gain = bassGain;
-      args.bass_boost_fc = numOr("bf-bass-fc", 105);
-      args.bass_boost_q = numOr("bf-bass-q", 0.76);
+      args.bass_boost_fc = numOr("bf-bass-fc", brirDefault("bass_boost_fc", 105));
+      args.bass_boost_q = numOr("bf-bass-q", brirDefault("bass_boost_q", 0.76));
     }
     const tilt = numOr("bf-tilt", 0);
     if (tilt) args.tilt = tilt;
@@ -879,19 +887,19 @@ function gatherBrirPayload() {
       if (decayMs !== null && decayMs > 0) args.decay = decayMs / 1000;
     }
 
-    args.head_ms = numOr("bf-head-ms", 1.0);
+    args.head_ms = numOr("bf-head-ms", brirDefault("head_ms", 1.0));
     args.jamesdsp = checked("bf-jamesdsp");
     args.hangloose = checked("bf-hangloose");
     args.interactive_plots = checked("bf-interactive-plots");
     args.microphone_deviation_correction = checked("bf-mic-deviation");
-    args.mic_deviation_strength = numOr("bf-mic-strength", 0.7);
+    args.mic_deviation_strength = numOr("bf-mic-strength", brirDefault("mic_deviation_strength", 0.7));
     args.mic_deviation_debug_plots = checked("bf-mic-debug");
     args.output_truehd_layouts = checked("bf-truehd");
   }
   if (isOpen("dis-vbass")) {
     args.vbass = true;
-    args.vbass_freq = Math.max(30, Math.min(500, Math.trunc(numOr("bf-vbass-freq", 250))));
-    args.vbass_hp = numOr("bf-vbass-hp", 15.0);
+    args.vbass_freq = Math.max(30, Math.min(500, Math.trunc(numOr("bf-vbass-freq", brirDefault("vbass_freq", 250)))));
+    args.vbass_hp = numOr("bf-vbass-hp", brirDefault("vbass_hp", 15.0));
     args.vbass_polarity = val("bf-vbass-polarity");
   }
   return args;
@@ -1106,6 +1114,7 @@ async function boot() {
   const data = response.data;
   state.version = data.version;
   state.platform = data.platform;
+  state.brirDefaults = data.brir_defaults || {};
   if (data.ui) {
     state.strings = data.ui.strings || {};
     state.language = data.ui.language || "en";


### PR DESCRIPTION
## 개요

격주 감사 이슈 #138의 1라운드 처리입니다. 유지보수자 결정이 필요 없는 Quick-win 항목(Top 5의 F031/F049 포함) 11건을 finding별 커밋으로 나눠 반영했습니다.

## 반영된 findings

| Finding | 커밋 | 내용 |
|---------|------|------|
| F031+F055 | `fix(audit)` | `LocalizationManager.get()`이 `default=`를 무시하던 계약 버그 수정 + 누락 키 1회 WARNING 로깅 |
| F049 | `fix(audit)` | FFmpeg lazy-init check-then-act 경쟁을 `threading.Lock`으로 직렬화 (동시 auto-install 차단) |
| F024+F009 | `fix(audit)` | `core.constants.speaker_side()` 단일 분류기 — `speaker[1]` 위치 판정이 3글자 톱레이어 이름에서 틀려 측정 경고가 침묵하던 버그 수정, 죽은 `_classify_speaker`/ILD 셸프 헬퍼 삭제 |
| F016 | `fix(audit)` | `gui_main.py` 부재 시 stale 13줄 stub을 조용히 생성하던 빌드 폴백 제거 → 즉시 실패 |
| F046 | `fix(audit)` | biweekly-audit 산출물을 `$RUNNER_TEMP/audit`으로 이동 + 5개 파일명 `.gitignore` (`.txt`는 release gate EXCLUDE에 없어 커밋 시 자동 릴리스 위험) |
| F042 | `test(audit)` | `index.html`의 `data-i18n` 키 ⊆ `en.json` 계약 테스트 |
| F041 | `test(audit)` | `updater/environment.py` probe ladder 첫 유닛 테스트 (마커 우선순위 등) |
| F019 | `refactor(audit)` | bass-boost Fc/Q(105/0.76) 하드코딩 3곳 → `ProcessingConfig` 참조 (값 동일, 동작 불변) |
| F020 | `fix(audit)` | `bootstrap()`이 `brir_defaults` 맵 제공, app.js 하드코딩 기본값(400/300 등) 제거, dataclass 계약 테스트 추가 |
| F053 | `fix(audit)` | WebView→CTk 조용한 폴백을 `~/.impulcifer/webview-fallback.log` + CTk 1회 경고 다이얼로그로 가시화 (i18n 키 2개, 11개 로케일 파일 추가) |
| F022 | `fix(audit)` | Studio 설정탭에 stable과 동일한 프론트엔드(WebView/CTk) 선택기 이식 |

버전: 2.10.1 → **2.10.2** (PATCH), CHANGELOG 갱신 포함.

## 검증

- **Tier 1**: py_compile + ruff 통과
- **Tier 2**: 전체 pytest 405 passed / 5 skipped (`test_scroll_perf.py`는 이 Windows 머신에서 origin/master 기준으로도 1~2개가 간헐 실패하는 기존 로컬 플레이크 — 브랜치/베이스라인 각각 3회 실행으로 무관성 확인), 모듈 임포트 검증, 의존성 동기화 확인 통과
- **Tier 3**: 같은 머신에서 origin/master worktree와 SHA-256 자기비교 — 기본 경로 및 `--vbass --vbass_freq=250` 경로 모두 **해시 일치** (vbass: `5f4ee3a1…`, 기본: `d54234fc…`)

## 미반영 (후속 라운드)

구조 개편(C1 파이프라인 seam, C2 서비스 단일화, C3 환경 모듈 등)과 유지보수자 결정이 필요한 항목(F018 decay 채널 계약, F021 Studio 녹음 채널 계약, F029 헤드폰 보상 파일 의미, F030 zh-cn/zh-tw 중복 삭제)은 이슈 #138 댓글로 정리했습니다.

Refs #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)
