### PR TITLE
fix: audit #138 round 4 (final) — frontend drift fixes + test expansion (2.10.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ first number changes, something has broken and you need to check your commands a
 changes there are only new features available and nothing old has broken and when the last number changes, old bugs have
 been fixed and old features improved.
 
+## 2.10.5 - 2026-08-02
+### 감사(#138) 4라운드(최종) — 프론트엔드 드리프트 수정 + 테스트 확충
+
+#### 🐛 버그 수정
+- **decay 채널 드리프트 수정 (F018, 유지보수자 판정 Q2)**: CTk의 단일값 decay가 하드코딩된 7채널에만 적용되던 것을 CLI와 동일하게 전체 15채널 `SPEAKER_NAMES`로 fan-out하도록 수정했다. 채널별 decay UI도 세 프론트엔드(CTk Stable/Studio 8채널씩 줄바꿈 그리드, WebView 그리드) 모두 톱레이어 포함 15채널을 노출한다. app.js의 채널 목록은 `SPEAKER_NAMES`와의 패리티 테스트로 고정.
+- **녹음 채널 의미 통일 (F021, 유지보수자 판정 Q5)**: Stable 탭의 계약(강제 체크 시에만 다채널, 아니면 스테레오)을 `core.recording_validation.resolve_recording_channels()` 공유 헬퍼로 추출하고, Studio의 `max(2, entry)` 독자 해석을 제거해 Stable 의미에 정렬했다(프리셋≠2 = 명시적 다채널 요청).
+
+#### ⭐ 개선
+- **zh 로케일 실질 정리 (F030, 유지보수자 판정 Q3 — 삭제 금지)**: 하이픈 파일(`zh-cn.json`/`zh-tw.json`)을 정본(`zh_CN`/`zh_TW`)의 **테스트 강제 byte-mirror**(BCP-47 스타일 파일명 별칭)로 공식화하고, 로더가 BCP-47 스타일 언어 코드(`zh-CN` 등)를 `normalize_language_code()`로 수용하게 했다. zh_TW가 진짜 번체 번역임을 고정하는 가드 테스트 추가(zh_CN 대비 79% 상이, 번체 고유 문자 존재).
+- **테스트 확충 (F038/F039)**: BRIR integrity에 미커버 플래그 시나리오 3종 추가(`--decay`+`--channel_balance`+`--bass_boost`, `--fs`+TrueHD+JamesDSP+Hangloose, `--no_headphone_compensation`). `channel_balance_firs` 7개 분기 전부·`crop_heads`(ITD 계약 + F024 톱레이어 경고 수정 고정)·`crop_tails`·`resample`에 플랫폼 무관 characterization 테스트 14종 신설.
+
 ## 2.10.4 - 2026-08-02
 ### 감사(#138) 3라운드 — C3: 환경 감지 단일화
 

--- a/core/recording_validation.py
+++ b/core/recording_validation.py
@@ -51,3 +51,19 @@ def validate_recording_setup(
         expected_channels=expected_channels,
         selected_channels=selected_channels,
     )
+
+
+def resolve_recording_channels(force_multi_channel, requested_channels):
+    """Resolve the recording channel count under the Stable-tab contract.
+
+    Stereo unless the user explicitly forces a multi-channel recording;
+    forced recordings use the requested count as-is. This is the single
+    contract for both CTk skins (audit #138 F021/Q5 — Studio's former
+    ``max(2, entry)`` reading was drift, not intent).
+
+    Returns:
+        ``(channels, force_channels)`` tuple.
+    """
+    if not force_multi_channel:
+        return 2, False
+    return int(requested_channels), True

--- a/gui/brir_args.py
+++ b/gui/brir_args.py
@@ -7,6 +7,7 @@ import os
 import shutil
 from typing import Any
 
+from core.constants import SPEAKER_NAMES
 from core.pipeline import ProcessingConfig
 from gui.utils import safe_get_double, safe_get_int, safe_get_string
 
@@ -127,9 +128,9 @@ def build_brir_args(tab: Any, loc: Any) -> dict:
             if decay_str.strip():
                 try:
                     decay_val = float(decay_str) / 1000
