### PR TITLE
fix: repaint Windows title bar at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ first number changes, something has broken and you need to check your commands a
 changes there are only new features available and nothing old has broken and when the last number changes, old bugs have
 been fixed and old features improved.
 
+## 2.12.2 - 2026-08-13
+### Windows 시작 제목 표시줄 수정
+
+#### 🐛 버그 수정
+- **시작 직후 제목 표시줄 테마 적용**: Windows에서 DWM 테마 속성만 바뀌고 비클라이언트 영역의 페인트가 다음 활성화 변경까지 미뤄지던 문제를 수정했다. Win32 함수 서명을 명시하고 제목 표시줄을 즉시 다시 그리며, 프레임 갱신 실패 시 재시도하여 창 바깥을 클릭하기 전까지 기본 제목 표시줄이 남는 현상을 없앴다.
+
 ## 2.12.1 - 2026-08-13
 ### 접두사가 붙은 Hangloose 파일 복원 수정
 

--- a/impulcifer_webview.py
+++ b/impulcifer_webview.py
@@ -73,8 +73,8 @@ def apply_windows_titlebar_theme(window: Any, dark: bool) -> bool:
     """Match the OS title bar to the app theme via DWM, like CustomTkinter.
 
     Without this the WebView window wears the default white Windows title
-    bar over the dark Pulse UI. Returns False only when the native handle
-    is not available yet (caller may retry); True otherwise (done or no-op).
+    bar over the dark Pulse UI. Returns False while the native handle or
+    frame is not ready (caller may retry); True otherwise (done or no-op).
     """
     if platform.system() != "Windows":
         return True
@@ -94,12 +94,34 @@ def apply_windows_titlebar_theme(window: Any, dark: bool) -> bool:
         for attribute in (20, 19):
             if set_attribute(hwnd, attribute, ctypes.byref(value), ctypes.sizeof(value)) == 0:
                 break
-        # SWP_NOSIZE|NOMOVE|NOZORDER|FRAMECHANGED — repaint the frame so the
-        # new title bar color shows without waiting for a resize.
-        ctypes.windll.user32.SetWindowPos(hwnd, 0, 0, 0, 0, 0, 0x0001 | 0x0002 | 0x0004 | 0x0020)
+        set_window_pos = ctypes.windll.user32.SetWindowPos
+        set_window_pos.argtypes = [
+            wintypes.HWND,
+            wintypes.HWND,
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_int,
+            wintypes.UINT,
+        ]
+        set_window_pos.restype = wintypes.BOOL
+        # SWP_NOSIZE|NOMOVE|NOZORDER|FRAMECHANGED recalculates the frame.
+        frame_changed = set_window_pos(hwnd, 0, 0, 0, 0, 0, 0x0001 | 0x0002 | 0x0004 | 0x0020)
+
+        redraw_window = ctypes.windll.user32.RedrawWindow
+        redraw_window.argtypes = [
+            wintypes.HWND,
+            ctypes.c_void_p,
+            ctypes.c_void_p,
+            wintypes.UINT,
+        ]
+        redraw_window.restype = wintypes.BOOL
+        # RDW_INVALIDATE|UPDATENOW|FRAME explicitly paints the non-client
+        # area; otherwise Windows may wait for an activation change.
+        frame_redrawn = redraw_window(hwnd, None, None, 0x0001 | 0x0100 | 0x0400)
+        return bool(frame_changed and frame_redrawn)
     except Exception:
-        pass
-    return True
+        return False
 
 
 # open_url() is allowlist-only so the JS side can never navigate the host

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "impulcifer-py313"
-version = "2.12.1"
+version = "2.12.2"
 authors = [
   { name="원본 저자: Jaakko Pasanen", email="" },
   { name="Python 3.13/3.14 호환 버전: 115dkk", email="" },

--- a/tests/test_webview_bridge.py
+++ b/tests/test_webview_bridge.py
@@ -178,6 +178,98 @@ def test_main_rejects_unsupported_platform(monkeypatch) -> None:
         impulcifer_webview.main()
 
 
+def test_windows_titlebar_repaint_preserves_64_bit_handle(monkeypatch) -> None:
+    import ctypes
+    from ctypes import wintypes
+
+    import impulcifer_webview
+
+    class _FakeFunction:
+        def __init__(self, result) -> None:
+            self.result = result
+            self.calls: list[tuple] = []
+
+        def __call__(self, *args):
+            self.calls.append(args)
+            return self.result
+
+    set_attribute = _FakeFunction(0)
+    set_window_pos = _FakeFunction(1)
+    redraw_window = _FakeFunction(1)
+    monkeypatch.setattr(impulcifer_webview.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(
+        ctypes,
+        "windll",
+        SimpleNamespace(
+            dwmapi=SimpleNamespace(DwmSetWindowAttribute=set_attribute),
+            user32=SimpleNamespace(
+                SetWindowPos=set_window_pos,
+                RedrawWindow=redraw_window,
+            ),
+        ),
+        raising=False,
+    )
+    native_handle = 0x1_0000_1234
+    window = SimpleNamespace(
+        native=SimpleNamespace(Handle=SimpleNamespace(ToInt64=lambda: native_handle)),
+    )
+
+    assert impulcifer_webview.apply_windows_titlebar_theme(window, dark=True)
+    assert set_window_pos.argtypes == [
+        wintypes.HWND,
+        wintypes.HWND,
+        ctypes.c_int,
+        ctypes.c_int,
+        ctypes.c_int,
+        ctypes.c_int,
+        wintypes.UINT,
+    ]
+    assert set_window_pos.restype is wintypes.BOOL
+    assert set_window_pos.calls == [
+        (native_handle, 0, 0, 0, 0, 0, 0x0001 | 0x0002 | 0x0004 | 0x0020),
+    ]
+    assert redraw_window.argtypes == [
+        wintypes.HWND,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        wintypes.UINT,
+    ]
+    assert redraw_window.restype is wintypes.BOOL
+    assert redraw_window.calls == [
+        (native_handle, None, None, 0x0001 | 0x0100 | 0x0400),
+    ]
+
+
+def test_windows_titlebar_retries_when_frame_repaint_fails(monkeypatch) -> None:
+    import ctypes
+
+    import impulcifer_webview
+
+    class _FakeFunction:
+        def __init__(self, result) -> None:
+            self.result = result
+
+        def __call__(self, *args):
+            return self.result
+
+    monkeypatch.setattr(impulcifer_webview.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(
+        ctypes,
+        "windll",
+        SimpleNamespace(
+            dwmapi=SimpleNamespace(DwmSetWindowAttribute=_FakeFunction(0)),
+            user32=SimpleNamespace(
+                SetWindowPos=_FakeFunction(0),
+                RedrawWindow=_FakeFunction(0),
+            ),
+        ),
+        raising=False,
+    )
+    window = SimpleNamespace(native=SimpleNamespace(Handle=1234))
+
+    assert not impulcifer_webview.apply_windows_titlebar_theme(window, dark=True)
+
+
 def test_bootstrap_reports_webview_backend(monkeypatch) -> None:
     import impulcifer_webview
     from impulcifer_webview import WebviewBridge


### PR DESCRIPTION
## 요약
- DWM 제목 표시줄 테마 적용 뒤 Win32 프레임 갱신 함수의 정확한 서명을 선언합니다.
- `RedrawWindow(RDW_INVALIDATE | RDW_UPDATENOW | RDW_FRAME)`로 비클라이언트 영역을 즉시 다시 그립니다.
- 프레임 갱신 실패 시 기존 폴링 경로가 재시도하도록 반환값을 바로잡습니다.
- 64비트 HWND와 재그리기·재시도 동작을 회귀 테스트로 고정하고 버전을 2.12.2로 올립니다.

## 검증
- `python -m py_compile` 전체 추적 Python 파일 통과
- `pytest tests/test_webview_bridge.py -q`: 35 passed
- `pytest tests/test_suite.py -v -m "not slow"`: 17 passed, 2 skipped
- 전체 테스트: 환경 의존 10개 제외 496 passed, 17 skipped, 6 subtests passed
- 핵심 모듈 임포트·의존성 목록 동기화·`pip check` 통과
- 저장소 전체 Ruff는 기존 누적 791건(비차단)

Closes #159