### PR TITLE
fix: detect prefixed Hangloose recovery files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ first number changes, something has broken and you need to check your commands a
 changes there are only new features available and nothing old has broken and when the last number changes, old bugs have
 been fixed and old features improved.
 
+## 2.12.1 - 2026-08-13
+### 접두사가 붙은 Hangloose 파일 복원 수정
+
+#### 🐛 버그 수정
+- **Hangloose 파일 탐지 수정**: `400se7chdelayBL.wav`처럼 공통 출력 이름 뒤에 스피커 코드가 붙은 Hangloose 파일을 복원 원본으로 인식한다. 3글자 높이 채널(`TFL` 등)은 짧은 채널명(`FL`)보다 먼저 판별하며, 서로 다른 출력 세트를 한 폴더에서 잘못 합치지 않도록 파일 접두사의 일치 여부를 검증한다.
+
 ## 2.12.0 - 2026-08-11
 ### BRIR 출력 형식 복원
 

--- a/core/brir_recovery.py
+++ b/core/brir_recovery.py
@@ -5,7 +5,8 @@ Impulcifer writes the same speaker/ear impulse responses in three layouts:
 * ``hrir.wav`` uses :data:`HEXADECAGONAL_TRACK_ORDER` (32 tracks, including
   two silent LFE placeholders).
 * ``hesuvi.wav`` uses :data:`HESUVI_TRACK_ORDER` (30 tracks).
-* ``Hangloose/<speaker>.wav`` stores one stereo file per measured speaker.
+* ``Hangloose/[prefix]<speaker>.wav`` stores one stereo file per measured
+  speaker.  The optional prefix is shared by all files in one output set.
 
 This module validates one surviving representation and rebuilds the missing
 representations by channel reordering only.  It never applies gain, DSP, or
@@ -39,6 +40,7 @@ _SPEAKER_TRACKS = tuple(
     for speaker in SPEAKER_NAMES
     for side in ("left", "right")
 )
+_SPEAKER_SUFFIXES = tuple(sorted(SPEAKER_NAMES, key=len, reverse=True))
 
 
 class BrirRecoveryError(ValueError):
@@ -262,14 +264,27 @@ def _find_named_dir(directory: Path, name: str) -> Path | None:
 def _find_split_files(directory: Path) -> dict[str, Path]:
     if not directory.is_dir():
         return {}
-    canonical = {speaker.casefold(): speaker for speaker in SPEAKER_NAMES}
     found: dict[str, Path] = {}
+    prefix: str | None = None
     for path in directory.iterdir():
         if not path.is_file() or path.suffix.casefold() != ".wav":
             continue
-        speaker = canonical.get(path.stem.casefold())
-        if speaker is None:
+        match = _match_split_stem(path.stem)
+        if match is None:
             continue
+        file_prefix, speaker = match
+        normalized_prefix = file_prefix.casefold()
+        if prefix is None:
+            prefix = normalized_prefix
+        elif normalized_prefix != prefix:
+            raise BrirRecoveryError(
+                "AMBIGUOUS_SOURCE",
+                "Hangloose files must use one shared filename prefix.",
+                details={
+                    "files": [str(found_path) for found_path in found.values()]
+                    + [str(path)]
+                },
+            )
         if speaker in found:
             raise BrirRecoveryError(
                 "AMBIGUOUS_SOURCE",
@@ -278,6 +293,15 @@ def _find_split_files(directory: Path) -> dict[str, Path]:
             )
         found[speaker] = path
     return found
+
+
+def _match_split_stem(stem: str) -> tuple[str, str] | None:
+    normalized = stem.casefold()
+    for speaker in _SPEAKER_SUFFIXES:
+        suffix = speaker.casefold()
+        if normalized.endswith(suffix):
+            return stem[: -len(speaker)], speaker
+    return None
 
 
 def _read_combined(path: Path, order: Iterable[str], kind: str) -> _TrackSet:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "impulcifer-py313"