-                    args["decay"] = {
-                        ch: decay_val for ch in ("FL", "FC", "FR", "SL", "SR", "BL", "BR")
-                    }
+                    # 단일값 decay는 CLI와 동일하게 전체 SPEAKER_NAMES로 fan-out
+                    # (기존 7채널 하드코딩은 드리프트 — 감사 #138 F018/Q2 판정)
+                    args["decay"] = {ch: decay_val for ch in SPEAKER_NAMES}
                 except ValueError:
                     pass
 

--- a/gui/skins/studio_impulcifer_tab.py
+++ b/gui/skins/studio_impulcifer_tab.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 import customtkinter as ctk
 
 import impulcifer
+from core.constants import SPEAKER_NAMES
 from gui.brir_args import (
     build_brir_args,
     processing_default,
@@ -87,9 +88,7 @@ class StudioImpulciferTab:
         self.channel_balance_db_var = ctk.IntVar(value=0)
         self.decay_var = ctk.StringVar()
         self.decay_per_channel_var = ctk.BooleanVar(value=False)
-        self.decay_channel_vars = {
-            ch: ctk.StringVar() for ch in ("FL", "FC", "FR", "SL", "SR", "BL", "BR")
-        }
+        self.decay_channel_vars = {ch: ctk.StringVar() for ch in SPEAKER_NAMES}
         self.pre_response_var = ctk.DoubleVar(value=1.0)
         self.jamesdsp_var = ctk.BooleanVar(value=False)
         self.hangloose_var = ctk.BooleanVar(value=False)
@@ -447,17 +446,18 @@ class StudioImpulciferTab:
         self.decay_channels_frame = ctk.CTkFrame(adv_body, fg_color="transparent")
         self.decay_channels_frame.grid(row=5, column=0, sticky="ew", padx=(18, 0), pady=(0, 8))
         for idx, (ch, var) in enumerate(self.decay_channel_vars.items()):
+            row_i, col_i = divmod(idx, 8)
             ctk.CTkLabel(
                 self.decay_channels_frame,
                 text=f"{ch}:",
                 font=ctk.CTkFont(size=12, weight="bold"),
                 text_color=COLORS["fg-1"],
-            ).grid(row=0, column=idx * 2, sticky="w", padx=(0, 4), pady=4)
+            ).grid(row=row_i, column=col_i * 2, sticky="w", padx=(0, 4), pady=4)
             ctk.CTkEntry(
                 self.decay_channels_frame,
                 textvariable=var,
                 width=54,
-            ).grid(row=0, column=idx * 2 + 1, sticky="w", padx=(0, 8), pady=4)
+            ).grid(row=row_i, column=col_i * 2 + 1, sticky="w", padx=(0, 8), pady=4)
         self.decay_channels_frame.grid_remove()
 
         output_row = ctk.CTkFrame(adv_body, fg_color="transparent")

--- a/gui/skins/studio_recorder_tab.py
+++ b/gui/skins/studio_recorder_tab.py
@@ -15,7 +15,7 @@ import sounddevice
 from core import recorder
 from core.headphones_recording import inspect_headphones_playback
 from core.recording_naming import resolve_headphones_record_path, resolve_record_path
-from core.recording_validation import validate_recording_setup
+from core.recording_validation import resolve_recording_channels, validate_recording_setup
 from core.sweep_set_generator import generate_sweep_set
 from gui.constants import FILETYPES_AUDIO
 from gui.recording_status import RecordingStatusController, analyze_recording
@@ -468,7 +468,15 @@ class StudioRecorderTab:
             )
             return
         record_file = resolve_record_path(record_dir, play_file)
-        channels = max(2, safe_get_int(self.channels_var, 2))
+        # Stable's force-channels checkbox is expressed here by the channel
+        # preset itself: picking anything other than stereo IS the explicit
+        # multi-channel request. The resolution contract is shared with the
+        # stable tab (audit #138 F021/Q5 — the old max(2, entry) reading was
+        # drift, not intent).
+        requested_channels = safe_get_int(self.channels_var, 2)
+        channels, force_channels = resolve_recording_channels(
+            requested_channels != 2, requested_channels
+        )
 
         if not os.path.exists(play_file):
             messagebox.showerror(
@@ -477,11 +485,7 @@ class StudioRecorderTab:
             )
             return
 
