### PR TITLE
fix: apply Windows title bar theme before show

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ first number changes, something has broken and you need to check your commands a
 changes there are only new features available and nothing old has broken and when the last number changes, old bugs have
 been fixed and old features improved.
 
+## 2.12.3 - 2026-08-13
+### Windows 시작 제목 표시줄 적용 순서 수정
+
+#### 🐛 버그 수정
+- **최초 표시 전에 앱 테마 확정**: `webview.start()` 작업 스레드에서 적용한 앱 테마를 pywebview의 WinForms 창 생성 과정이 Windows 시스템 테마로 다시 덮어쓰던 문제를 수정했다. 네이티브 폼 생성이 끝난 뒤 화면에 나타나기 직전인 동기식 `before_show` 이벤트에서 제목 표시줄 테마를 적용하여 첫 프레임부터 앱 테마와 일치하게 한다.
+
 ## 2.12.2 - 2026-08-13
 ### Windows 시작 제목 표시줄 수정
 

--- a/impulcifer_webview.py
+++ b/impulcifer_webview.py
@@ -195,9 +195,8 @@ class WebviewBridge:
     def apply_titlebar_theme(self) -> None:
         """Sync the native title bar with the current app theme (Windows).
 
-        The webview.start callback can fire before the native window handle
-        exists, so poll briefly instead of silently doing nothing (observed:
-        the packaged app kept the default white title bar).
+        ``before_show`` normally runs with the native handle ready. Keep the
+        short retry for runtime theme changes and unusually slow handle setup.
         """
         window = self._window
         if window is None:
@@ -307,6 +306,12 @@ def create_app_window(webview_module: Any, bridge: "WebviewBridge") -> Any:
         background_color=_WINDOW_BACKGROUNDS[resolve_effective_theme()],
     )
     bridge.attach_window(window)
+    # pywebview applies the Windows system theme inside BrowserForm.__init__.
+    # Run after that assignment but before BrowserForm.Show() so the app theme
+    # is the final value and the first visible frame already has the right
+    # caption. A webview.start callback begins before BrowserForm is created
+    # and can therefore be overwritten by pywebview during construction.
+    window.events.before_show += bridge.apply_titlebar_theme
     return window
 
 
@@ -324,8 +329,7 @@ def main() -> None:
 
     bridge = WebviewBridge()
     create_app_window(webview, bridge)