-version = "2.12.0"
+version = "2.12.1"
 authors = [
   { name="원본 저자: Jaakko Pasanen", email="" },
   { name="Python 3.13/3.14 호환 버전: 115dkk", email="" },

--- a/tests/test_brir_recovery.py
+++ b/tests/test_brir_recovery.py
@@ -84,6 +84,71 @@ def test_hangloose_directory_rebuilds_both_canonical_layouts(tmp_path: Path) -> 
     np.testing.assert_array_equal(hesuvi, _stack(tracks, HESUVI_TRACK_ORDER))
 
 
+def test_prefixed_hangloose_filenames_rebuild_both_layouts(tmp_path: Path) -> None:
+    speakers = ("FL", "FR", "FC", "BL", "BR", "SL", "SR")
+    tracks = _speaker_tracks(speakers)
+    prefix = "400se7chdelay"
+    for speaker in speakers:
+        write_wav(
+            str(tmp_path / f"{prefix}{speaker}.wav"),
+            FS,
+            np.vstack(
+                (tracks[f"{speaker}-left"], tracks[f"{speaker}-right"])
+            ),
+            bit_depth=32,
+        )
+
+    result = recover_brir_outputs(tmp_path)
+
+    assert result.source_kind == "hangloose"
+    assert result.speakers == speakers
+    assert {Path(path).name for path in result.created_files} == {
+        "hrir.wav",
+        "hesuvi.wav",
+    }
+    assert {Path(path).name for path in result.existing_files} == {
+        f"{prefix}{speaker}.wav" for speaker in speakers
+    }
+    _, hrir = _read_matrix(tmp_path / "hrir.wav")
+    _, hesuvi = _read_matrix(tmp_path / "hesuvi.wav")
+    np.testing.assert_array_equal(hrir, _stack(tracks, HEXADECAGONAL_TRACK_ORDER))
+    np.testing.assert_array_equal(hesuvi, _stack(tracks, HESUVI_TRACK_ORDER))
+
+
+def test_longest_speaker_suffix_wins_for_prefixed_top_channel(tmp_path: Path) -> None:
+    tracks = _speaker_tracks(("TFL",))
+    write_wav(
+        str(tmp_path / "profileTFL.wav"),
+        FS,
+        np.vstack((tracks["TFL-left"], tracks["TFL-right"])),
+        bit_depth=32,
+    )
+
+    result = recover_brir_outputs(tmp_path)
+
+    assert result.speakers == ("TFL",)
+
+
+def test_mixed_hangloose_filename_prefixes_are_ambiguous(tmp_path: Path) -> None:
+    tracks = _speaker_tracks(("FL", "FR"))
+    for filename, speaker in (("firstFL.wav", "FL"), ("secondFR.wav", "FR")):
+        write_wav(
+            str(tmp_path / filename),
+            FS,
+            np.vstack(
+                (tracks[f"{speaker}-left"], tracks[f"{speaker}-right"])
+            ),
+            bit_depth=32,
+        )
+
+    with pytest.raises(BrirRecoveryError) as error:
+        recover_brir_outputs(tmp_path)
+
+    assert error.value.code == "AMBIGUOUS_SOURCE"
+    assert not (tmp_path / "hrir.wav").exists()
+    assert not (tmp_path / "hesuvi.wav").exists()
+
+
 def test_hrir_only_restores_hesuvi_and_optional_hangloose(tmp_path: Path) -> None:
     speakers = ("FL", "FR", "FC", "BL", "BR", "SL", "SR")
     tracks = _speaker_tracks(speakers)


### PR DESCRIPTION
## 요약
- `400se7chdelayBL.wav`처럼 공통 접두사 뒤에 스피커 코드가 붙은 Hangloose 출력 파일을 복원 원본으로 인식합니다.
- `TFL` 등의 3글자 채널을 `FL`로 잘못 판별하지 않도록 긴 스피커 코드부터 검사합니다.
- 서로 다른 접두사의 출력 세트가 섞인 폴더는 `AMBIGUOUS_SOURCE`로 거부합니다.
- 이슈 화면의 7채널 파일명을 그대로 재현하는 회귀 테스트를 추가합니다.

## 검증
- 복원 코어·application service·WebView 연결 테스트 45개 통과
- 전체 실행 466개 통과, 14개 환경 의존 실패(Tcl/Tk, PortAudio, `/proc/self/status` 부재)
- 수정 파일 Ruff 통과
- 기본값 및 virtual bass BRIR SHA-256이 `origin/master`와 동일

Closes #157