-        # Stable's force-channels checkbox is replaced here by the channel
-        # preset itself: keep the auto-stereo (channels == 2) path silent,
-        # and only warn when the user explicitly picks a different channel
-        # count that disagrees with the speaker-list filename.
-        validation = validate_recording_setup(record_file, channels, channels != 2)
+        validation = validate_recording_setup(record_file, channels, force_channels)
         if validation and validation.has_mismatch:
             warning_msg = self.loc.get(
                 "message_channel_mismatch_body",

--- a/gui/tabs/impulcifer_tab.py
+++ b/gui/tabs/impulcifer_tab.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING
 import customtkinter as ctk
 
 import impulcifer
+from core.constants import SPEAKER_NAMES
 from gui.constants import (
     FILETYPES_AUDIO_WITH_PKL,
     FILETYPES_TEXT,
@@ -353,12 +354,18 @@ class ImpulciferTab:
         decay_ch_subframe = ctk.CTkFrame(self.decay_channels_frame, fg_color="transparent")
         decay_ch_subframe.grid(row=0, column=0, sticky="ew", padx=30, pady=5)
 
+        # 전체 SPEAKER_NAMES 노출 (톱레이어 포함 15채널; 8채널씩 줄바꿈 그리드)
         self.decay_channel_vars = {}
-        for i, ch in enumerate(['FL', 'FC', 'FR', 'SL', 'SR', 'BL', 'BR']):
-            ctk.CTkLabel(decay_ch_subframe, text=f"{ch}:").pack(side="left", padx=2)
+        for i, ch in enumerate(SPEAKER_NAMES):
+            row_i, col_i = divmod(i, 8)
+            ctk.CTkLabel(decay_ch_subframe, text=f"{ch}:").grid(
+                row=row_i, column=col_i * 2, sticky="w", padx=2, pady=2
+            )
             var = ctk.StringVar()
             self.decay_channel_vars[ch] = var
-            ctk.CTkEntry(decay_ch_subframe, textvariable=var, width=WIDGET_ENTRY_WIDTH_TINY).pack(side="left", padx=2)
+            ctk.CTkEntry(
+                decay_ch_subframe, textvariable=var, width=WIDGET_ENTRY_WIDTH_TINY
+            ).grid(row=row_i, column=col_i * 2 + 1, sticky="w", padx=2, pady=2)
 
         pre_frame = ctk.CTkFrame(self.advanced_options_frame, fg_color="transparent")
         pre_frame.grid(row=adv_row, column=0, sticky="ew", padx=15, pady=5)

--- a/gui/tabs/recorder_tab.py
+++ b/gui/tabs/recorder_tab.py
@@ -20,7 +20,7 @@ import sounddevice
 import core.recorder as recorder
 from core.headphones_recording import inspect_headphones_playback
 from core.recording_naming import resolve_headphones_record_path, resolve_record_path
-from core.recording_validation import validate_recording_setup
+from core.recording_validation import resolve_recording_channels, validate_recording_setup
 from core.sweep_set_generator import generate_sweep_set
 from gui.constants import (
     FILETYPES_AUDIO,
@@ -473,7 +473,9 @@ class RecorderTab:
             )
             return
         record_file = resolve_record_path(record_dir, play_file)
-        selected_channels = safe_get_int(self.channels_var, 14) if self.channels_check_var.get() else 2
+        selected_channels, force_channels = resolve_recording_channels(
+            self.channels_check_var.get(), safe_get_int(self.channels_var, 14)
+        )
 
         if not os.path.exists(play_file):
             messagebox.showerror(self.loc.get('message_error'), self.loc.get('message_play_file_not_exist', file=play_file))
@@ -482,7 +484,7 @@ class RecorderTab:
         validation = validate_recording_setup(
             record_file,
             selected_channels,
-            self.channels_check_var.get(),
+            force_channels,
         )
         if validation and validation.has_mismatch:
             warning_msg = self.loc.get(

--- a/i18n/localization.py
+++ b/i18n/localization.py
@@ -43,6 +43,24 @@ LOCALE_MAPPING = {
 }
 
 
+def normalize_language_code(code: str) -> str:
+    """Canonicalize a language code to the ``SUPPORTED_LANGUAGES`` form.
+
+    Accepts BCP-47-style variants (``zh-CN``, ``zh-tw``, ``ko-KR``) from web
+    or OS contexts and maps them to the underscore form (``zh_CN``). The
+    hyphenated ``i18n/locales/zh-cn.json``/``zh-tw.json`` files are kept as
+    byte-mirrors of the canonical files for external BCP-47-style consumers
+    (audit #138 F030/Q3); the loader itself always reads the canonical file.
+    """
+    if not code:
+        return code
+    normalized = code.replace('-', '_')
+    parts = normalized.split('_')
+    if len(parts) == 2:
+        normalized = parts[0].lower() + '_' + parts[1].upper()
+    return normalized
+
+
 class LocalizationManager:
     """Manages translations and user preferences"""
 
@@ -172,6 +190,7 @@ class LocalizationManager:
 
     def set_language(self, language_code: str):
         """Set current language and load translations"""
+        language_code = normalize_language_code(language_code)
         if language_code not in SUPPORTED_LANGUAGES:
             language_code = 'en'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "impulcifer-py313"
-version = "2.10.4"
+version = "2.10.5"
 authors = [
   { name="원본 저자: Jaakko Pasanen", email="" },
   { name="Python 3.13/3.14 호환 버전: 115dkk", email="" },

--- a/tests/test_audit_contracts.py
+++ b/tests/test_audit_contracts.py
@@ -106,3 +106,59 @@ def test_parallel_processing_map_supports_initializer_contract() -> None:
     )
 
     assert result == [("task", "ready")]
+
+
+class AdvancedDecayBrirTab(MinimalBrirTab):
+    """Tab stand-in with the advanced panel open and a single decay value."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.show_advanced_var = DummyVar(True)
+        self.fs_check_var = DummyVar(False)
+        self.fs_var = DummyVar(raises=ValueError)
+        self.target_level_var = DummyVar("")
+        self.channel_balance_var = DummyVar("none")
+        self.channel_balance_db_var = DummyVar(0)
+        self.bass_boost_gain_var = DummyVar(0.0)
+        self.bass_boost_fc_var = DummyVar(raises=ValueError)
+        self.bass_boost_q_var = DummyVar(raises=ValueError)
+        self.tilt_var = DummyVar(0.0)
+        self.decay_per_channel_var = DummyVar(False)
+        self.decay_channel_vars = {}
+        self.decay_var = DummyVar("300")
+        self.pre_response_var = DummyVar(1.0)
+        self.jamesdsp_var = DummyVar(False)
+        self.hangloose_var = DummyVar(False)
+        self.interactive_plots_var = DummyVar(False)
+        self.microphone_deviation_correction_var = DummyVar(False)
+        self.mic_deviation_strength_var = DummyVar(0.7)
+        self.mic_deviation_debug_plots_var = DummyVar(False)
+        self.output_truehd_layouts_var = DummyVar(False)
+
+
+def test_gui_single_decay_fans_out_to_all_speaker_names() -> None:
+    """Single-value decay must cover the full 15-speaker layout like the CLI.
+
+    Audit #138 F018/Q2: the old hardcoded 7-channel tuple was drift, not an
+    intentional "GUI only exposes 7.1" decision.
+    """
+    from core.constants import SPEAKER_NAMES
+
+    args = build_brir_args(AdvancedDecayBrirTab(), DummyLoc())
+
+    assert set(args["decay"]) == set(SPEAKER_NAMES)
+    assert all(value == 0.3 for value in args["decay"].values())
+
+
+def test_webview_decay_channels_mirror_speaker_names() -> None:
+    """app.js DECAY_CHANNELS must stay in sync with core SPEAKER_NAMES."""
+    import re
+    from pathlib import Path
+
+    from core.constants import SPEAKER_NAMES
+
+    app_js = (Path(__file__).parent.parent / "webview_ui" / "app.js").read_text(encoding="utf-8")
+    match = re.search(r"const DECAY_CHANNELS = \[(.*?)\];", app_js, flags=re.DOTALL)
+    assert match, "DECAY_CHANNELS not found in app.js"
+    channels = re.findall(r'"([A-Z]+)"', match.group(1))
+    assert channels == list(SPEAKER_NAMES)

--- a/tests/test_brir_integrity.py
+++ b/tests/test_brir_integrity.py
@@ -45,6 +45,19 @@ SCENARIOS = [
         name="virtual_bass",
         extra_args=("--vbass", "--vbass_freq=250"),
     ),
+    # Audit #138 F038: the flags below had no end-to-end coverage at all.
+    BrirScenario(
+        name="dsp_shaping",
+        extra_args=("--decay=100", "--channel_balance=trend", "--bass_boost=4"),
+    ),
+    BrirScenario(
+        name="resample_and_extra_outputs",
+        extra_args=("--fs=44100", "--output_truehd_layouts", "--jamesdsp", "--hangloose"),
+    ),
+    BrirScenario(
+        name="no_headphone_compensation",
+        extra_args=("--no_headphone_compensation",),
+    ),
 ]
 
 

--- a/tests/test_dsp_characterization.py
+++ b/tests/test_dsp_characterization.py
@@ -1,0 +1,241 @@
+"""Characterization tests for core HRIR DSP paths (audit #138 F039).
+
+``channel_balance_firs`` (all seven method branches), ``crop_heads``,
+``crop_tails`` and ``resample`` previously had zero direct tests — they were
+covered only by the opaque Linux-only end-to-end hash. These tests pin their
+numeric contracts with synthetic inputs so regressions surface on every
+platform. Tolerances are deliberately loose (±1 dB / ±2 samples) — the tests
+characterize behavior, they do not redefine it.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pytest
+
+from autoeq.frequency_response import FrequencyResponse
+from core.hrir import HRIR
+from core.impulse_response import ImpulseResponse
+from core.utils import magnitude_response
+
+FS = 48_000
+
+
+class _DummyEstimator:
+    fs = FS
+
+
+class _TailEstimator:
+    fs = FS
+    n_octaves = 10
+
+    def __len__(self) -> int:
+        return FS * 6
+
+
+def _hrir(channels: dict, estimator=None) -> HRIR:
+    hrir = HRIR(estimator or _DummyEstimator())
+    hrir.irs = channels
+    return hrir
+
+
+def _ir(data: np.ndarray) -> ImpulseResponse:
+    return ImpulseResponse(np.asarray(data, dtype=np.float64), FS)
+
+
+def _impulse_at(index: int, length: int) -> np.ndarray:
+    data = np.zeros(length)
+    data[index] = 1.0
+    return data
+
+
+def _flat_fr(level_db: float) -> FrequencyResponse:
+    frequency = FrequencyResponse.generate_frequencies(f_min=10, f_max=FS / 2, f_step=1.01)
+    return FrequencyResponse(
+        name="flat",
+        frequency=frequency,
+        raw=np.full(len(frequency), float(level_db)),
+    )
+
+
+def _fir_gain_db(fir: np.ndarray, at_hz: float = 1000.0) -> float:
+    freqs, mags = magnitude_response(np.asarray(fir), FS)
+    return float(mags[np.argmin(np.abs(freqs - at_hz))])
+
+
+# ── channel_balance_firs() ─────────────────────────────────────────────────
+
+def test_channel_balance_numeric_scales_right_side() -> None:
+    hrir = _hrir({})
+    firs = hrir.channel_balance_firs(_flat_fr(0.0), _flat_fr(0.0), "6")
+
+    assert len(firs) == 2
+    assert np.argmax(np.abs(firs[0])) == 0 and firs[0][0] == pytest.approx(1.0)
+    assert firs[1][0] == pytest.approx(10 ** (6 / 20), rel=1e-6)
+    assert len(firs[0]) == int(round(FS * 0.1))
+
+
+def test_channel_balance_invalid_method_raises() -> None:
+    hrir = _hrir({})
+    with pytest.raises(ValueError):
+        hrir.channel_balance_firs(_flat_fr(0.0), _flat_fr(0.0), "not-a-number")
+
+
+def test_channel_balance_mids_guesses_gain_from_mid_levels() -> None:
+    """Right side 6 dB below left → right FIR boosts by ~+6 dB."""
+    hrir = _hrir({})
+    firs = hrir.channel_balance_firs(_flat_fr(0.0), _flat_fr(-6.0), "mids")
+
+    assert firs[0][0] == pytest.approx(1.0)
+    assert firs[1][0] == pytest.approx(10 ** (6 / 20), rel=1e-3)
+
+
+def test_channel_balance_trend_equalizes_right_to_left() -> None:
+    hrir = _hrir({})
+    firs = hrir.channel_balance_firs(_flat_fr(0.0), _flat_fr(-6.0), "trend")
+
+    # Left stays a unit impulse; right gets ~+6 dB broadband.
+    assert np.argmax(np.abs(firs[0])) == 0
+    assert _fir_gain_db(firs[1]) == pytest.approx(6.0, abs=1.0)
+
+
+def test_channel_balance_left_reference() -> None:
+    """method='left': right side is equalized towards the left response."""
+    hrir = _hrir({})
+    firs = hrir.channel_balance_firs(_flat_fr(0.0), _flat_fr(-6.0), "left")
+
+    assert np.argmax(np.abs(firs[0])) == 0
+    assert _fir_gain_db(firs[1]) == pytest.approx(6.0, abs=1.0)
+
+
+def test_channel_balance_right_reference() -> None:
+    """method='right': left side is equalized towards the right response."""
+    hrir = _hrir({})
+    firs = hrir.channel_balance_firs(_flat_fr(0.0), _flat_fr(-6.0), "right")
+
+    assert np.argmax(np.abs(firs[1])) == 0
+    assert _fir_gain_db(firs[0]) == pytest.approx(-6.0, abs=1.0)
+
+
+def test_channel_balance_avg_meets_in_the_middle() -> None:
+    hrir = _hrir({})
+    firs = hrir.channel_balance_firs(_flat_fr(0.0), _flat_fr(-6.0), "avg")
+
+    assert _fir_gain_db(firs[0]) == pytest.approx(-3.0, abs=1.0)
+    assert _fir_gain_db(firs[1]) == pytest.approx(3.0, abs=1.0)
+
+
+def test_channel_balance_min_takes_the_lower_response() -> None:
+    hrir = _hrir({})
+    firs = hrir.channel_balance_firs(_flat_fr(0.0), _flat_fr(-6.0), "min")
+
+    assert _fir_gain_db(firs[0]) == pytest.approx(-6.0, abs=1.0)
+    assert _fir_gain_db(firs[1]) == pytest.approx(0.0, abs=1.0)
+
+
+# ── crop_heads() ───────────────────────────────────────────────────────────
+
+def test_crop_heads_moves_first_peak_to_head_offset() -> None:
+    """Left-side speaker: crop leaves head_ms of lead-in before the first peak
+    and preserves the interaural delay."""
+    length = 4800
+    hrir = _hrir({
+        "FL": {
+            "left": _ir(_impulse_at(480, length)),
+            "right": _ir(_impulse_at(528, length)),
+        },
+    })
+
+    hrir.crop_heads(head_ms=1)
+
+    head = int(FS * 1 / 1000)
+    assert hrir.irs["FL"]["left"].peak_index() == head
+    assert hrir.irs["FL"]["right"].peak_index() == head + 48  # ITD preserved
+    assert len(hrir.irs["FL"]["left"].data) == length - (480 - head)
+
+
+def test_crop_heads_warns_on_side_mismatch_including_top_layer() -> None:
+    """A right-side speaker whose sound reaches the left ear first must warn.
+
+    Includes a 3-letter top-layer name: the old positional speaker[1] check
+    silently skipped TFR/TSL/… (audit #138 F024 — fixed via speaker_side()).
+    """
+    length = 4800
+    for speaker in ("FR", "TFR"):
+        hrir = _hrir({
+            speaker: {
+                "left": _ir(_impulse_at(480, length)),
+                "right": _ir(_impulse_at(528, length)),
+            },
+        })
+        with pytest.warns(UserWarning, match=speaker):
+            hrir.crop_heads(head_ms=1)
+
+
+def test_crop_heads_correct_side_does_not_warn() -> None:
+    length = 4800
+    hrir = _hrir({
+        "FL": {
+            "left": _ir(_impulse_at(480, length)),
+            "right": _ir(_impulse_at(528, length)),
+        },
+    })
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        hrir.crop_heads(head_ms=1)
+
+
+# ── crop_tails() ───────────────────────────────────────────────────────────
+
+def test_crop_tails_trims_to_uniform_faded_length() -> None:
+    rng = np.random.default_rng(7)
+    length = FS  # 1 second
+    t = np.arange(length) / FS
+
+    def _decaying() -> np.ndarray:
+        data = rng.standard_normal(length) * np.exp(-t * 30.0) * 0.5
+        data[100] = 1.0
+        return data
+
+    hrir = _hrir(
+        {
+            "FL": {"left": _ir(_decaying()), "right": _ir(_decaying())},
+            "FR": {"left": _ir(_decaying()), "right": _ir(_decaying())},
+        },
+        estimator=_TailEstimator(),
+    )
+
+    tail_ind = hrir.crop_tails()
+
+    assert 0 < tail_ind <= length
+    for pair in hrir.irs.values():
+        for ir in pair.values():
+            assert len(ir.data) == tail_ind
+            # Fade-out window pulls the very end to (near) zero.
+            assert abs(ir.data[-1]) < 1e-6
+
+
+def test_crop_tails_rejects_mismatched_sampling_rate() -> None:
+    hrir = _hrir({"FL": {"left": _ir(_impulse_at(0, 100)), "right": _ir(_impulse_at(0, 100))}})
+    hrir.fs = 44_100
+    with pytest.raises(ValueError):
+        hrir.crop_tails()
+
+
+# ── resample() ─────────────────────────────────────────────────────────────
+
+def test_resample_updates_rate_and_scales_length() -> None:
+    length = FS // 2
+    hrir = _hrir({
+        "FL": {"left": _ir(_impulse_at(1000, length)), "right": _ir(_impulse_at(1000, length))},
+    })
+
+    hrir.resample(44_100)
+
+    assert hrir.fs == 44_100
+    expected = length * 44_100 / FS
+    for ir in hrir.irs["FL"].values():
+        assert len(ir.data) == pytest.approx(expected, abs=2)
+        assert ir.fs == 44_100

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -329,3 +329,14 @@ def test_processing_dialog_cancel_sets_event(ctk_root) -> None:
         assert dialog.cancel_event.is_set() is True
     finally:
         dialog.destroy()
+
+
+def test_resolve_recording_channels_stable_contract() -> None:
+    """Shared channel contract (audit #138 F021/Q5): stereo unless forced."""
+    from core.recording_validation import resolve_recording_channels
+
+    assert resolve_recording_channels(False, 14) == (2, False)
+    assert resolve_recording_channels(True, 14) == (14, True)
+    assert resolve_recording_channels(True, 6) == (6, True)
+    # Studio maps "preset != 2" to the force flag; stereo preset stays silent.
+    assert resolve_recording_channels(2 != 2, 2) == (2, False)

--- a/tests/test_i18n_locales.py
+++ b/tests/test_i18n_locales.py
@@ -126,3 +126,33 @@ def test_webview_html_i18n_keys_exist_in_english() -> None:
 
     missing = sorted(html_keys - set(english))
     assert not missing, f"index.html data-i18n keys missing from en.json: {missing}"
+
+
+def test_bcp47_alias_files_mirror_canonical() -> None:
+    """zh-cn/zh-tw are byte-mirrors of zh_CN/zh_TW.
+
+    They are kept as BCP-47-style filename aliases for external consumers
+    (audit #138 F030/Q3 — maintainer: do not delete). This test turns the
+    accidental duplication into an enforced mirror contract so the pairs can
+    never drift apart silently.
+    """
+    locale_dir = Path(__file__).parent.parent / "i18n" / "locales"
+    for alias, canonical in (("zh-cn.json", "zh_CN.json"), ("zh-tw.json", "zh_TW.json")):
+        assert (locale_dir / alias).read_bytes() == (locale_dir / canonical).read_bytes(), (
+            f"{alias} must stay a byte-mirror of {canonical}"
+        )
+
+
+def test_traditional_chinese_is_a_real_translation() -> None:
+    """zh_TW must remain genuinely Traditional, not a zh_CN copy."""
+    locale_dir = Path(__file__).parent.parent / "i18n" / "locales"
+    cn = json.loads((locale_dir / "zh_CN.json").read_text(encoding="utf-8"))
+    tw = json.loads((locale_dir / "zh_TW.json").read_text(encoding="utf-8"))
+
+    differing = sum(1 for key in cn if cn[key] != tw.get(key))
+    assert differing > len(cn) * 0.5, "zh_TW looks like a zh_CN copy"
+
+    tw_text = "".join(value for value in tw.values() if isinstance(value, str))
+    traditional_only = "設應體錯誤"
+    hits = sum(1 for ch in traditional_only if ch in tw_text)
+    assert hits >= 3, "Traditional-specific characters missing from zh_TW"

--- a/tests/test_localization_manager.py
+++ b/tests/test_localization_manager.py
@@ -44,3 +44,14 @@ def test_missing_key_warns_once(caplog):
         mgr.get('warn_once_key')
         mgr.get('warn_once_key')
     assert sum('warn_once_key' in record.getMessage() for record in caplog.records) == 1
+
+
+def test_normalize_language_code_accepts_bcp47_variants():
+    from i18n.localization import normalize_language_code
+
+    assert normalize_language_code('zh-CN') == 'zh_CN'
+    assert normalize_language_code('zh-tw') == 'zh_TW'
+    assert normalize_language_code('ko-KR') == 'ko_KR'
+    assert normalize_language_code('zh_CN') == 'zh_CN'
+    assert normalize_language_code('en') == 'en'
+    assert normalize_language_code('') == ''

--- a/webview_ui/app.js
+++ b/webview_ui/app.js
@@ -30,7 +30,10 @@ const state = {
   recDoneSpeakers: new Set(),
 };
 
-const DECAY_CHANNELS = ["FL", "FC", "FR", "SL", "SR", "BL", "BR"];
+/* Full speaker layout — must mirror core/constants.py SPEAKER_NAMES
+   (pinned by tests/test_audit_contracts.py; audit #138 F018). */
+const DECAY_CHANNELS = ["FL", "FR", "FC", "BL", "BR", "SL", "SR", "WL", "WR",
+  "TFL", "TFR", "TSL", "TSR", "TBL", "TBR"];
 
 /* BRIR pipeline stages for the Studio activity checklist. The logger
    emits these exact localized strings (optionally with a suffix), so


### PR DESCRIPTION
## 개요

감사 이슈 #138의 마지막 라운드 — 유지보수자 답변(Q2/Q5/Q3) 반영 + F038/F039 테스트 확충입니다.

> **스택 PR**: base가 `claude/audit-138-round3-c3`(PR #143)입니다. 머지 순서: #139 → round2 재생성 PR → #143 → 이 PR. (#141은 base 브랜치 삭제로 닫혀 round2 브랜치로 재생성 예정)

## 변경 내용

- **F018 (Q2: 드리프트 판정)**: CTk 단일값 decay 7채널 → CLI와 동일한 15채널 `SPEAKER_NAMES` fan-out. 채널별 decay UI를 3개 프론트엔드 모두 15채널 노출(CTk 8/행 그리드, WebView flex-wrap). app.js 채널 목록은 패리티 테스트로 고정.
- **F021 (Q5: Stable이 계약)**: `core.recording_validation.resolve_recording_channels()` 공유 헬퍼 신설, Studio의 `max(2, entry)` 제거 — 프리셋≠2 = 명시적 다채널 요청으로 Stable 의미에 정렬.
- **F030 (Q3: 삭제 금지, 실질 분리)**: 조사 결과 zh_CN/zh_TW는 이미 진짜 분리된 번역(388키 중 79% 상이, 번체 고유 문자는 TW에만 존재). 진짜 찐빠는 하이픈 사본 2개 → **테스트 강제 byte-mirror**(BCP-47 파일명 별칭)로 공식화 + 로더가 `zh-CN` 스타일 코드 수용(`normalize_language_code`) + 번체 진위 가드 테스트. 의도가 다르셨다면 알려주세요.
- **F038**: BRIR integrity 시나리오 3종 추가 (dsp_shaping / resample_and_extra_outputs / no_headphone_compensation).
- **F039**: `channel_balance_firs` 7분기·`crop_heads`(ITD + F024 톱레이어 경고 고정)·`crop_tails`·`resample` characterization 테스트 14종 — 전 플랫폼 실행.

버전: 2.10.4 → **2.10.5** (PATCH).

## 검증

- Tier 1/2: ruff·전체 pytest **437 passed** (신규 integrity 시나리오는 설계상 로컬 skip, CI Linux에서 실행)
- Tier 3: GUI/테스트/i18n 변경으로 CLI 데모 경로 무영향 — CI `brir-integrity`(이제 5개 시나리오)가 상대 비교로 검증

Refs #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)