-    # Runs once the window is shown: the native handle exists only then.
-    webview.start(bridge.apply_titlebar_theme, gui=backend, debug=False)
+    webview.start(gui=backend, debug=False)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "impulcifer-py313"
-version = "2.12.2"
+version = "2.12.3"
 authors = [
   { name="원본 저자: Jaakko Pasanen", email="" },
   { name="Python 3.13/3.14 호환 버전: 115dkk", email="" },

--- a/tests/test_webview_bridge.py
+++ b/tests/test_webview_bridge.py
@@ -69,6 +69,19 @@ class _FakeWindow:
         return self.selection
 
 
+class _FakeEvent:
+    def __init__(self) -> None:
+        self.handlers = []
+
+    def __iadd__(self, handler):
+        self.handlers.append(handler)
+        return self
+
+    def fire(self) -> None:
+        for handler in self.handlers:
+            handler()
+
+
 def _install_fake_webview(monkeypatch) -> SimpleNamespace:
     fake_webview = SimpleNamespace(
         FileDialog=SimpleNamespace(OPEN="OPEN", FOLDER="FOLDER", SAVE="SAVE"),
@@ -150,8 +163,13 @@ def test_main_forces_platform_backend(monkeypatch, system, expected_backend) -> 
     import impulcifer_webview
 
     calls = []
+
+    def create_window(*args, **kwargs):
+        calls.append(("create", args, kwargs))
+        return SimpleNamespace(events=SimpleNamespace(before_show=_FakeEvent()))
+
     fake_webview = SimpleNamespace(
-        create_window=lambda *args, **kwargs: calls.append(("create", args, kwargs)),
+        create_window=create_window,
         start=lambda *args, **kwargs: calls.append(("start", args, kwargs)),
     )
     monkeypatch.setattr(impulcifer_webview.platform, "system", lambda: system)
@@ -166,8 +184,38 @@ def test_main_forces_platform_backend(monkeypatch, system, expected_backend) -> 
     start_name, start_args, start_kwargs = calls[1]
     assert start_name == "start"
     assert start_kwargs == {"gui": expected_backend, "debug": False}
-    # First positional arg is the on-shown callback that themes the title bar.
-    assert len(start_args) == 1 and callable(start_args[0])
+    # The title-bar callback belongs to before_show, not webview.start(): the
+    # latter starts its worker before pywebview constructs the native form.
+    assert start_args == ()
+
+
+def test_create_window_applies_titlebar_after_pywebview_setup_before_show(monkeypatch) -> None:
+    import impulcifer_webview
+
+    before_show = _FakeEvent()
+    window = SimpleNamespace(events=SimpleNamespace(before_show=before_show))
+    fake_webview = SimpleNamespace(create_window=lambda *args, **kwargs: window)
+    bridge = impulcifer_webview.WebviewBridge(_FakeService())
+    calls = []
+
+    monkeypatch.setattr(impulcifer_webview, "_index_uri", lambda: "file:///index.html")
+    monkeypatch.setattr(impulcifer_webview, "resolve_effective_theme", lambda: "dark")
+    monkeypatch.setattr(
+        impulcifer_webview,
+        "apply_windows_titlebar_theme",
+        lambda attached_window, dark: calls.append((attached_window, dark)) or True,
+    )
+
+    created = impulcifer_webview.create_app_window(fake_webview, bridge)
+
+    assert created is window
+    assert calls == []
+    assert before_show.handlers == [bridge.apply_titlebar_theme]
+
+    # pywebview fires this only after BrowserForm.__init__ has applied its own
+    # system theme, and immediately before BrowserForm.Show().
+    before_show.fire()
+    assert calls == [(window, True)]
 
 
 def test_main_rejects_unsupported_platform(monkeypatch) -> None:
@@ -339,4 +387,5 @@ def test_webview_entrypoint_contains_no_qt_backend() -> None:
     assert '"Windows": "edgechromium"' in source
     assert '"Darwin": "cocoa"' in source
     assert '"Linux": "gtk"' in source
-    assert "webview.start(bridge.apply_titlebar_theme, gui=backend" in source
+    assert "window.events.before_show += bridge.apply_titlebar_theme" in source
+    assert "webview.start(gui=backend" in source


### PR DESCRIPTION
## 문제

v2.12.2에서도 Windows 10에서 시작 직후 흰색 기본 제목 표시줄이 남았습니다.

## 원인

`webview.start(callback)`은 네이티브 WinForms 창 생성보다 먼저 callback 작업 스레드를 시작합니다. 기존 코드는 이 스레드에서 앱 테마를 적용했지만, 이후 pywebview 6.2의 `BrowserForm.__init__`이 Windows 시스템 테마를 다시 적용하여 값을 덮어썼습니다.

## 수정

- 제목 표시줄 테마 적용을 동기식 `window.events.before_show`로 이동
- pywebview의 폼 초기화가 끝난 뒤, `BrowserForm.Show()` 직전에 앱 테마 확정
- 시작 콜백에서 제목 표시줄을 적용하지 않도록 변경
- 이 호출 순서를 고정하는 회귀 테스트 추가
- 버전 2.12.3 및 변경 로그 반영

## 검증

- `tests/test_webview_bridge.py`: 36 passed
- Tier 1: 17 passed, 2 skipped
- 전체 환경 독립 테스트: 497 passed, 17 skipped, 10 deselected, 6 subtests passed
- `pip check`: no broken requirements

Closes #159