### PR TITLE
ci: AUR 바이너리 패키지(impulcifer-py313-bin) 자동 발행

### DIFF
--- a/.github/scripts/release_gate.py
+++ b/.github/scripts/release_gate.py
@@ -51,6 +51,7 @@ ZERO_SHA = "0" * 40
 EXCLUDE = (
     "*.md", "*.rst", "*.adoc", "*.ipynb",
     "docs/*", ".github/*", "tests/*", "research/*", ".claude/*",
+    "packaging/*",
     "LICENSE*", "CHANGELOG*", "CONTEXT.md", ".gitignore", ".gitattributes",
 )
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -747,3 +747,70 @@ jobs:
           prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ---------------------------------------------------------------------------
+  # 5. Publish/update the AUR binary package (impulcifer-py313-bin).
+  #    AUR_SSH_PRIVATE_KEY 시크릿이 없으면 조용히 스킵된다 — 설정 방법은
+  #    packaging/aur/README.md 참조.
+  # ---------------------------------------------------------------------------
+  publish-aur:
+    name: Publish AUR package
+    needs: [gate, create-release]
+    if: needs.gate.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check AUR deploy key
+        id: key
+        env:
+          AUR_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+        run: |
+          if [ -n "$AUR_KEY" ]; then
+            echo "have=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "have=false" >> "$GITHUB_OUTPUT"
+            echo "AUR_SSH_PRIVATE_KEY secret is not set; skipping AUR publish."
+          fi
+
+      - name: Checkout code
+        if: steps.key.outputs.have == 'true'
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.gate.outputs.release_sha }}
+
+      - name: Download Linux tarball artifact
+        if: steps.key.outputs.have == 'true'
+        uses: actions/download-artifact@v7
+        with:
+          name: linux-tarball
+          path: tarball
+
+      - name: Generate PKGBUILD from template
+        if: steps.key.outputs.have == 'true'
+        run: |
+          APP_VERSION="${{ needs.gate.outputs.version }}"
+          TARBALL="tarball/Impulcifer-${APP_VERSION}-linux-x86_64.tar.gz"
+          if [ ! -f "$TARBALL" ]; then
+            echo "Error: expected tarball not found: $TARBALL"
+            ls -R tarball/
+            exit 1
+          fi
+          SHA256=$(sha256sum "$TARBALL" | cut -d' ' -f1)
+          echo "Version: $APP_VERSION  SHA256: $SHA256"
+          sed -e "s/@PKGVER@/${APP_VERSION}/" \
+              -e "s/@SHA256@/${SHA256}/" \
+              packaging/aur/PKGBUILD.in > PKGBUILD
+          echo "---- PKGBUILD ----"
+          cat PKGBUILD
+
+      - name: Publish to AUR
+        if: steps.key.outputs.have == 'true'
+        uses: KSXGitHub/github-actions-deploy-aur@v4.1.1
+        with:
+          pkgname: impulcifer-py313-bin
+          pkgbuild: ./PKGBUILD
+          commit_username: 115dkk
+          commit_email: 33408534+115dkk@users.noreply.github.com
+          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          commit_message: "Update to ${{ needs.gate.outputs.version }}"
+          ssh_keyscan_types: ed25519

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ been fixed and old features improved.
 ## 2.10.6 - 2026-08-06
 ### 인터랙티브 분석 플롯 수치 정합성 수정 + 플롯 메모리 잔류 해소·병렬화
 
