### PR TITLE
refactor: 주석 전면 청소 — 재기술·이력 서술·중복 설명 제거 (2.11.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ first number changes, something has broken and you need to check your commands a
 changes there are only new features available and nothing old has broken and when the last number changes, old bugs have
 been fixed and old features improved.
 
+## 2.11.1 - 2026-08-09
+### 주석(각주) 전면 청소
+
+#### 🔧 빌드 / 설정 변경
+- **코드 주석 정리(동작 변경 없음)**: 출하 코드 전반(core/gui/application/i18n/infra/updater/build_scripts)에서 ①코드를 재기술할 뿐인 주석, ②작업 이력·감사 번호 등 유래 서술("audit #NNN에서 이동" 류), ③중복 설명을 삭제했다(27개 파일, 약 −310줄/+68줄). DSP 수식 근거·플랫폼 특이사항(Win32 스크롤 blit, GDI 폰트, Nuitka 화이트리스트 등)·수정 전 필수 지식에 해당하는 주석은 전부 유지. `core/hrir.py`의 `correct_channel_balance()`에서 생성만 되고 사용되지 않던 죽은 `stacks` 블록도 함께 제거했다. BRIR 출력 바이트 동일성은 같은 머신 자기비교로 확인(default `3F9297…`, vbass `3AD84C…` — 2.11.0 오라클과 일치).
+
 ## 2.11.0 - 2026-08-08
 ### 즉석 스윕 생성·재생 + 스윕 자동 감지 + WebView 기동 최적화 + pkl 지원 삭제
 

--- a/application/impulcifer_service.py
+++ b/application/impulcifer_service.py
@@ -29,9 +29,6 @@ _RECORDING_FIELDS = {
     "confirm_warnings",
     "sweep",
 }
-# On-the-fly sweep sub-object of a recording request. mode "default" and
-# "custom" generate the sequence in memory (no play file needed); "file"
-# (or an absent sweep object) keeps the legacy play_path behaviour.
 _SWEEP_REQUEST_FIELDS = {"mode", "fs", "duration", "speakers", "tracks"}
 _SWEEP_MODES = ("default", "custom", "file")
 
@@ -59,9 +56,6 @@ _THEME_CODES = ("dark", "light", "system")
 # Mirrors gui.skins.SKIN_CHOICES without importing the gui package (this
 # module must stay importable without tkinter).
 _SKIN_CODES = ("stable", "studio")
-# gui_main launcher targets; ``webview`` is the default since 2.10 and CTk
-# stays supported for the rest of version 2 (kept frozen like the legacy GUI
-# from version 3 on — not removed).
 _FRONTEND_CODES = ("webview", "ctk")
 
 _dsp_prewarm_started = False
@@ -143,7 +137,7 @@ def _brir_field_defaults() -> dict[str, Any]:
     """Map every defaulted ``ProcessingConfig`` field to its canonical default.
 
     Shipped to frontends via ``bootstrap()`` so they never hardcode copies of
-    pipeline defaults (audit #138 F020).
+    pipeline defaults.
     """
     global _brir_field_defaults_cache
     if _brir_field_defaults_cache is None:
@@ -241,12 +235,9 @@ class ImpulciferApplicationService:
         # The DSP stack (impulcifer → core → scipy …) must never be able to
         # kill the UI shell: a packaging regression there should surface as a
         # readable job/system-info error, not as a dead bootstrap that leaves
-        # raw i18n keys and an empty language list on screen (observed with
-        # the 2.10.0 standalone, whose bundle was missing a lazy scipy
-        # vendored module). infra.version is deliberately DSP-free — reading
-        # the version via ``import impulcifer`` used to pull scipy/matplotlib/
-        # bokeh in and made bootstrap (= the WebView's first paint) take
-        # seconds.
+        # raw i18n keys on screen. infra.version is deliberately DSP-free —
+        # ``import impulcifer`` would pull scipy/matplotlib/bokeh into the
+        # WebView's first paint and cost seconds.
         try:
             from infra.version import get_app_version
 
@@ -263,8 +254,6 @@ class ImpulciferApplicationService:
         except Exception:
             brir_defaults = {}
 
-        # On-the-fly sweep presets for the recorder UI (layout choices and
-        # canonical defaults) — degrades to an empty dict like the above.
         # core.constants is import-light on purpose; do NOT source these
         # from core.sweep_signal here (that would drag scipy into bootstrap).
         try:
@@ -288,7 +277,6 @@ class ImpulciferApplicationService:
             active_job = self._jobs.get(self._active_job_id or "")
             active = active_job.snapshot() if active_job is not None else None
 
-        # Warm the DSP imports off the critical path once the UI is up.
         _start_dsp_prewarm()
 
         return _ok(
@@ -945,7 +933,6 @@ class ImpulciferApplicationService:
 
         play_path: str | None = str(request.get("play_path", "")).strip()
         if sweep_spec is not None:
-            # Generated sweeps need no play file.
             play_path = None
         elif not play_path or not os.path.isfile(play_path):
             return _error("FILE_NOT_FOUND", "Playback file does not exist.", details={"path": play_path})

--- a/build_scripts/build_nuitka.py
+++ b/build_scripts/build_nuitka.py
@@ -100,7 +100,6 @@ def build_impulcifer(project_version="0.0.0", output_base_dir="dist", target_pla
         build_nuitka_args,
     )
 
-    # 플랫폼 감지
     if target_platform is None:
         target_platform = get_platform()
 
@@ -167,7 +166,6 @@ def main():
     """메인 빌드 프로세스"""
     print("=== Impulcifer Nuitka 크로스 플랫폼 빌드 스크립트 ===\n", flush=True)
 
-    # 플랫폼 감지 및 표시
     current_platform = get_platform()
     print(f"감지된 플랫폼: {current_platform}", flush=True)
 
@@ -191,7 +189,6 @@ def main():
     if build_impulcifer(project_version=current_version, output_base_dir="dist"):
         print("\n빌드가 완료되었습니다!", flush=True)
 
-        # 플랫폼별 출력 경로 확인
         if current_platform == "windows":
             final_path = Path('dist/Impulcifer_Distribution/ImpulciferGUI').resolve()
         elif current_platform == "macos":

--- a/core/audio_io.py
+++ b/core/audio_io.py
@@ -81,7 +81,6 @@ def read_wav(file_path, expand=False):
 
 def write_wav(file_path, fs, data, bit_depth=32):
     """Writes WAV file."""
-    # Ensure the directory exists before saving
     os.makedirs(os.path.dirname(file_path), exist_ok=True)
     
     if bit_depth == 16:

--- a/core/audio_truehd.py
+++ b/core/audio_truehd.py
@@ -50,10 +50,8 @@ def convert_truehd_to_wav(truehd_path, output_path=None):
         fd, output_path = tempfile.mkstemp(suffix='.wav')
         os.close(fd)
 
-    # Get channel layout info first
     channel_info = get_truehd_channel_info(truehd_path)
 
-    # Convert to WAV with proper channel mapping
     cmd = [
         _discovery.FFMPEG_PATH, '-i', truehd_path,
         '-acodec', 'pcm_f32le',  # 32-bit float PCM
@@ -92,13 +90,11 @@ def get_truehd_channel_info(file_path):
         channels = stream.get('channels', 0)
         stream.get('channel_layout', '')
 
-        # Map channel layouts to speaker names
         from core.constants import CHANNEL_LAYOUT_MAP
 
         if channels in CHANNEL_LAYOUT_MAP:
             return CHANNEL_LAYOUT_MAP[channels]
         else:
-            # Unknown layout, return None
             return None
     except Exception:
         return None
@@ -164,7 +160,6 @@ def read_audio(file_path, expand=False):
     # 기반 빠른 분기로 모듈 import / 일반 처리 경로의 ffmpeg 탐색 비용을 제거.
     ext = os.path.splitext(file_path)[1].lower()
     if ext in _TRUEHD_EXTENSIONS and is_truehd_file(file_path):
-        # Convert TrueHD to temporary WAV
         temp_wav, channel_info = convert_truehd_to_wav(file_path)
         try:
             data, fs = sf.read(temp_wav)
@@ -179,7 +174,6 @@ def read_audio(file_path, expand=False):
             if os.path.exists(temp_wav):
                 os.remove(temp_wav)
     else:
-        # Original WAV reading logic
         data, fs = sf.read(file_path)
         if len(data.shape) > 1:
             # Soundfile has tracks on columns, we want them on rows

--- a/core/constants.py
+++ b/core/constants.py
@@ -111,7 +111,7 @@ DEFAULT_SWEEP_FS = 48000
 DEFAULT_SWEEP_DURATION = 5.0
 SWEEP_TRACK_LAYOUTS = ("mono", "stereo", "5.1", "7.1", "7.1.4", "7.1.6")
 
-# 기본 테스트 신호 파일 목록
+# CLI --test_signal 별칭 → 번들 WAV 파일명
 TEST_SIGNALS = {
     'default': 'sweep-6.15s-48000Hz-32bit-2.93Hz-24000Hz.wav',
     'sweep': 'sweep-6.15s-48000Hz-32bit-2.93Hz-24000Hz.wav',

--- a/core/eqapo.py
+++ b/core/eqapo.py
@@ -638,7 +638,7 @@ def _parse_lines(lines, state, base_dir, depth, visited):
                 continue
             condition = _try_evaluate_condition(value, state.srate)
             if condition is None:
-                # 평가 불가: 블록 전체를 보수적으로 바이패스(기존 동작).
+                # 평가 불가: 블록 전체를 보수적으로 바이패스.
                 state.bypassed.append(
                     EqApoCommandReport(line_number, key, line.strip(), REASON_CONDITIONAL)
                 )

--- a/core/ffmpeg_discovery.py
+++ b/core/ffmpeg_discovery.py
@@ -28,9 +28,8 @@ def get_ffmpeg_version(ffmpeg_path):
                               capture_output=True, text=True, timeout=10,
                               encoding='utf-8', errors='replace')
         if result.returncode == 0:
-            # 첫 번째 줄에서 버전 정보 추출
+            # 'ffmpeg version X.Y.Z' 형태의 첫 줄에서 버전 추출
             first_line = result.stdout.split('\n')[0]
-            # 'ffmpeg version X.Y.Z' 형태에서 버전 추출
             if 'version' in first_line:
                 version_part = first_line.split('version')[1].strip().split()[0]
                 
@@ -51,11 +50,9 @@ def get_ffmpeg_version(ffmpeg_path):
                     except (ValueError, IndexError):
                         return (1, 0)  # 파싱 실패시 구버전으로 간주
                 
-                # 숫자로 시작하는 일반 버전 추출
                 version_nums = []
                 for part in version_part.split('.'):
                     try:
-                        # 숫자가 아닌 문자가 나오면 중단
                         clean_part = ''
                         for char in part:
                             if char.isdigit():
@@ -143,9 +140,7 @@ def install_ffmpeg():
     
     try:
         if system == 'windows':
-            # Windows: Chocolatey 또는 winget 사용
-            
-            # 먼저 chocolatey 시도
+            # Chocolatey → winget 순으로 시도
             try:
                 subprocess.run(['choco', '--version'], capture_output=True, check=True, timeout=10,
                              encoding='utf-8', errors='replace')
@@ -158,7 +153,6 @@ def install_ffmpeg():
             except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
                 pass
 
-            # winget 시도
             try:
                 subprocess.run(['winget', '--version'], capture_output=True, check=True, timeout=10,
                              encoding='utf-8', errors='replace')
@@ -171,8 +165,7 @@ def install_ffmpeg():
             except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
                 pass
                 
-        elif system == 'darwin':  # macOS
-            # Homebrew 사용
+        elif system == 'darwin':
             try:
                 subprocess.run(['brew', '--version'], capture_output=True, check=True, timeout=10,
                              encoding='utf-8', errors='replace')

--- a/core/hrir.py
+++ b/core/hrir.py
@@ -38,15 +38,14 @@ def get_center_value(fr, frequency_range):
     Returns:
         The negative of the gain shift that would be applied by center()
     """
-    # Create interpolator - use linear interpolation to avoid overshoot/undershoot
-    k_order = 1  # Always use linear interpolation to prevent artifacts
+    # Linear interpolation (k=1) avoids overshoot/undershoot artifacts.
+    k_order = 1
     try:
         interpolator = InterpolatedUnivariateSpline(np.log10(fr.frequency), fr.raw, k=k_order)
     except ValueError:
         interpolator = InterpolatedUnivariateSpline(np.log10(fr.frequency), fr.raw, k=1)
 
     if isinstance(frequency_range, (list, np.ndarray)) and len(frequency_range) > 1:
-        # Use the average of the gain values between the given frequencies
         diff = np.mean(fr.raw[np.logical_and(
             fr.frequency >= frequency_range[0],
             fr.frequency <= frequency_range[1]
@@ -54,7 +53,6 @@ def get_center_value(fr, frequency_range):
     else:
         if isinstance(frequency_range, (list, np.ndarray)):
             frequency_range = frequency_range[0]
-        # Use the gain value at the given frequency
         diff = interpolator(np.log10(frequency_range))
 
     return -diff
@@ -150,7 +148,6 @@ def _ingest_recording(estimator, expected_fs, file_path, speakers, side=None,
             f"  WARNING: Not enough tracks in recording! Need {len(speakers) * tracks_k}, have {recording.shape[0]}"
         )
 
-    # Crop out initial silence
     recording = recording[:, silence_length:]
     print(f"  After silence crop: {recording.shape}")
 
@@ -190,7 +187,7 @@ def _ingest_recording(estimator, expected_fs, file_path, speakers, side=None,
         start_sample = i * column_size
         end_sample = min(
             (i + 1) * column_size, recording.shape[1]
-        )  # Ensure we don't exceed recording length
+        )
 
         if end_sample > start_sample and (end_sample - start_sample) >= len(
             estimator
@@ -210,7 +207,7 @@ def _ingest_recording(estimator, expected_fs, file_path, speakers, side=None,
 
         # Option 1: Reduce silence length
         if silence_length > 0:
-            min_silence = int(0.5 * fs)  # Minimum 0.5 seconds silence
+            min_silence = int(0.5 * fs)
             available_for_silence = recording.shape[1] - len(estimator)
 
             if available_for_silence >= min_silence:
@@ -263,7 +260,6 @@ def _ingest_recording(estimator, expected_fs, file_path, speakers, side=None,
                     f"  Fallback 2: Single column with {available_length} samples"
                 )
             else:
-                # Divide equally among columns
                 column_size = available_length // n_columns
                 for i in range(n_columns):
                     start_sample = i * column_size
@@ -332,7 +328,6 @@ def _ingest_recording(estimator, expected_fs, file_path, speakers, side=None,
                         f"  WARNING: Not enough tracks for stereo processing of {speaker}"
                     )
             else:
-                # Only the given side
                 data = column[i, :]
                 print(
                     f"  Processing {speaker} {side}: Track {i} (max={np.max(np.abs(data)):.6f})"
@@ -426,7 +421,6 @@ class HRIR(HRIRPlotter):
         if track_order is None:
             track_order = HEXADECAGONAL_TRACK_ORDER
 
-        # Add only the requested impulse responses in output order.
         irs_by_name = {}
         for speaker, pair in self.irs.items():
             for side, ir in pair.items():
@@ -461,7 +455,6 @@ class HRIR(HRIRPlotter):
             left.append(pair["left"].data)
             right.append(pair["right"].data)
 
-        # Filter out empty arrays before stacking
         left = [arr for arr in left if arr.size > 0]
         right = [arr for arr in right if arr.size > 0]
 
@@ -474,7 +467,6 @@ class HRIR(HRIRPlotter):
         right_lengths = [len(arr) for arr in right]
 
         if len(set(left_lengths)) > 1 or len(set(right_lengths)) > 1:
-            # Arrays have different lengths, pad shorter ones to match the longest
             max_left_len = max(left_lengths) if left_lengths else 0
             max_right_len = max(right_lengths) if right_lengths else 0
 
@@ -520,7 +512,6 @@ class HRIR(HRIRPlotter):
 
         if PARALLEL_PROCESSING_AVAILABLE and len(self.irs) > 4:
             def apply_gain_to_pair(speaker, pair):
-                """각 스피커 채널에 gain을 적용"""
                 for ir in pair.values():
                     ir.data *= gain_scalar
                 return pair
@@ -532,7 +523,6 @@ class HRIR(HRIRPlotter):
             if is_free_threaded_available():
                 print(f"  🚀 Free-Threaded 병렬 정규화 완료 ({len(self.irs)} 채널)")
         else:
-            # 순차 처리 (채널 수가 적거나 병렬 처리 모듈 없음)
             for speaker, pair in self.irs.items():
                 for ir in pair.values():
                     ir.data *= gain_scalar
@@ -558,7 +548,6 @@ class HRIR(HRIRPlotter):
             peak_left = pair["left"].peak_index()
             peak_right = pair["right"].peak_index()
 
-            # Handle cases where peak_index returns None (empty arrays)
             if peak_left is None or peak_right is None:
                 print(
                     f"Warning: Could not find peaks for {speaker}. Skipping crop_heads processing for this speaker."
@@ -567,17 +556,12 @@ class HRIR(HRIRPlotter):
 
             itd = np.abs(peak_left - peak_right) / self.fs
 
-            # Speaker channel delay
             head = int(head_ms * self.fs / 1000)
-            delay = (
-                int(np.round(SPEAKER_DELAYS[speaker] * self.fs)) + head
-            )  # Channel delay in samples
+            delay = int(np.round(SPEAKER_DELAYS[speaker] * self.fs)) + head
 
             if peak_left < peak_right:
                 # Delay to left ear is smaller, this must be a left side speaker
                 if speaker_side(speaker) == "right":
-                    # Speaker name indicates this is right side speaker but delay to left ear is smaller than to right.
-                    # There is something wrong with the measurement
                     warnings.warn(
                         f"Warning: {speaker} measurement has lower delay to left ear than to right ear. "
                         f"{speaker} should be at the right side of the head so the sound should arrive first "
@@ -594,8 +578,6 @@ class HRIR(HRIRPlotter):
             else:
                 # Delay to right ear is smaller, this must be a right side speaker
                 if speaker_side(speaker) == "left":
-                    # Speaker name indicates this is left side speaker but delay to right ear is smaller than to left.
-                    # There si something wrong with the measurement
                     warnings.warn(
                         f"Warning: {speaker} measurement has lower delay to right ear than to left ear. "
                         f"{speaker} should be at the left side of the head so the sound should arrive first "
@@ -607,8 +589,7 @@ class HRIR(HRIRPlotter):
                 pair["right"].data = pair["right"].data[crop_index:]
                 pair["left"].data = pair["left"].data[crop_index:]
 
-            # Make sure impulse response starts from silence
-            # Ensure we have enough data for the windowing
+            # Fade in so the impulse response starts from silence
             if len(pair["left"].data) >= head and len(pair["right"].data) >= head:
                 window = hann(head * 2)[:head]
                 pair["left"].data[:head] *= window
@@ -635,7 +616,6 @@ class HRIR(HRIRPlotter):
                     _, tail_ind, _, _ = ir.decay_params()
                     tail_indices.append(tail_ind)
                 except Exception:
-                    # If decay_params fails, use full length as fallback
                     tail_indices.append(len(ir.data))
                 lengths.append(len(ir.data))
 
@@ -652,7 +632,6 @@ class HRIR(HRIRPlotter):
         for speaker, pair in self.irs.items():
             for ir in pair.values():
                 ir.data = ir.data[:tail_ind]
-                # Apply fade-out window
                 ir.data *= np.concatenate([np.ones(len(ir.data) - len(window)), window])
 
         return tail_ind
@@ -691,9 +670,7 @@ class HRIR(HRIRPlotter):
                 treble_f_lower=20000,
                 treble_f_upper=int(round(self.fs / 2)),
             )
-            # Trend is the equalization target
             right_fr.equalization = trend.smoothed
-            # Unit impulse for left side and equalization FIR filter for right side
             fir = right_fr.minimum_phase_impulse_response(fs=self.fs, normalize=False)
             firs = [signal.unit_impulse((len(fir))), fir]
 
@@ -705,16 +682,13 @@ class HRIR(HRIRPlotter):
                 ref = right_fr
                 subj = left_fr
 
-            # Smoothen reference
             ref.smoothen_fractional_octave(
                 window_size=1 / 3,
                 treble_f_lower=20000,
                 treble_f_upper=int(round(self.fs / 2)),
             )
-            # Center around 0 dB
             gain = ref.center([100, 10000])
             subj.raw += gain
-            # Compensate and equalize to reference
             subj.target = ref.smoothed
             subj.error = subj.raw - subj.target
             subj.smoothen_heavy_light()
@@ -732,7 +706,6 @@ class HRIR(HRIRPlotter):
             left_fr.raw += gain
             right_fr.raw += gain
 
-            # Smoothen
             left_fr.smoothen_fractional_octave(
                 window_size=1 / 3, treble_f_lower=20000, treble_f_upper=23999
             )
@@ -740,18 +713,15 @@ class HRIR(HRIRPlotter):
                 window_size=1 / 3, treble_f_lower=20000, treble_f_upper=23999
             )
 
-            # Target
             if method == "avg":
-                # Target is the average between the two FRs
                 target = (left_fr.raw + right_fr.raw) / 2
             else:
-                # Target is the  frequency-vise minimum of the two FRs
                 target = np.min([left_fr.raw, right_fr.raw], axis=0)
 
-            # Compensate and equalize both to the target
             firs = []
             for fr in [left_fr, right_fr]:
-                # Optimized: No need to copy target array since it's not modified
+                # ``target`` is shared (not copied) between both FRs; safe only
+                # while nothing downstream mutates fr.target in place.
                 fr.target = target
                 fr.error = fr.raw - fr.target
                 fr.smoothen_fractional_octave(
@@ -790,14 +760,6 @@ class HRIR(HRIRPlotter):
         Returns:
             HRIR with FIR filter for equalizing each speaker-side
         """
-        # Create frequency responses for left and right side IRs
-        stacks = [[], []]
-        for speaker, pair in self.irs.items():
-            if speaker not in ["FL", "FR"]:
-                continue
-            for i, ir in enumerate(pair.values()):
-                stacks[i].append(ir.data)
-
         # Group the same left and right side speakers
         eqir = HRIR(self.estimator)
         for speakers in [["FC"], ["FL", "FR"], ["SL", "SR"], ["BL", "BR"]]:
@@ -808,16 +770,13 @@ class HRIR(HRIRPlotter):
             for speaker in speakers:
                 left.append(self.irs[speaker]["left"].data)
                 right.append(self.irs[speaker]["right"].data)
-            # Create frequency responses
             left_fr = ImpulseResponse(
                 np.mean(np.vstack(left), axis=0), self.fs
             ).frequency_response()
             right_fr = ImpulseResponse(
                 np.mean(np.vstack(right), axis=0), self.fs
             ).frequency_response()
-            # Create EQ FIR filters
             firs = self.channel_balance_firs(left_fr, right_fr, method)
-            # Assign to speakers in EQ HRIR
             for speaker in speakers:
                 self.irs[speaker]["left"].equalize(firs[0])
                 self.irs[speaker]["right"].equalize(firs[1])
@@ -854,7 +813,6 @@ class HRIR(HRIRPlotter):
 
         print("마이크 착용 편차 보정 v4.0 중...")
 
-        # 플롯 디렉토리 설정
         if plot_analysis and plot_dir:
             mic_deviation_plot_dir = os.path.join(plot_dir, "microphone_deviation")
             os.makedirs(mic_deviation_plot_dir, exist_ok=True)
@@ -927,14 +885,11 @@ class HRIR(HRIRPlotter):
             None
         """
         if PARALLEL_PROCESSING_AVAILABLE and len(self.irs) > 4:
-            # 병렬 처리: 각 스피커 채널 리샘플링
             def resample_pair(speaker, pair):
-                """각 스피커 채널을 리샘플링"""
                 for side, ir in pair.items():
                     ir.resample(fs)
                 return pair
 
-            # 병렬 실행
             self.irs = parallel_process_dict(resample_pair, self.irs, use_threads=True)
 
             if is_free_threaded_available():
@@ -942,7 +897,6 @@ class HRIR(HRIRPlotter):
                     f"  🚀 Free-Threaded 병렬 리샘플링 완료 ({len(self.irs)} 채널, {self.fs}Hz → {fs}Hz)"
                 )
         else:
-            # 순차 처리
             for speaker, pair in self.irs.items():
                 for side, ir in pair.items():
                     ir.resample(fs)
@@ -1066,7 +1020,6 @@ class HRIR(HRIRPlotter):
                     }
                     continue
 
-                # Convert ms to samples
                 direct_end_sample = peak_idx + int(
                     direct_sound_duration_ms * self.fs / 1000
                 )
@@ -1075,7 +1028,6 @@ class HRIR(HRIRPlotter):
                 late_start_sample = peak_idx + int(late_ref_start_ms * self.fs / 1000)
                 late_end_sample = peak_idx + int(late_ref_end_ms * self.fs / 1000)
 
-                # Ensure slices are within bounds
                 data_len = len(ir.data)
                 direct_sound_segment = ir.data[
                     peak_idx : min(direct_end_sample, data_len)
@@ -1087,7 +1039,6 @@ class HRIR(HRIRPlotter):
                     min(late_start_sample, data_len) : min(late_end_sample, data_len)
                 ]
 
-                # Calculate RMS, handle potentially empty segments
                 rms_direct = (
                     np.sqrt(np.mean(direct_sound_segment**2))
                     if len(direct_sound_segment) > 0
@@ -1104,7 +1055,6 @@ class HRIR(HRIRPlotter):
                     else 0
                 )
 
-                # Add epsilon to rms_direct before division to prevent log(0) or division by zero
                 rms_direct = rms_direct if rms_direct > epsilon else epsilon
 
                 db_early = (

--- a/core/impulse_response.py
+++ b/core/impulse_response.py
@@ -381,17 +381,14 @@ class ImpulseResponse(ImpulseResponsePlotter):
                 # Targets not found on the Schroeder curve
                 continue
 
-            # Check if we have valid data range for linear regression
+            # Need at least 2 points for linear regression
             if start >= end or (end - start) < 2:
-                # Need at least 2 points for linear regression
                 continue
 
-            # Check if the sliced arrays are not empty
             t_slice = t[start:end]
             schroeder_slice = schroeder[start:end]
 
             if len(t_slice) == 0 or len(schroeder_slice) == 0:
-                # Empty arrays, skip this decay time calculation
                 continue
 
             slope, intercept, _, _, _ = stats.linregress(t_slice, schroeder_slice)

--- a/core/impulse_response_estimator.py
+++ b/core/impulse_response_estimator.py
@@ -45,11 +45,8 @@ class ImpulseResponseEstimator(object):
         self.w1 = self.low / self.fs * 2 * np.pi
         self.w2 = self.high / self.fs * 2 * np.pi
 
-        # Generate test signal
         self.test_signal = self.generate_test_signal(min_duration)
         self.duration = len(self.test_signal) / self.fs
-
-        # Generate inverse filter
         self.inverse_filter = self.generate_inverse_filter()
 
     def __len__(self):
@@ -74,11 +71,7 @@ class ImpulseResponseEstimator(object):
         plt.show()
 
     def generate_inverse_filter(self):
-        """Generates inverse filter for test signal.
-
-        Returns:
-
-        """
+        """Generates inverse filter for test signal."""
         P = self.n_octaves
         N = len(self.test_signal)
         inverse_filter = np.flip(self.test_signal) * (2**(P / N))**(np.arange(N)*-1) * P * np.log(2) / (1 - 2**-P)
@@ -128,7 +121,6 @@ class ImpulseResponseEstimator(object):
 
         seconds_per_octave = N / self.fs / P
 
-        # Fade-in window
         if fade_in is None:
             fade_in_window = []
         else:
@@ -137,7 +129,6 @@ class ImpulseResponseEstimator(object):
                 fade_in += 1
             fade_in_window = hann(fade_in)[:fade_in // 2]
 
-        # Fade-out window
         if fade_out is None:
             fade_out_window = []
         else:
@@ -146,7 +137,6 @@ class ImpulseResponseEstimator(object):
                 fade_out += 1
             fade_out_window = hann(fade_out)[fade_out // 2:]
 
-        # Create window from fade-in window and fade-out window with ones in the middle
         win = np.concatenate([
             fade_in_window,
             np.ones(len(test_signal) - len(fade_in_window) - len(fade_out_window)),
@@ -198,7 +188,6 @@ class ImpulseResponseEstimator(object):
             if speaker in unique_speakers:
                 raise ValueError('All speaker names in speakers must be unique.')
 
-        # Remap channels
         if tracks in SEQUENCE_TRACK_ORDERS:
             standard_order = SEQUENCE_TRACK_ORDERS[tracks]
             n_tracks = len(standard_order)
@@ -228,7 +217,6 @@ class ImpulseResponseEstimator(object):
                 ))
         speaker_indices = [standard_order.index(ch) for ch in speakers]
 
-        # Create test signal sequence
         data = np.zeros((n_tracks, int((self.fs * 2.0 + len(self)) * len(speakers) + self.fs * 2.0)))
         for i, speaker in enumerate(speakers):
             start_zeros = int((self.fs * 2.0 + len(self)) * i + self.fs * 2.0)
@@ -248,33 +236,27 @@ class ImpulseResponseEstimator(object):
         """Creates ImpulseResponseEstimator instance from test signal WAV."""
         fs, data = read_wav(file_path)
 
-        # Handle multi-channel data by using the first channel only
         if len(data.shape) > 1:
             data_for_comparison = data[0, :]
         else:
             data_for_comparison = data
 
-        # Calculate duration from actual data length
+        # (N-1)/fs keeps the ceil() in generate_test_signal from overshooting
+        # to the next sweep-grid length.
         duration = (len(data_for_comparison) - 1) / fs
 
-        # Create estimator with the correct duration (this calculates proper n_octaves)
         ire = cls(min_duration=duration, fs=fs)
 
         # Handle length mismatch (can occur due to rounding in signal generation)
         if len(ire.test_signal) != len(data_for_comparison):
-            # Length differs - use the loaded data and regenerate inverse filter
-            # with correct n_octaves (already calculated from duration)
             ire.test_signal = data_for_comparison
             ire.duration = len(data_for_comparison) / fs
-            # Regenerate inverse filter using correct n_octaves
             ire.inverse_filter = ire.generate_inverse_filter()
 
         # Handle value mismatch (32-bit vs 64-bit float precision)
         elif np.max(np.abs(ire.test_signal - data_for_comparison)) > 1e-4:
-            # Values differ slightly - use loaded data and regenerate
             print("Warning: Loaded WAV differs slightly from generated signal. Re-calculating inverse filter based on WAV.")
             ire.test_signal = data_for_comparison
-            # n_octaves is already correct, just regenerate inverse filter
             ire.inverse_filter = ire.generate_inverse_filter()
 
         return ire
@@ -317,13 +299,11 @@ def create_cli():
                                  '"mono" will force speakers to "FL".')
     cli_args = arg_parser.parse_args()
     if not os.path.isdir(cli_args.dir_path):
-        # File path is required
         raise TypeError('--dir_path must be a directory.')
     return cli_args
 
 
 def main():
-    # Handle command line arguments
     cli_args = create_cli()
     dir_path = cli_args.dir_path
     fs = cli_args.fs
@@ -332,7 +312,6 @@ def main():
     speakers = cli_args.speakers.split(',')
     tracks = cli_args.tracks
 
-    # Create sweep sequence WAV data
     ire = ImpulseResponseEstimator(min_duration=duration, fs=fs)
     wav_data = ire.sweep_sequence(speakers, tracks)
 

--- a/core/parallel_processing.py
+++ b/core/parallel_processing.py
@@ -24,7 +24,6 @@ from core.parallel_utils import is_gil_disabled, _run_parallel_map
 T = TypeVar('T')
 R = TypeVar('R')
 
-# Python 버전 및 Free-Threaded 지원 확인
 PYTHON_VERSION = sys.version_info
 IS_PYTHON_314_PLUS = PYTHON_VERSION >= (3, 14)
 IS_FREE_THREADED = is_gil_disabled()
@@ -132,7 +131,6 @@ def parallel_map(
     if max_workers is None:
         max_workers = get_optimal_worker_count()
 
-    # 항목 수가 워커 수보다 적으면 조정
     max_workers = min(max_workers, len(items))
 
     # 실제 실행 루프는 core.parallel_utils와 공유한다. ``use_threads`` 기본값을
@@ -183,7 +181,6 @@ def parallel_process_dict(
     keys = list(data_dict.keys())
     values = list(data_dict.values())
 
-    # 키-값 쌍을 함수에 전달하는 래퍼
     def wrapper(item):
         key, value = item
         return key, func(key, value)
@@ -220,19 +217,16 @@ def enable_parallel_processing(func: Callable) -> Callable:
     """
     @wraps(func)
     def wrapper(*args, **kwargs):
-        # parallel 파라미터 확인
         use_parallel = kwargs.pop('use_parallel', False)
         max_workers = kwargs.pop('max_workers', None)
 
         if not use_parallel:
             return func(*args, **kwargs)
 
-        # 첫 번째 인자가 iterable인지 확인
         if args and hasattr(args[0], '__iter__'):
             iterable = args[0]
             remaining_args = args[1:]
 
-            # 병렬 처리 함수 생성
             def parallel_func(item):
                 return func(item, *remaining_args, **kwargs)
 

--- a/core/parallel_utils.py
+++ b/core/parallel_utils.py
@@ -252,7 +252,6 @@ def get_parallelization_info() -> dict:
 
 
 if __name__ == "__main__":
-    # Print parallelization info when run directly
     info = get_parallelization_info()
     print("=== Parallelization Configuration ===")
     for key, value in info.items():

--- a/core/pipeline.py
+++ b/core/pipeline.py
@@ -457,13 +457,12 @@ class BRIRPipeline:
         ]
 
     def run(self) -> None:
-        """Run the full stage sequence (estimator -> room/headphone/
-        EQ -> target -> HRIR open -> crop/align -> virtual bass ->
-        mic-deviation -> equalize -> decay -> balance -> normalize -> plots ->
-        resample -> write). Output byte-exactness is guarded by
-        tests/test_brir_integrity.py. DSP stage helpers live in
-        core.pipeline_stages and are imported lazily inside the stage methods
-        so constructing a pipeline stays cheap until run() is called."""
+        """Run the enabled stages from :meth:`_stage_table` in order.
+
+        Output byte-exactness is guarded by tests/test_brir_integrity.py.
+        DSP stage helpers live in core.pipeline_stages and are imported
+        lazily inside the stage methods so constructing a pipeline stays
+        cheap until run() is called."""
         import os
 
         from core.cancellation import check_cancelled
@@ -633,7 +632,7 @@ class BRIRPipeline:
         check_cancelled()
 
     def _stage_write_responses(self):
-        """Write multi-channel WAV file with sine sweeps for debugging."""
+        """Write all impulse responses to responses.wav (debug artifact)."""
         import os
 
         from core.cancellation import check_cancelled
@@ -730,7 +729,6 @@ class BRIRPipeline:
         check_cancelled()
 
     def _stage_write_readme(self):
-        """Write info and stats in readme."""
         import os
 
         from core.cancellation import check_cancelled
@@ -764,12 +762,10 @@ class BRIRPipeline:
             for side, ir in pair.items():
                 ir.recording = convolve(self.estimator.test_signal, ir.data, mode="full")
 
-        # Plot post processing
         self.hrir.plot(os.path.join(self.dir_path, "plots", "post"))
         check_cancelled()
 
     def _stage_plot_results(self):
-        """Plot results, always."""
         import os
 
         from core.cancellation import check_cancelled
@@ -861,12 +857,10 @@ class BRIRPipeline:
         from core.cancellation import check_cancelled
         from core.constants import HESUVI_TRACK_ORDER
 
-        # Write multi-channel WAV file with standard track order
         self.logger.step("cli_writing_brirs")
         check_cancelled()
         self.hrir.write_wav(os.path.join(self.dir_path, "hrir.wav"))
 
-        # Write multi-channel WAV file with HeSuVi track order
         check_cancelled()
         self.hrir.write_wav(os.path.join(self.dir_path, "hesuvi.wav"), track_order=HESUVI_TRACK_ORDER)
 
@@ -878,10 +872,6 @@ class BRIRPipeline:
 
         self.logger.step("cli_generating_truehd")
 
-        # 레이아웃별로 보유 채널을 세고, 최소 채널 수를 만족하면 좌/우 트랙
-        # 순서를 만들어 기록한다. (구 core/channel_generation.py 인라인 —
-        # validate가 만든 리스트를 버리고 같은 것을 다시 계산하던 3-함수
-        # 시퀀스였다.)
         for layout_name, layout_order, min_channels, ok_key, fail_key in (
             ("11ch", TRUEHD_11CH_ORDER, 8, "cli_success_truehd_11ch", "cli_warning_truehd_11ch_fail"),  # 7.0.4
             ("13ch", TRUEHD_13CH_ORDER, 10, "cli_success_truehd_13ch", "cli_warning_truehd_13ch_fail"),  # 7.0.6
@@ -923,7 +913,6 @@ class BRIRPipeline:
                 avg_target=cfg.target_level,
             )
 
-        # FL-L, FL-R, FR-L, FR-R 순서로 파일 생성
         jd_order = ["FL-left", "FL-right", "FR-left", "FR-right"]
         out_path = os.path.join(self.dir_path, "jamesdsp.wav")
         dsp_hrir.write_wav(out_path, track_order=jd_order)
@@ -953,10 +942,9 @@ class BRIRPipeline:
         check_cancelled()
 
     def _cleanup(self):
-        """중간 산출물 참조 해제 + figure 정리 + GC.
+        """중간 산출물 참조 해제 + figure 정리 + GC (성공 경로에서만).
 
-        기존 run() 꼬리의 del 블록과 동일하게 성공 경로에서만 수행한다. 스테이지
-        메서드의 지역 변수(eq_tasks 등)는 메서드 반환 시점에 이미 해제되므로,
+        스테이지 메서드의 지역 변수는 메서드 반환 시점에 이미 해제되므로,
         여기서는 루트 객체 참조만 끊으면 된다.
         """
         import gc

--- a/core/pipeline_stages.py
+++ b/core/pipeline_stages.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 """BRIR pipeline stage helpers.
 
-Moved out of the top-level ``impulcifer`` script (audit #138 C1) so
-:class:`core.pipeline.BRIRPipeline` no longer has to import back into the
-script module. ``impulcifer`` re-exports every helper for legacy callers.
+``impulcifer`` re-exports every helper for legacy callers.
 """
 
 import os
@@ -39,8 +37,7 @@ from core.utils import (
 )
 from infra.logger import get_logger
 
-# Repo root for the source-tree ``data/`` fallback (this module lives in
-# ``core/``; the fallback previously resolved relative to impulcifer.py).
+# Repo root for the source-tree ``data/`` fallback.
 _PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
@@ -370,7 +367,6 @@ def headphone_compensation(estimator, dir_path, headphone_file_path=None):
     logger = get_logger()
 
     if headphone_file_path:
-        # Normalize the path to handle Windows/Unix path separators
         normalized_path = os.path.normpath(headphone_file_path)
         logger.info("cli_info_hp_param_provided", file=normalized_path)
 
@@ -585,7 +581,6 @@ def write_readme(file_path, hrir, fs, estimator, applied_gain):
 
             peak_idx_current_ir = ir_obj.peak_index()
             if peak_idx_current_ir is not None:
-                # PNR 계산
                 peak_val_linear = np.abs(ir_obj.data[peak_idx_current_ir])
                 peak_val_db = 20 * np.log10(
                     peak_val_linear + 1e-9

--- a/core/plotting/hrir_plotter.py
+++ b/core/plotting/hrir_plotter.py
@@ -363,14 +363,12 @@ class HRIRPlotter:
             ["Left raw", "Right raw", "Left smoothed", "Right smoothed", "Difference"]
         )
 
-        # Save figures
         file_path = os.path.join(dir_path, "results.png")
 
         os.makedirs(dir_path, exist_ok=True)
 
         fig.savefig(file_path, bbox_inches="tight")
         plt.close(fig)
-        # Optimize file size
         im = Image.open(file_path)
         im = im.convert("P", palette=ADAPTIVE_PALETTE, colors=60)
         im.save(file_path, optimize=True)

--- a/core/plotting/impulse_response_plotter.py
+++ b/core/plotting/impulse_response_plotter.py
@@ -58,7 +58,6 @@ class ImpulseResponsePlotter:
             Figure
         """
         if fig is None:
-            # Create figure and axises for the plots
             fig = plt.figure()
             fig.set_size_inches(22, 10)
             ax = []

--- a/core/plotting_utils.py
+++ b/core/plotting_utils.py
@@ -121,7 +121,6 @@ def optimize_png_size(file_path, n_colors=60):
 
 def save_fig_as_png(file_path, fig, n_colors=60):
     """Saves figure and optimizes file size."""
-    # Ensure the directory exists before saving
     os.makedirs(os.path.dirname(file_path), exist_ok=True)
     
     fig.savefig(file_path, bbox_inches='tight')

--- a/core/recorder.py
+++ b/core/recorder.py
@@ -121,7 +121,6 @@ def record_target(file_path, length, fs, channels=2, append=False, debug_plots=F
     recording = sd.rec(length, samplerate=fs, channels=channels, blocking=True)
     _debug_recording(debug_plots, f"  Raw recording shape: {recording.shape}")
     
-    # Analyze recording content
     if debug_plots:
         print("  Recording content analysis:")
         for ch in range(recording.shape[1] if len(recording.shape) > 1 else 1):
@@ -139,7 +138,6 @@ def record_target(file_path, length, fs, channels=2, append=False, debug_plots=F
         recording = np.transpose(recording)
         _debug_recording(debug_plots, f"  After transpose: {recording.shape}")
     elif len(recording.shape) == 1:
-        # Mono recording, expand dimensions
         recording = np.expand_dims(recording, axis=0)
         _debug_recording(debug_plots, f"  Mono expanded to: {recording.shape}")
     
@@ -147,7 +145,6 @@ def record_target(file_path, length, fs, channels=2, append=False, debug_plots=F
     _debug_recording(debug_plots, f"  Maximum gain: {max_gain:.2f} dB (headroom: {-1.0*max_gain:.1f} dB)")
     
     if append and os.path.isfile(file_path):
-        # Adding to existing file, read the file
         _debug_recording(debug_plots, "  Appending to existing file...")
         _fs, data = read_wav(file_path, expand=True)
         _debug_recording(debug_plots, f"  Existing file shape: {data.shape}")
@@ -162,7 +159,6 @@ def record_target(file_path, length, fs, channels=2, append=False, debug_plots=F
             recording = np.pad(recording, [(0, 0), (0, padding)])
             _debug_recording(debug_plots, f"  Padded new recording by {padding} samples")
         
-        # Add recording to the end of the existing data
         recording = np.vstack([data, recording])
         _debug_recording(debug_plots, f"  Final appended shape: {recording.shape}")
     
@@ -192,7 +188,6 @@ def get_device(device_name, kind, host_api=None, min_channels=1):
         raise TypeError('Device name is required and cannot be None')
     if kind is None:
         raise TypeError('Kind is required and cannot be None')
-    # Available host APIs
     host_api_names = get_host_api_names()
 
     for i in range(len(host_api_names)):
@@ -201,16 +196,13 @@ def get_device(device_name, kind, host_api=None, min_channels=1):
     if host_api is not None:
         host_api = host_api.replace('Windows ', '')
 
-    # Host API check pattern
     host_api_pattern = f'({"|".join([re.escape(name) for name in host_api_names])})$'
 
-    # Find with the given name
     device = None
     if re.search(host_api_pattern, device_name):
         # Host API in the name, this should return only one device
         device = sd.query_devices(device_name, kind=kind)
         if device[f'max_{kind}_channels'] < min_channels:
-            # Channel count not satisfied
             raise DeviceNotFoundError(f'Found {kind} device "{device["name"]} {host_api_names[device["hostapi"]]}"" '
                                       f'but minimum number of channels is not satisfied. 1')
     elif not re.search(host_api_pattern, device_name) and host_api is not None:
@@ -219,17 +211,14 @@ def get_device(device_name, kind, host_api=None, min_channels=1):
             # This should give one or zero devices
             device = sd.query_devices(f'{device_name} {host_api}', kind=kind)
         except ValueError:
-            # Zero devices
             raise DeviceNotFoundError(f'No device found with name "{device_name}" and host API "{host_api}". ')
         if device[f'max_{kind}_channels'] < min_channels:
-            # Channel count not satisfied
             raise DeviceNotFoundError(f'Found {kind} device "{device["name"]} {host_api_names[device["hostapi"]]}" '
                                       f'but minimum number of channels is not satisfied.')
     else:
         # Host API not in the name and host API is not given as parameter
         host_api_preference = [x for x in ['DirectSound', 'MME', 'WASAPI'] if x in host_api_names]
         for host_api_name in host_api_preference:
-            # Looping in the order of preference
             try:
                 device = sd.query_devices(f'{device_name} {host_api_name}', kind=kind)
                 if device[f'max_{kind}_channels'] >= min_channels:
@@ -257,18 +246,13 @@ def get_devices(input_device=None, output_device=None, host_api=None, min_channe
         - Input device object
         - Output device object
     """
-    # Find devices
     devices = sd.query_devices()
 
-    # Select input device
     if input_device is None:
-        # Not given, use default
         input_device = devices[sd.default.device[0]]['name']
     input_device = get_device(input_device, 'input', host_api=host_api)
 
-    # Select output device
     if output_device is None:
-        # Not given, use default
         output_device = devices[sd.default.device[1]]['name']
     output_device = get_device(output_device, 'output', host_api=host_api, min_channels=min_channels)
 
@@ -333,7 +317,6 @@ def play_and_record(
     if play_signal is None and play is None:
         raise TypeError('Either "play" or "play_signal" is required.')
 
-    # Create output directory
     out_dir, out_file = os.path.split(os.path.abspath(record))
     os.makedirs(out_dir, exist_ok=True)
 
@@ -383,10 +366,8 @@ def play_and_record(
             "multi-channel sweep WAV generated by Impulcifer instead."
         )
 
-    # Opt-in mono→stereo broadcast — only the dedicated headphone path
-    # asks for this. For speaker-side capture the mono signal must be
-    # left on output channel 0 alone (see the ``mono_to_stereo`` docstring
-    # above for the rationale).
+    # Opt-in broadcast — speaker-side capture must keep this off (see the
+    # ``mono_to_stereo`` docstring).
     if mono_to_stereo and data.shape[0] == 1:
         data = np.broadcast_to(data, (2, data.shape[1])).copy()
 
@@ -399,7 +380,6 @@ def play_and_record(
     print(f"Audio info: {fs}Hz, {n_channels} channels, {data.shape[1]} samples")
     print(f"Duration: {duration:.2f} seconds")
 
-    # Find and set devices as default
     try:
         input_device, output_device = get_devices(
             input_device=input_device,
@@ -428,14 +408,12 @@ def play_and_record(
         ),
     )
 
-    # If recording with TrueHD source, save channel info
     if channel_info and record:
         info_file = os.path.splitext(record)[0] + '_channels.txt'
         with open(info_file, 'w') as f:
             f.write(','.join(channel_info))
         print(f"Channel info saved to: {info_file}")
 
-    # Check if output device supports required channels
     if output_device["max_output_channels"] < n_channels:
         print(f"WARNING: Output device only supports {output_device['max_output_channels']} channels")
         print(f"but file has {n_channels} channels. Audio will be truncated.")

--- a/core/room_correction.py
+++ b/core/room_correction.py
@@ -38,7 +38,6 @@ def room_correction(
         - Room Impulse Responses as HRIR or None
         - Equalization frequency responses as dict of dicts (similar to HRIR) or None
     """
-    # Open files
     target = open_room_target(estimator, dir_path, target=target)
     mic_calibration = open_mic_calibration(estimator, dir_path, mic_calibration=mic_calibration)
     rir = open_room_measurements(estimator, dir_path, debug=plot)
@@ -61,7 +60,6 @@ def room_correction(
     fr_axes = []
     figs = None
     if len(rir.irs):
-        # Crop heads and tails from room impulse responses
         for speaker, pair in rir.irs.items():
             for side, ir in pair.items():
                 ir.crop_head()
@@ -69,7 +67,6 @@ def room_correction(
         rir.write_wav(os.path.join(dir_path, 'room-responses.wav'))
 
         if plot:
-            # Plot all but frequency response
             plot_dir = os.path.join(dir_path, 'plots', 'room')
             os.makedirs(plot_dir, exist_ok=True)
             figs = rir.plot(plot_fr=False, close_plots=False)
@@ -82,7 +79,6 @@ def room_correction(
                 fr = ir.frequency_response()
 
                 if mic_calibration is not None:
-                    # Calibrate frequency response
                     fr.raw -= mic_calibration.raw
 
                 # Sync gains
@@ -94,7 +90,6 @@ def room_correction(
                 # Adjust target level with the (negative) gain caused by speaker-ear distance in reverberant room
                 target_adjusted = target.copy()
                 target_adjusted.raw += IR_ROOM_SPL[speaker][side]
-                # Compensate with the adjusted room target
                 fr.compensate(target_adjusted, min_mean_error=False)
 
                 # Zero error above limit
@@ -133,9 +128,7 @@ def room_correction(
     if plot and figs is not None:
         room_plots_dir = os.path.join(dir_path, 'plots', 'room')
         os.makedirs(room_plots_dir, exist_ok=True)
-        # Sync FR plot axes
         sync_axes(fr_axes)
-        # Save specific fR figures
         for speaker, pair in figs.items():
             for side, fig in pair.items():
                 save_fig_as_png(os.path.join(room_plots_dir, f'{speaker}-{side}.png'), fig)
@@ -154,17 +147,14 @@ def open_room_measurements(estimator, dir_path, debug=False):
     Returns:
         HRIR instance with the room measurements
     """
-    # Read room measurement files
     rir = HRIR(estimator)
     # room-BL,SL.wav, room-left-FL,FR.wav, room-right-FC.wav, etc...
     pattern = rf'^room-{SPEAKER_LIST_PATTERN}(-(left|right))?\.wav$'
     for i, file_name in enumerate([f for f in os.listdir(dir_path) if re.match(pattern, f)]):
-        # Read the speaker names from the file name into a list
         speakers = re.search(SPEAKER_LIST_PATTERN, file_name)
         if speakers is not None:
             speakers = speakers[0].split(',')
         file_path = os.path.join(dir_path, file_name)
-        # Read side if present
         side = re.search(r'(left|right)', file_name)
         if side is not None:
             side = side[0]
@@ -213,16 +203,13 @@ def open_generic_room_measurement(estimator,
             # Ends at start plus one more (current) sweep
             end = int(start + 2 * estimator.fs + len(estimator))
             end = min(end, len(track))
-            # Select current sweep
             sweep = track[start:end]
-            # Deconvolve as impulse response
             ir = ImpulseResponse(estimator.estimate(sweep), estimator.fs, sweep)
             # Crop harmonic distortion from the head
             # Noise in the tail should not affect frequency response so it doesn't have to be cropped
             ir.crop_head(head_ms=1)
             irs.append(ir)
 
-    # Frequency response for the generic room measurement
     room_fr = FrequencyResponse(
         name='generic_room',
         frequency=FrequencyResponse.generate_frequencies(f_min=10, f_max=estimator.fs / 2, f_step=1.01),
@@ -250,7 +237,6 @@ def open_generic_room_measurement(estimator,
     errors = np.vstack(errors)
 
     if errors.shape[0] > 1:
-        # Combine errors
         if method == 'conservative':
             # Conservative error curve is zero everywhere else but on indexes where both have the same sign,
             # at these indexes the smaller absolute value is selected.
@@ -291,19 +277,16 @@ def open_generic_room_measurement(estimator,
         room_plots_dir = os.path.join(dir_path, 'plots', 'room')
         os.makedirs(room_plots_dir, exist_ok=True)
 
-        # Create generic FR plot
         fr = room_fr.copy()
         fr.name = 'Generic room measurement'
         fr.raw = fr.smoothed.copy()
         fr.error = fr.error_smoothed.copy()
 
-        # Create figure and axes
         fig, ax = plt.subplots()
         fig.set_size_inches(15, 9)
         config_fr_axis(ax)
         ax.set_title('Generic room measurement')
 
-        # Plot target, raw and error
         ax.plot(fr.frequency, fr.target, color=COLORS['lightpurple'], linewidth=5, label='Target')
         for raw in raws:
             raw.smoothen(window_size=1/3, treble_window_size=1/3)
@@ -337,11 +320,9 @@ def open_room_target(estimator, dir_path, target=None):
     Returns:
         Room response target FrequencyResponse
     """
-    # Room target
     if target is None:
         target = os.path.join(dir_path, 'room-target.csv')
     if os.path.isfile(target):
-        # File exists, create frequency response
         target = FrequencyResponse.read_csv(target)
         target.interpolate(f_step=1.01, f_min=10, f_max=estimator.fs / 2)
         target.center()
@@ -370,14 +351,11 @@ def open_mic_calibration(estimator, dir_path, mic_calibration=None):
         if not os.path.isfile(mic_calibration):
             mic_calibration = os.path.join(dir_path, 'room-mic-calibration.txt')
     elif not os.path.isfile(mic_calibration):
-        # Room mic calibration file path given, but the file doesn't exist
         raise FileNotFoundError(f'Room mic calibration file doesn\'t exist at "{mic_calibration}"')
     if os.path.isfile(mic_calibration):
-        # File found, create frequency response
         mic_calibration = FrequencyResponse.read_csv(mic_calibration)
         mic_calibration.interpolate(f_step=1.01, f_min=10, f_max=estimator.fs / 2)
         mic_calibration.center()
     else:
-        # File not found, skip calibration
         mic_calibration = None
     return mic_calibration

--- a/gui/brir_args.py
+++ b/gui/brir_args.py
@@ -130,7 +130,6 @@ def build_brir_args(tab: Any, loc: Any) -> dict:
                 try:
                     decay_val = float(decay_str) / 1000
                     # 단일값 decay는 CLI와 동일하게 전체 SPEAKER_NAMES로 fan-out
-                    # (기존 7채널 하드코딩은 드리프트 — 감사 #138 F018/Q2 판정)
                     args["decay"] = {ch: decay_val for ch in SPEAKER_NAMES}
                 except ValueError:
                     pass

--- a/gui/skins/studio_recorder_tab.py
+++ b/gui/skins/studio_recorder_tab.py
@@ -81,9 +81,9 @@ class StudioRecorderTab:
         self.play_var = ctk.StringVar(
             value=os.path.join("data", "sweep-seg-FL,FR-stereo-6.15s-48000Hz-32bit-2.93Hz-24000Hz.wav")
         )
-        # Sweep source — on-the-fly generation is the default since 2.11;
-        # the play file only applies in file mode (labels/codes shared
-        # with the Stable skin via gui.sweep_source).
+        # Sweep source — on-the-fly generation is the default; the play file
+        # only applies in file mode (labels/codes shared with the Stable
+        # skin via gui.sweep_source).
         self._sweep_mode_labels = recorder_sweep_mode_labels(self.loc)
         self.sweep_source_var = ctk.StringVar(value=self._sweep_mode_labels["default"])
         self.sweep_speakers_var = ctk.StringVar(value="FL,FR")
@@ -211,7 +211,6 @@ class StudioRecorderTab:
         body = make_card_body(card)
         body.grid_columnconfigure(0, weight=1)
 
-        # Host API
         api_row = self._labelled_row(body, row=0, label=self.loc.get("label_host_api"))
         self.host_api_menu = ctk.CTkOptionMenu(
             api_row,
@@ -221,14 +220,12 @@ class StudioRecorderTab:
         )
         self.host_api_menu.grid(row=0, column=1, sticky="ew", padx=0, pady=4)
 
-        # Output
         out_row = self._labelled_row(body, row=1, label=self.loc.get("label_playback_device"))
         self.output_device_menu = ctk.CTkOptionMenu(
             out_row, variable=self.output_device_var, values=["—"]
         )
         self.output_device_menu.grid(row=0, column=1, sticky="ew", padx=0, pady=4)
 
-        # Input
         in_row = self._labelled_row(body, row=2, label=self.loc.get("label_recording_device"))
         self.input_device_menu = ctk.CTkOptionMenu(
             in_row, variable=self.input_device_var, values=["—"]
@@ -309,7 +306,6 @@ class StudioRecorderTab:
                 if self.channels_custom_row:
                     self.channels_custom_row.grid_remove()
                 return
-        # Custom path
         if self.channels_custom_row:
             self.channels_custom_row.grid()
         if self.channels_custom_entry:
@@ -626,8 +622,7 @@ class StudioRecorderTab:
         # Stable's force-channels checkbox is expressed here by the channel
         # preset itself: picking anything other than stereo IS the explicit
         # multi-channel request. The resolution contract is shared with the
-        # stable tab (audit #138 F021/Q5 — the old max(2, entry) reading was
-        # drift, not intent).
+        # stable tab.
         requested_channels = safe_get_int(self.channels_var, 2)
         channels, force_channels = resolve_recording_channels(
             requested_channels != 2, requested_channels
@@ -852,12 +847,9 @@ class StudioRecorderTab:
                     from core.sweep_signal import build_sweep_playback
 
                     play_signal = build_sweep_playback(sweep_spec)
-                # ``mono_to_stereo=True`` only matters when the play file
-                # is mono: it duplicates the sweep onto both headphone
-                # drivers so the user gets an L=R generic EQ. The user
-                # has already been warned about this trade-off above.
-                # Generated sweeps are stereo sequences, so the broadcast
-                # is a file-mode-only concern.
+                # File mode only: a mono play file is broadcast onto both
+                # headphone drivers (L=R generic EQ — the user was warned
+                # above). Generated sweeps are already stereo sequences.
                 recorder.play_and_record(
                     play=play_file if play_signal is None else None,
                     play_signal=play_signal,

--- a/gui/tabs/impulcifer_tab.py
+++ b/gui/tabs/impulcifer_tab.py
@@ -105,8 +105,8 @@ class ImpulciferTab:
             width=WIDGET_BUTTON_WIDTH_BROWSE,
         ).grid(row=1, column=2, padx=15, pady=5)
 
-        # Test signal source — auto detection is the default since 2.11.
-        # The manual and file rows only appear for their modes.
+        # Test signal source — auto detection is the default. The manual
+        # and file rows only appear for their modes.
         self._test_signal_labels = test_signal_source_labels(self.loc)
         ctk.CTkLabel(input_frame, text=self.loc.get('label_test_signal_source')).grid(row=2, column=0, sticky="w", padx=15, pady=5)
         self.test_signal_source_var = ctk.StringVar(value=self._test_signal_labels['auto'])
@@ -703,6 +703,5 @@ class ImpulciferTab:
                 except Exception:
                     pass
 
-        # Start processing thread
         thread = threading.Thread(target=run_processing, daemon=True)
         thread.start()

--- a/gui/tabs/recorder_tab.py
+++ b/gui/tabs/recorder_tab.py
@@ -136,8 +136,8 @@ class RecorderTab:
             font=self.fonts['heading']
         ).grid(row=0, column=0, columnspan=3, sticky="w", padx=15, pady=(15, 10))
 
-        # Sweep source — on-the-fly generation is the default since 2.11;
-        # a play file is only needed for unusual/custom recordings.
+        # Sweep source — on-the-fly generation is the default; a play file
+        # is only needed for unusual/custom recordings.
         self._sweep_mode_labels = recorder_sweep_mode_labels(self.loc)
         ctk.CTkLabel(files_frame, text=self.loc.get('label_sweep_source')).grid(row=1, column=0, sticky="w", padx=15, pady=5)
         self.sweep_source_var = ctk.StringVar(value=self._sweep_mode_labels['default'])
@@ -820,14 +820,11 @@ class RecorderTab:
                     from core.sweep_signal import build_sweep_playback
 
                     play_signal = build_sweep_playback(sweep_spec)
-                # Always 2-channel recording for headphone compensation —
-                # the two in-ear mics. Speaker-side ``force channels`` is
-                # not relevant here so we hard-pin it. ``mono_to_stereo``
-                # only matters when the play file is mono: it duplicates
-                # the sweep onto both headphone drivers so the user gets
-                # an L=R generic EQ (warned about above). Generated sweeps
-                # are already stereo sequences, so the broadcast is a
-                # file-mode-only concern.
+                # Always 2-channel recording (the two in-ear mics) —
+                # speaker-side ``force channels`` is irrelevant here. File
+                # mode only: a mono play file is broadcast onto both
+                # headphone drivers (L=R generic EQ, warned above);
+                # generated sweeps are already stereo sequences.
                 recorder.play_and_record(
                     play=play_file if play_signal is None else None,
                     play_signal=play_signal,

--- a/gui/utils.py
+++ b/gui/utils.py
@@ -28,11 +28,8 @@ from gui.theme import get_ico_path, get_png_path
 def setup_app_icon(root: ctk.CTk) -> bool:
     """Apply the bundled pulse logo to the GUI window and Windows taskbar.
 
-    Why this exists. The redesign hands off ``logo/pulse.ico``
-    (multi-resolution 16/24/32/48/64/
-    128/256) and ``logo/pulse-*.png``; this helper wires both paths so the
-    Windows title bar, the Windows taskbar (including pinned shortcuts),
-    and the X11 / macOS dock icons all render the Pulse mark.
+    Wires both ``logo/pulse.ico`` (multi-resolution) and ``logo/pulse-*.png``
+    so the title bar, Windows taskbar and X11/macOS dock all render the mark.
 
     On Windows we also call ``SetCurrentProcessExplicitAppUserModelID`` so
     the taskbar groups by our AppUserModelID instead of ``python.exe``
@@ -92,7 +89,6 @@ def open_data_folder() -> None:
     data_dir = Path(DATA_DIR)
 
     if not data_dir.exists():
-        # Fallback: executable 디렉토리 기준
         from infra.environment import is_standalone_build
 
         if is_standalone_build():
@@ -101,7 +97,7 @@ def open_data_folder() -> None:
             data_dir = Path(__file__).parent.parent / "data"
 
     if not data_dir.exists():
-        data_dir = Path.home() / "Documents"  # 최종 폴백
+        data_dir = Path.home() / "Documents"
 
     system = platform.system()
 
@@ -117,15 +113,7 @@ def open_data_folder() -> None:
 
 
 def safe_get_double(var: Any, default: float = 0.0) -> float:
-    """Safely read a DoubleVar.
-
-    Args:
-        var: Tk variable with a ``get`` method.
-        default: Value returned when the variable is empty or invalid.
-
-    Returns:
-        The variable value or ``default``.
-    """
+    """Read a DoubleVar, returning ``default`` when empty or invalid."""
     try:
         return var.get()
     except (TclError, ValueError):
@@ -133,15 +121,7 @@ def safe_get_double(var: Any, default: float = 0.0) -> float:
 
 
 def safe_get_int(var: Any, default: int = 0) -> int:
-    """Safely read an IntVar.
-
-    Args:
-        var: Tk variable with a ``get`` method.
-        default: Value returned when the variable is empty or invalid.
-
-    Returns:
-        The variable value or ``default``.
-    """
+    """Read an IntVar, returning ``default`` when empty or invalid."""
     try:
         return var.get()
     except (TclError, ValueError):
@@ -149,15 +129,7 @@ def safe_get_int(var: Any, default: int = 0) -> int:
 
 
 def safe_get_string(var: Any, default: str = "") -> str:
-    """Safely read a StringVar.
-
-    Args:
-        var: Tk variable with a ``get`` method.
-        default: Value returned when the variable is empty or invalid.
-
-    Returns:
-        The variable value or ``default``.
-    """
+    """Read a StringVar, returning ``default`` when empty or invalid."""
     try:
         return var.get()
     except (TclError, ValueError):
@@ -317,11 +289,6 @@ def _tk_renders_family(desired: str) -> Optional[str]:
     can render with the requested family, ``actual`` returns that family
     verbatim; otherwise it returns whatever Tk fell back to (e.g. the
     system default like Malgun Gothic), which we treat as a miss.
-
-    This was the bug behind issue #87 follow-up: ``setup_pretendard_font``
-    bailed to ``None`` because ``families()`` lacked Pretendard even though
-    GDI / Tk render layer would have used it. CTk widgets then defaulted
-    to the system font (Malgun Gothic / 명조 fallback on Korean Windows).
     """
     try:
         probe = tkfont.Font(family=desired, size=10)
@@ -459,7 +426,6 @@ def setup_pretendard_font(current_language: str = 'en') -> Optional[str]:
         _font_cache[current_language] = value
         return value
 
-    # Only use Pretendard for the languages we bundle a cut for (ko/en/ja).
     if current_language not in _PRETENDARD_LANGUAGES:
         # Even when we don't pick Pretendard for the language, still register
         # any bundled font so other code paths (e.g. matplotlib, dialogs that
@@ -473,22 +439,14 @@ def setup_pretendard_font(current_language: str = 'en') -> Optional[str]:
     )
 
     try:
-        # Register every bundled font once — Pretendard is the primary, but
-        # any companion font the user drops into ``font/`` becomes addressable
-        # too.
         register_all_bundled_fonts_for_tk()
 
-        # PRIMARY check: ask Tk's render layer directly.
-        # tkfont.families() caches at startup and AddFontResourceExW does NOT
-        # always invalidate that cache, but Tk renders via GDI which DOES see
-        # process-private fonts immediately. So we trust actual() resolution
-        # over the families() snapshot.
-        #
-        # We try the "* Variable" family FIRST: the bundled file's family-name
-        # (name table id 1) is "Pretendard Variable" / "Pretendard JP Variable",
-        # not the plain "Pretendard". Hitting this directly avoids one
-        # render-probe miss + lets Win32 GDI auto-map weight="bold" to the fvar
-        # wght=700 instance instead of falling through to synthetic bold.
+        # Ask Tk's render layer directly (see _tk_renders_family for why
+        # families() cannot be trusted). The "* Variable" family goes FIRST:
+        # the bundled file's name-table family is "Pretendard Variable" /
+        # "Pretendard JP Variable", and hitting it directly lets Win32 GDI
+        # map weight="bold" to the fvar wght=700 instance instead of
+        # synthetic bold.
         for candidate in family_candidates:
             rendered = _tk_renders_family(candidate)
             if rendered:
@@ -515,9 +473,8 @@ def setup_pretendard_font(current_language: str = 'en') -> Optional[str]:
             for font_name in (available_fonts or set()):
                 if "Pretendard" not in font_name:
                     continue
-                # For Japanese only accept a JP cut — the standard Pretendard
-                # has no kanji, so the OS font is a better fallback than a
-                # Pretendard that would tofu every ideograph.
+                # For Japanese only accept a JP cut (standard Pretendard has
+                # no kanji — see _PRETENDARD_FAMILIES_BY_LANG).
                 if prefer_jp != ("JP" in font_name):
                     continue
                 rendered = _tk_renders_family(font_name)
@@ -634,7 +591,6 @@ def browse_file(var: Any, mode: str, filetypes: Optional[list[tuple[str, str]]] 
         )
 
     if filename:
-        # Convert to relative path if possible
         try:
             filename = os.path.relpath(filename, os.getcwd())
         except Exception:
@@ -649,7 +605,6 @@ def browse_directory(var: Any) -> None:
     )
 
     if dirname:
-        # Convert to relative path if possible
         try:
             dirname = os.path.relpath(dirname, os.getcwd())
         except Exception:
@@ -1030,7 +985,6 @@ def install_smooth_scrolling(scroll_frame: ctk.CTkScrollableFrame) -> None:
     # CTkScrollableFrame installs is the unconditional one.
     scroll_frame.unbind("<Configure>")
 
-    # Use a list so the closure can mutate without `nonlocal`.
     last_size: list[Optional[int]] = [None, None]
 
     def _on_configure(event):

--- a/i18n/localization.py
+++ b/i18n/localization.py
@@ -150,7 +150,6 @@ class LocalizationManager:
 
         self.settings = self.load_settings()
 
-        # Set language (from settings or detect system)
         if 'language' in self.settings:
             self.set_language(self.settings['language'])
         else:
@@ -198,14 +197,12 @@ class LocalizationManager:
         self.settings['language'] = language_code
         self.save_settings()
 
-        # Load translation file
         self.load_translations(language_code)
 
     def load_translations(self, language_code: str):
         """Load translation file for specified language"""
         locale_file = self.locales_dir / f'{language_code}.json'
 
-        # Debug: print locales directory and file path
         if not locale_file.exists():
             print(f"Translation file not found: {locale_file}")
             print(f"Locales directory: {self.locales_dir}")

--- a/impulcifer.py
+++ b/impulcifer.py
@@ -12,7 +12,7 @@ import matplotlib.font_manager as fm
 from core.utils import set_matplotlib_font
 from core.constants import SPEAKER_NAMES
 
-# Cancellation now lives in core.cancellation; these re-exports keep the
+# Cancellation lives in core.cancellation; these re-exports keep the
 # historical import surface (GUI tabs, application service, tests) working.
 from core.cancellation import (  # noqa: F401
     CancelledError,
@@ -24,8 +24,8 @@ from core.cancellation import (  # noqa: F401
 # from the top-level module.
 from core.impulse_response_estimator import ImpulseResponseEstimator  # noqa: F401
 
-# Stage helpers now live in core.pipeline_stages (audit #138 C1); re-exported
-# for legacy callers (tests import equalization from here, etc.).
+# Stage helpers live in core.pipeline_stages; re-exported for legacy
+# callers (tests import equalization from here, etc.).
 from core.pipeline_stages import (  # noqa: F401
     _find_eq_settings_file,
     _read_eq_settings,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "impulcifer-py313"
-version = "2.11.0"
+version = "2.11.1"
 authors = [
   { name="원본 저자: Jaakko Pasanen", email="" },
   { name="Python 3.13/3.14 호환 버전: 115dkk", email="" },

--- a/updater/update_checker.py
+++ b/updater/update_checker.py
@@ -102,7 +102,6 @@ class UpdateChecker:
         Returns:
             Normalized semantic version (X.Y.Z format)
         """
-        # Remove leading 'v' if present
         ver_string = ver_string.lstrip('v')
 
         # Extract base semantic version (X.Y.Z or X.Y.Z.W)
@@ -150,24 +149,19 @@ class UpdateChecker:
         """
         assets = release_data.get('assets', [])
 
-        # Detect platform
         system = platform.system()
 
-        # Look for installer file
         for asset in assets:
             name = asset.get('name', '').lower()
             download_url = asset.get('browser_download_url')
 
             if system == 'Windows':
-                # Look for .exe installer
                 if name.endswith('.exe') and 'setup' in name:
                     return download_url
-            elif system == 'Darwin':  # macOS
-                # Look for .dmg or .pkg
+            elif system == 'Darwin':
                 if name.endswith(('.dmg', '.pkg')):
                     return download_url
             elif system == 'Linux':
-                # Look for .deb, .rpm, or .AppImage
                 if name.endswith(('.deb', '.rpm', '.appimage')):
                     return download_url
 


### PR DESCRIPTION
## 요약

출하 코드 전반의 주석(각주) 청소. **동작 변경 없음** — 27개 코드 파일에서 약 −310줄/+68줄.

### 삭제 기준
1. **AI 특유의 중얼거림 / 작업 중계**: "audit #NNN에서 이동", "기존 X였는데 Y로 변경" 류의 유래·이력 서술 (git이 이미 기록하는 정보)
2. **코드 재기술**: `# Detect platform` → `platform.system()` 같은, 코드가 이미 말하는 것을 반복하는 주석
3. **중복 설명**: 같은 내용이 docstring과 인라인에 이중으로 있던 것 (한쪽만 유지)

### 유지 기준 — "코드 수정 전 알아야만 하는 것"
- DSP 수식 근거 (Farina ESS 파라미터, Hammershøi & Møller 소거 논리, RBJ cookbook 파리티 등)
- 플랫폼 특이사항 (Win32 스크롤 blit 잔상, GDI 폰트 렌더 경로, Nuitka pywebview 화이트리스트 등)
- 계약/불변식 (bootstrap import-light, `sd.play(blocking=True)`, PCM_32 왕복 양자화, `_ok()` dataclass flatten 함정 등)
- 부호 규약·단위·매직넘버 근거

### 코드 변경 (주석 외)
- `core/hrir.py` `correct_channel_balance()`: 생성만 되고 사용되지 않던 죽은 `stacks` 블록 6줄 제거 (오해 소지 주석과 함께)
- `core/impulse_response_estimator.py` `from_wav()`: 재기술 주석을 실제 이유((N−1)/fs 그리드 오버슛 방지)로 교체
- `core/pipeline.py` `_stage_write_responses` docstring: "sine sweeps"라고 잘못 적혀 있던 것을 실제 동작(임펄스 응답 기록)으로 정정

### 제외 범위
- `autoeq/` (벤더링 — 업스트림 diff 최소화)
- `gui/legacy_gui.py` (deprecated 동결)
- `research/` (비출하 분석 스크립트)

## 검증

- Tier 1: py_compile 전체 OK, `ruff check .` All checks passed, fast suite 19 passed
- Tier 2: `pytest tests/` **488 passed**, 17 skipped
- Tier 3 (같은 머신 자기비교): default `3F9297…`, vbass `3AD84C…` — 2.11.0 master 오라클과 **바이트 동일**
- 버전 2.11.0 → 2.11.1 (내부 리팩토링 PATCH), CHANGELOG 갱신. README 해당 사항 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)