+#### 🔧 빌드 / 설정 변경 (릴리스 후 추가 — 출하물 변화 없음)
+- **AUR 패키지 `impulcifer-py313-bin` 자동 발행**: 릴리스 파이프라인에 `publish-aur` job을 추가했다. `create-release` 성공 후 Linux tarball의 SHA-256을 계산해 `packaging/aur/PKGBUILD.in` 템플릿을 치환하고 AUR에 푸시한다(.SRCINFO는 배포 액션이 생성). `AUR_SSH_PRIVATE_KEY` 시크릿이 없으면 조용히 스킵되어 파이프라인은 그린 유지 — 설정 절차는 `packaging/aur/README.md` 참조. 패키지는 `/opt` 설치 + `impulcifer-py313` 런처 + 데스크톱 엔트리/Pulse 아이콘을 제공하며, `portaudio`를 의존성으로, `webkit2gtk-4.1`(WebView UI)·`ffmpeg`(TrueHD)를 선택 의존성으로 선언한다.
+- **릴리스 게이트 제외 경로 추가**: `packaging/*`는 출하물에 포함되지 않으므로 `release_gate.py`의 EXCLUDE에 추가했다 (`tests/test_release_gate.py`로 고정).
+
 #### 🐛 버그 수정
 - **IACC 플롯이 쓰레기값을 표시하던 문제**: "Cross-Correlation Coefficient" 축에 정규화되지 않은 상관값(신호 길이에 비례, 완전 상관 신호에서 1.0이 아니라 ~48000)이 그대로 실렸다. ISO 3382-1 정의대로 `sqrt(sum(l²)·sum(r²))`로 정규화한 IACF로 수정해 값이 항상 [-1, 1] 범위이며, IACC(범례 표기)는 탐색 창 내 max |IACF|로 계산한다.
 - **IPD 플롯이 중·고역에서 무의미한 값을 내던 문제**: 대역 내 복소 스펙트럼을 각각 합한 뒤 위상차를 취하는 방식은 빈 간 위상 회전으로 상쇄가 일어나 실제 위상차와 무관한 값을 냈다(0.5ms 지연 신호의 2kHz 대역 정답 0° 대비 128° 등). 크로스 스펙트럼 합 `sum(L·conj(R))`의 위상각(에너지 가중 원형 평균)으로 수정해 순수 지연에 대해 대역 중심 주파수의 이론 위상차와 일치한다.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,16 @@ sudo apt-get install -y gir1.2-gtk-3.0 gir1.2-webkit2-4.1 \
 
 Python을 따로 설치하지 않고 쓰려면 [GitHub Releases](https://github.com/115dkk/Impulcifer-pip313/releases)에서 운영체제에 맞는 파일을 받으세요. 릴리스 파일 이름과 구성은 버전마다 달라질 수 있으므로, 각 릴리스의 설명을 확인해 주세요.
 
+### Arch Linux (AUR)
+
+Arch 계열 배포판에서는 AUR의 [`impulcifer-py313-bin`](https://aur.archlinux.org/packages/impulcifer-py313-bin) 패키지로 설치할 수 있습니다. 릴리스 tarball 기반 바이너리 패키지이며 새 릴리스마다 자동으로 갱신됩니다.
+
+```bash
+yay -S impulcifer-py313-bin
+```
+
+WebView UI를 쓰려면 `webkit2gtk-4.1`을 함께 설치하세요 (없으면 CustomTkinter UI로 폴백).
+
 ## 실행
 
 GUI를 쓰려면 다음 명령을 실행합니다.

--- a/packaging/aur/PKGBUILD.in
+++ b/packaging/aur/PKGBUILD.in
@@ -1,0 +1,60 @@
+# Maintainer: 115dkk <33408534+115dkk@users.noreply.github.com>
+# 이 파일은 템플릿이다. 릴리스 파이프라인(.github/workflows/publish.yml의
+# publish-aur job)이 @PKGVER@ / @SHA256@를 실제 릴리스 값으로 치환해
+# AUR(impulcifer-py313-bin)에 푸시한다. 손으로 AUR에 올릴 때도 같은
+# 자리표시자만 바꾸면 된다.
+
+pkgname=impulcifer-py313-bin
+pkgver=@PKGVER@
+pkgrel=1
+pkgdesc="HRIR measurement and binaural BRIR processing for headphone surround virtualization (Nuitka binary release)"
+arch=('x86_64')
+url="https://github.com/115dkk/Impulcifer-pip313"
+license=('MIT')
+provides=('impulcifer-py313')
+conflicts=('impulcifer-py313')
+# Nuitka standalone 번들은 Python 런타임과 대부분의 .so를 포함하지만,
+# 오디오 재생/녹음(PortAudio)과 WebView UI(WebKit2GTK)는 시스템
+# 라이브러리를 런타임에 로드한다 (typelib만 번들됨).
+depends=('glibc' 'gcc-libs' 'portaudio')
+optdepends=(
+  'webkit2gtk-4.1: WebView(Pulse Studio) UI — 없으면 CustomTkinter UI로 폴백'
+  'ffmpeg: TrueHD/MLP 테스트 신호 디코드 지원'
+)
+options=('!strip' '!debug')
+source=("${url}/releases/download/v${pkgver}/Impulcifer-${pkgver}-linux-x86_64.tar.gz")
+sha256sums=('@SHA256@')
+
+package() {
+  install -dm755 "$pkgdir/opt/$pkgname"
+  cp -a "$srcdir/Impulcifer-linux/." "$pkgdir/opt/$pkgname/"
+
+  # 실행 런처
+  install -dm755 "$pkgdir/usr/bin"
+  cat > "$pkgdir/usr/bin/impulcifer-py313" << 'EOF'
+#!/bin/bash
+exec /opt/impulcifer-py313-bin/Impulcifer "$@"
+EOF
+  chmod 755 "$pkgdir/usr/bin/impulcifer-py313"
+
+  # 데스크톱 엔트리 + 아이콘 (아이콘은 번들에 포함된 Pulse 로고 재사용)
+  install -Dm644 "$srcdir/Impulcifer-linux/logo/pulse-256.png" \
+    "$pkgdir/usr/share/icons/hicolor/256x256/apps/impulcifer-py313.png"
+  install -dm755 "$pkgdir/usr/share/applications"
+  cat > "$pkgdir/usr/share/applications/impulcifer-py313.desktop" << 'EOF'
+[Desktop Entry]
+Type=Application
+Name=Impulcifer
+Comment=HRIR measurement and binaural BRIR processing for headphone surround virtualization
+Comment[ko]=HRIR 측정 및 헤드폰 서라운드 가상화용 바이노럴 BRIR 생성
+Exec=impulcifer-py313
+Icon=impulcifer-py313
+Categories=AudioVideo;Audio;
+Terminal=false
+EOF
+
+  install -Dm644 "$srcdir/Impulcifer-linux/LICENSE" \
+    "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+  install -Dm644 "$srcdir/Impulcifer-linux/THIRD_PARTY_LICENSES.md" \
+    "$pkgdir/usr/share/licenses/$pkgname/THIRD_PARTY_LICENSES.md"
+}

--- a/packaging/aur/README.md
+++ b/packaging/aur/README.md
@@ -1,0 +1,41 @@
+# AUR 패키지 (`impulcifer-py313-bin`)
+
+릴리스 파이프라인이 GitHub Release의 Linux tarball을 소스로 하는 AUR
+바이너리 패키지를 자동 발행/갱신한다.
+
+## 동작 방식
+
+- `.github/workflows/publish.yml`의 `publish-aur` job이 `create-release`
+  성공 후 실행된다.
+- job은 방금 발행된 `Impulcifer-<버전>-linux-x86_64.tar.gz`를 내려받아
+  SHA-256을 계산하고, `PKGBUILD.in`의 `@PKGVER@` / `@SHA256@`를 치환한
+  PKGBUILD를 [KSXGitHub/github-actions-deploy-aur] 액션으로
+  `aur.archlinux.org/impulcifer-py313-bin`에 커밋한다 (.SRCINFO는 액션이
+  Arch 컨테이너에서 자동 생성).
+- 저장소 시크릿 `AUR_SSH_PRIVATE_KEY`가 없으면 job은 **조용히 스킵**되고
+  파이프라인은 그린으로 유지된다. 즉 시크릿을 넣기 전까지는 아무 일도
+  일어나지 않는다.
+
+## 최초 1회 설정 (메인테이너)
+
+1. [AUR 계정](https://aur.archlinux.org/register) 생성 (이미 있으면 생략).
+2. AUR 전용 SSH 키 생성: `ssh-keygen -t ed25519 -f aur -C aur@impulcifer -N ""`
+3. 공개키(`aur.pub`)를 AUR 계정 설정(My Account → SSH Public Key)에 등록.
+4. 개인키(`aur`) 내용을 이 GitHub 저장소의 Actions 시크릿
+   `AUR_SSH_PRIVATE_KEY`로 등록.
+5. 다음 릴리스부터 자동 발행된다. 패키지 베이스는 첫 push 때 AUR이
+   자동 생성하므로 웹에서 미리 만들 필요 없다.
+
+## 수동 발행이 필요할 때
+
+`PKGBUILD.in`의 자리표시자를 치환한 뒤 통상적인 AUR 절차를 따른다:
+
+```bash
+sed -e 's/@PKGVER@/2.10.6/' \
+    -e "s/@SHA256@/$(sha256sum Impulcifer-2.10.6-linux-x86_64.tar.gz | cut -d' ' -f1)/" \
+    PKGBUILD.in > PKGBUILD
+makepkg --printsrcinfo > .SRCINFO
+git -C <aur-clone> add PKGBUILD .SRCINFO && git commit && git push
+```
+
+[KSXGitHub/github-actions-deploy-aur]: https://github.com/KSXGitHub/github-actions-deploy-aur

--- a/tests/test_release_gate.py
+++ b/tests/test_release_gate.py
@@ -55,6 +55,14 @@ def test_nested_excluded_dirs_match_at_any_depth():
     ]) == []
 
 
+def test_packaging_metadata_is_not_shippable():
+    # AUR PKGBUILD 등 배포 채널 메타데이터는 출하물(wheel/standalone)에
+    # 포함되지 않으므로 릴리스를 트리거하면 안 된다.
+    assert release_gate.classify_shippable([
+        "packaging/aur/PKGBUILD.in", "packaging/aur/README.md",
+    ]) == []
+
+
 # ── parse_version / next_free_patch ──────────────────────────────────────────
 
 def test_parse_version():


### PR DESCRIPTION
# 개요

AUR에 릴리스 tarball 기반 바이너리 패키지 `impulcifer-py313-bin`을 자동 발행/갱신하는 CI 연동을 추가합니다. (배포 채널 검토에서 "AUR `-bin` 패키지가 노력 대비 최선" 결론에 따른 구현)

## 구성

### `packaging/aur/PKGBUILD.in` — PKGBUILD 템플릿

- 소스: GitHub Release의 `Impulcifer-<버전>-linux-x86_64.tar.gz` (`@PKGVER@`/`@SHA256@` 자리표시자를 CI가 치환)
- `/opt/impulcifer-py313-bin` 설치 + `/usr/bin/impulcifer-py313` 런처 + 데스크톱 엔트리 + Pulse 아이콘(번들의 `logo/pulse-256.png` 재사용) + LICENSE/THIRD_PARTY_LICENSES 설치
- 의존성은 실제 tarball 내용을 분석해 결정: Nuitka 번들에 tcl/tk·gi는 포함되지만 **PortAudio는 미번들**(→ `depends=portaudio`), WebKit2GTK는 typelib만 포함(→ `optdepends=webkit2gtk-4.1`, 없으면 CTk UI 폴백). `ffmpeg`는 TrueHD 지원용 optdepends
- `options=('!strip' '!debug')` — Nuitka 산출물 재스트립 방지
- **검증**: v2.10.6 실물 tarball(sha256 `b1e2e37b…`)로 `package()` 파일 연산 시뮬레이션 통과, 템플릿 치환 렌더링 확인

### `publish.yml` — `publish-aur` job

- `needs: [gate, create-release]`, 기존 불변식대로 명시적 `if: needs.gate.outputs.should_release == 'true'` 유지
- linux-tarball 아티팩트를 내려받아 SHA-256 계산 → 템플릿 치환 → [KSXGitHub/github-actions-deploy-aur@v4.1.1](https://github.com/KSXGitHub/github-actions-deploy-aur)로 AUR에 커밋 (.SRCINFO는 액션이 Arch 컨테이너에서 자동 생성)
- **`AUR_SSH_PRIVATE_KEY` 시크릿이 없으면 조용히 스킵** — 시크릿 설정 전에는 파이프라인 동작이 변하지 않고 그린을 유지합니다. 설정 절차(AUR 계정/SSH 키/시크릿 등록)는 `packaging/aur/README.md`에 문서화

### `release_gate.py` — `packaging/*` EXCLUDE 추가

PKGBUILD 등 배포 채널 메타데이터는 wheel/standalone 출하물에 포함되지 않으므로 릴리스를 트리거하면 안 됩니다. `tests/test_release_gate.py`에 케이스를 추가해 고정했습니다. (따라서 이 PR 자체도 gate가 `should_release=false`로 판정 — docs/CI/packaging만 변경)

### README

Arch Linux(AUR) 설치 섹션 추가.

## 머지 후 필요한 1회 작업 (메인테이너)

1. AUR 계정에 SSH 공개키 등록
2. 저장소 Actions 시크릿 `AUR_SSH_PRIVATE_KEY`에 개인키 등록
3. 다음 릴리스부터 자동 발행 (패키지 베이스는 첫 push 때 AUR이 자동 생성)

## 검증

- `tests/test_release_gate.py` + `tests/test_build_config.py` + `tests/test_nuitka_flags.py` 41개 통과 (CHANGELOG 버전 헤딩 유일성 테스트 포함)
- publish.yml YAML 파싱 검증
- 버전 bump 없음 (빌드/배포 설정 + 문서만 — 출하물 무변경, CHANGELOG에는 2.10.6 섹션에 🔧 항목으로 추가)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HfKE63E4jpZVu6ZVhiN7oz

---
_Generated by [Claude Code](https://claude.ai/code/session_01HfKE63E4jpZVu6ZVhiN7oz)_