### PR TITLE
docs: Rust unsafe 회피·격리 조사 추가

### DIFF
--- a/docs/research/rewrite-stack-2026-09/03-rust-unsafe.md
+++ b/docs/research/rewrite-stack-2026-09/03-rust-unsafe.md
@@ -1,0 +1,183 @@
+# Rust로 짤 때 unsafe는 피할 수 없는가, 피할 수 없다면 어떻게 가두는가 (2026-09-07)
+
+ASTRA 워커 2기의 보고서(`report-10-rust-unsafe-inventory.md` 인벤토리, `report-11-rust-unsafe-quarantine.md` 격리 아키텍처)를 Claude가 읽고 종합한 문서입니다. 대상 스택은 앞선 결정대로 Rust 코어 + Tauri 2, Windows는 wasapi-rs, macOS/Linux는 CPAL입니다. 표지는 [V] 검증(출처 또는 소스 확인), [I] 추론, [U] 미확인입니다. 두 보고서 모두 실제 Rust 워크스페이스를 빌드하지는 않았습니다.
+
+## 1. 결론
+
+1. **[I] 우리가 손수 쓰는 unsafe는 0으로 갈 수 있습니다.** 필요한 모든 기능에 안전한 호출 표면이 있습니다. WASAPI 열거·렌더·캡처(wasapi 0.24.0), CoreAudio/ALSA(cpal 0.18.2), FFT(RustFFT 6.4.1/RealFFT 3.5.0), 배열(ndarray 0.17.2/nalgebra 0.35.0), 병렬(rayon 1.11), WAV(hound 3.5.1 또는 자체 안전 writer), ffmpeg 실행(std::process), Tauri 명령·테마·다이얼로그·업데이터, PyO3 0.27/0.29 + numpy(소유 복사 경로), Velopack 1.2.0 전부입니다. 따라서 **애플리케이션 크레이트 전부에 `#![forbid(unsafe_code)]`**를 걸 수 있습니다.
+2. **[V] 그러나 "실행 파일에 unsafe가 없다"는 뜻은 아닙니다.** wasapi-rs `api.rs` 한 파일에만 unsafe 블록이 99개 있고(소스 텍스트 집계), PyO3 매크로는 `unsafe extern "C"` 내보내기를 생성하며, Tauri 자체(`app.rs`)와 wry/tao, RustFFT의 SIMD 커널, rayon 내부가 모두 unsafe를 씁니다. 우리가 통제하는 것은 손수 쓰는 unsafe이고, 나머지는 검토·고정·감사 대상입니다.
+3. **[V] 진짜 위험은 lint가 잡지 못하는 곳, 즉 '안전해 보이는 함수의 불건전성'에 있습니다.** 인벤토리가 두 건을 소스에서 찾아냈고 Claude가 원본으로 재확인했습니다(2절).
+4. **[I] 격리 방식은 Tauri와 같습니다.** 플랫폼 unsafe는 leaf 크레이트 하나(`impulcifer-sys-win`)에만 허용하되, 초기 허용량은 0이고, wasapi-rs가 못 하는 네이티브 호출이 실제로 증명될 때만 개별 승인으로 열어 줍니다. 그 크레이트의 공개 API에는 포인터·COM 인터페이스·unsafe 트레이트가 하나도 나오지 않습니다.
+5. **[I] "Tauri처럼 가둔다"는 검토와 소유권의 경계이지 샌드박스가 아닙니다.** 크레이트 경계는 메모리 격리를 주지 않습니다. 의존성 안의 unsafe가 불건전하면 바깥의 안전한 크레이트가 그것을 고칠 수 없습니다. 크래시 격리가 필요하면 프로세스 경계를 따로 설계해야 합니다.
+
+## 2. lint가 못 잡는 위험: 소스에서 확인된 불건전성
+
+| 대상 | 내용 | 확인 | 대응 |
+|---|---|---|---|
+| wasapi-rs 0.24.0 `WaveFormat::parse(&WAVEFORMATEX)` | `pub fn`(안전 시그니처)인데 `wFormatTag`가 EXTENSIBLE이고 `cbSize`가 충분하면 `&WAVEFORMATEX`를 `*const WAVEFORMATEXTENSIBLE`로 캐스팅해 `ptr::read`합니다. 호출자가 단독 `WAVEFORMATEX` 값을 넘기면 할당 바깥을 읽습니다. 헤더 필드가 뒤에 저장 공간이 있음을 증명하지 못하므로 불건전한 안전 API입니다 | [V] Claude가 `waveformat.rs` 원본으로 재확인 | 어댑터에서 이 함수 사용 금지. 길이 검사가 있는 `parse_from_blob_bytes`, 검증된 `WaveFormat::new`만 사용. 업스트림에 시그니처 변경(unsafe 또는 길이 제한 입력) 요청 |
+| wasapi-rs 0.24.0 캡처 `read_from_device` 두 변형 | `GetBuffer` 뒤 `AUDCLNT_BUFFERFLAGS_SILENT`를 확인하기 전에 반환 포인터로 슬라이스를 만들어 복사하고, 플래그는 복사 뒤 `BufferInfo`로만 돌려줍니다. Microsoft는 SILENT일 때 데이터 값을 무시하라고 합니다 | [V] `api.rs` 원본으로 재확인. [U] Windows가 SILENT에서 null을 돌려준다는 문서는 없어 UB 여부는 조건부 | 신호 의미로는 우리 쪽에서 SILENT 패킷을 0으로 채워야 하고, 메모리 의미로는 업스트림이 슬라이스 구성 전에 분기해야 합니다. 채택 전 재현 조사 필요 |
+| coreaudio-rs 0.14.2 `Handle::from_ptr` | 안전 함수가 임의 포인터를 저장하고 안전 `get()`이 검사 없이 역참조합니다. `from_ptr(null_mut()).get()`이 전부 안전한 Rust로 표현됩니다 | [V] 보고서 10의 소스 진단. [U] 일반 CPAL 빌더 경유로 도달하는지는 미확인 | CPAL의 타입 빌더만 쓰고 coreaudio 원시 헬퍼를 직접 쓰지 않음 |
+| Tauri `Manager::unmanage` | deprecated 안전 함수인데 문서 스스로 dangling reference를 경고 | [V] | 사용 금지, `Mutex<Option<T>>`로 대체 |
+
+이 표가 이 조사의 가장 중요한 교훈입니다. `#![forbid(unsafe_code)]`는 우리가 unsafe를 쓰지 않았다는 것만 보증하고, 우리가 부르는 안전한 함수가 건전한지는 보증하지 않습니다. 그래서 의존성의 unsafe와 그 불변식을 지키는 안전 코드까지 검토 대상에 넣어야 합니다.
+
+## 3. unsafe가 새어들 수 있는 지점과 안전한 대안
+
+| 새어드는 경로 | 이유 | 대안 |
+|---|---|---|
+| windows-rs로 COM/DWM/MMCSS 직접 호출 | 모든 COM 메서드가 `unsafe fn` | wasapi-rs 안전 표면 우선, Tauri `set_theme`으로 다크 타이틀바(tao가 내부에서 DwmSetWindowAttribute 호출), 부족하면 업스트림 수정, 그래도 안 되면 leaf 예외 |
+| COM 래퍼에 `unsafe impl Send/Sync` | 아파트먼트 규칙이 스레드 이동을 금지 | 오디오 전용 OS 스레드에서 생성·사용·해제, 스레드 간에는 ID·소유 버퍼·결과만 전달 |
+| 위 표의 불건전 안전 API 사용 | lint가 못 잡음 | 어댑터에서 명시적 금지 목록 유지 |
+| memmap2 파일 매핑 | 외부 파일 변경·절단이 메모리를 무효화하므로 `Mmap::map`이 unsafe | 수백 MB는 `std::fs::read`나 스트리밍 읽기로 충분 |
+| NumPy 원시/미초기화/차용 배열(`PyArray::new`, `borrow_from_array`, `PyArrayMethods::as_slice`) | 초기화·별칭·수명 의무 | `PyReadonlyArray` 가드 → 복사 → `Python::detach`로 소유 데이터만 계산 → `from_vec`/`from_slice`로 새 배열 반환 |
+| 포인터 SIMD, `get_unchecked`, `assume_init`, `set_len` | 경계·정렬·CPU 기능·초기화 | `Vec<f64>`와 안전 슬라이스, RustFFT 플래너의 런타임 디스패치 재사용, 측정된 병목에만 `wide`/`pulp` 안전 API |
+| 링버퍼 원시 커밋 API | 초기화된 슬롯과 공개 순서 증명 필요 | rtrb 0.3.5 이상 또는 ringbuf 0.4.8의 안전 push/pop만 |
+| `static mut`, 전역 환경변수 변경(2024 에디션에서 `set_var`가 unsafe), Unix `pre_exec` | 전역 별칭·프로세스 런타임 계약 | OnceLock/Arc/Mutex/원자값, `Command::env` |
+| 공유 메모리 IPC, 원시 콜백 | 수명·피어 변경·FFI unwind | Tauri JSON/바이너리 응답, stdio |
+
+## 4. 격리 아키텍처
+
+### 4.1 워크스페이스와 unsafe 예산
+
+| 크레이트 | 책임 | 손수 쓰는 unsafe 예산 |
+|---|---|---|
+| `impulcifer-types` | 검증된 설정·채널 레이아웃·오류 타입 | 0, forbid |
+| `impulcifer-dsp` | f64 scipy 호환 프리미티브, RustFFT, ndarray/nalgebra, rayon | 0, forbid. 자체 SIMD 금지 |
+| `impulcifer-io` | WAV/CSV/TXT, ffmpeg 프로세스, 안전 바이트 파싱 | 0, forbid |
+| `impulcifer-analysis` | 분석 배열, plotters PNG, 오프라인 Plotly | 0, forbid |
+| `impulcifer-audio-io` | 백엔드 선택, 측정 세션 오케스트레이션, macOS/Linux는 cpal | 0, forbid |
+| `impulcifer-sys-win` | Windows 엔드포인트·세션 구현(wasapi-rs), 승인된 windows-rs 직접 호출 | **유일한 예외 후보**. 초기 허용 0, 항목별 승인, 검토 트립와이어 12블록/120줄 |
+| `impulcifer-jobs` | seq 저널, 취소 토큰, 유계 큐 | 0, forbid |
+| `impulcifer-service` | JSON 안전 애플리케이션 연산 | 0, forbid |
+| `impulcifer-app` | Tauri 명령, 다이얼로그/테마/opener, 업데이터 어댑터 | 0, forbid(build.rs 포함) |
+| `impulcifer-cli` | 헤드리스 CLI | 0, forbid |
+| `impulcifer-python` | PyO3/maturin, 소유 입출력 경계 | 손수 쓰는 것 0, forbid. 매크로 생성 코드는 별도 검토 |
+| `impulcifer-policy` | CI에서 메타데이터·구문 파싱으로 정책 검사 | 0, forbid |
+
+```text
+existing vanilla UI + JSON catalogues
+                 |
+         impulcifer-app (Tauri)
+                 |
+        impulcifer-service <---------- impulcifer-cli
+                 |
+          impulcifer-jobs
+           /           \
+impulcifer-dsp      impulcifer-audio-io
+     ^              /              \
+     |      [Windows only]      [macOS/Linux only]
+impulcifer-python   impulcifer-sys-win       cpal
+                       |
+                     wasapi ---> windows/windows-core
+```
+
+leaf 안에서도 공개 unsafe 함수 0, `unsafe impl Send/Sync` 0, `static mut` 0, transmute 0, SIMD/어셈블리 0, 내보내는 원시 포인터 0입니다. 트립와이어를 넘기거나 새 범주가 필요하면 ADR 승인이 선행됩니다. 범용 `unsafe-utils` 크레이트는 만들지 않습니다. Python이나 SIMD용 unsafe가 정말 필요해지면 Windows 크레이트에 끼워 넣지 말고 별도 도메인 leaf를 새로 결정합니다.
+
+### 4.2 leaf 공개 API 규칙
+
+공개 타입은 소유 값, 검증된 설정, 일반 슬라이스, enum, `Result`뿐입니다. `OutputSession::play_to_completion(&mut self, PlaybackBuffer, &CancelToken) -> Result<PlaybackReport>`, `CaptureSession::read_into(&mut self, &mut [f32], &CancelToken) -> Result<CaptureRead>` 같은 형태이고 두 세션 타입은 의도적으로 `!Send + !Sync`입니다. HWND, COM 인터페이스, 네이티브 포인터, 원시 버퍼를 받는 콜백은 이 경계를 넘지 않습니다. `set_dark_titlebar(hwnd: usize)` 같은 "정수 핸들을 받는 안전 함수"는 만들지 않습니다.
+
+### 4.3 COM 소유권 규칙
+
+- Tauri 메인(STA) 아파트먼트는 건드리지 않습니다. 오디오 전용 OS 스레드마다 MTA를 초기화하고, 열거자·장치·AudioClient·서비스·이벤트를 그 스레드에서 만들고 쓰고 해제합니다.
+- `CoInitializeEx`는 S_FALSE까지 포함해 균형을 맞추고, 초기화 실패 뒤에는 `deinitialize`를 부르지 않습니다. 네이티브 인터페이스를 전부 drop한 뒤에 아파트먼트 가드를 놓습니다. wasapi-rs는 RAII 가드를 제공하지 않으므로 우리 어댑터가 `PhantomData<Rc<()>>`로 `!Send`를 강제한 비공개 가드를 둡니다.
+- 캡처 패킷의 `GetBuffer`/`ReleaseBuffer`는 같은 스레드에서 짝을 이루고, 패킷 borrow는 어댑터 밖으로 나가지 않습니다. SILENT면 데이터를 읽지 않고 0으로 채웁니다.
+- 컴파일 오류를 없애려고 `unsafe impl Send`를 추가하지 않습니다. async 실행기 위에서 스레드를 옮겨 다니는 작업에 아파트먼트 종속 상태를 들고 있지 않습니다.
+- `mem::forget`은 안전하므로 Drop이 항상 실행된다고 가정하지 않습니다. 값이 누수되면 자원은 새도 use-after-free는 생기지 않게 설계합니다.
+
+### 4.4 린트와 정책 검사기
+
+```toml
+# workspace Cargo.toml
+[workspace.package]
+edition = "2024"
+rust-version = "1.98"
+
+[workspace.lints.rust]
+unsafe_code = "forbid"
+unsafe_op_in_unsafe_fn = "deny"
+
+[workspace.lints.clippy]
+undocumented_unsafe_blocks = "deny"
+multiple_unsafe_ops_per_block = "deny"
+missing_safety_doc = "deny"
+```
+
+일반 멤버는 `[lints] workspace = true`로 상속하고(Cargo 1.74 이후, 멤버가 명시적으로 옵트인해야 함), 크레이트 루트마다 `#![forbid(unsafe_code)]`와 `#![deny(unsafe_op_in_unsafe_fn)]`를 중복으로 둡니다. leaf만 `forbid`를 상속하지 않되 나머지 세 clippy 린트는 deny입니다. `--cap-lints`와 `--force-warn`이 forbid를 낮출 수 있으므로 `.cargo/config*`, build.rs, CI 환경의 rustc 플래그를 `impulcifer-policy`가 검사합니다. 이 검사기는 `cargo metadata`로 모든 타깃 루트(lib/bin/build/test/example/bench)를 열거하고, 첫 번째 당사자 Rust/TOML을 파싱해 unsafe 블록·함수·impl·extern·unsafe 속성을 세며, cfg로 숨긴 코드도 잡고, 플랫폼 의존성 직접 사용 권한(windows/wasapi는 leaf만, cpal은 audio-io만, PyO3는 python만, Tauri는 app만)을 강제합니다. 검사기 자체와 워크플로·툴체인 파일·감사 원장은 유지보수자 검토 대상이며, AI 에이전트가 스스로 승인할 수 없습니다.
+
+## 5. 도구 판정
+
+| 도구 | 검증된 상태 | 판정 |
+|---|---|---|
+| rustc `unsafe_code = forbid` | 의존성에는 전이되지 않음. 매크로 확장 코드는 진단에서 제외 | 필수 |
+| Cargo workspace lints | 1.74 이후, 멤버 옵트인 필요 | 필수 |
+| clippy `undocumented_unsafe_blocks`, `multiple_unsafe_ops_per_block`, `missing_safety_doc` | 앞 둘은 restriction(기본 off) | leaf에서 deny |
+| cargo-deny 0.20.2 (2026-07-09) | advisories/licenses/bans/sources | 필수 게이트 |
+| cargo-audit 0.22.2 (2026-06-05) | RustSec 검사 | 주간·릴리스 |
+| cargo-vet 0.10.2 (2026-01-13) | 감사 원장. 기본 `safe-to-deploy`는 unsafe 전수 검토를 요구하지 않음 | 원장으로 채택하되 `impulcifer-soundness-reviewed` 커스텀 기준을 추가. 에이전트는 인증·면제 불가 |
+| cargo-crev 0.27.1 | 서명된 리뷰, 신뢰망 | 선택 |
+| cargo-geiger 0.13.0 (2025-08-31) | 구문 기반 unsafe 집계. `cargo install --locked`가 RUSTSEC-2025-0024에 걸린 yanked crossbeam-channel을 고르는 이슈 #564 미해결 | 자문용 인벤토리. 권한 있는 릴리스 잡에 설치하지 않음 |
+| Miri (nightly) | 실행된 순수 Rust 경로의 UB·레이스 검출. FFI/COM 실행 불가, Windows 지원 제한 | 순수 코드와 모델 테스트에만. COM 검증 아님 |
+| ASan/TSan (nightly `-Zsanitizer`, Linux x86_64) | std 재빌드 필요. TSan은 원자 fence·어셈블리 가시성 한계 | 주간 별도 잡, 필수 게이트 승격 전 실측 |
+| Kani | 유계 검증 하니스 | 정수 길이·라우팅·상태 헬퍼에 소규모 선택 적용 |
+| Verus | 지원 부분집합, 활발히 변경 중 | 초기 게이트에서 제외 |
+| Rust 1.98.1 (2026-09-03) | 1.98.0의 vtable 생성 오컴파일 수정 | 첫 후보 툴체인으로 고정, edition 2024 |
+
+edition 2024에서 `unsafe_op_in_unsafe_fn`은 warn 기본이므로 명시적으로 deny합니다. `unsafe extern` 블록과 `#[unsafe(no_mangle)]`은 leaf 밖에서 금지합니다. `std::env::set_var`는 2024에서 unsafe이므로 자식 프로세스 환경은 `Command::env`로만 설정합니다.
+
+## 6. CI 게이트 (요약)
+
+| 잡 | 빈도 | 내용 |
+|---|---|---|
+| policy-format | 매 PR | `cargo fmt --check`, `cargo run -p impulcifer-policy -- check` |
+| stable-native | 매 PR, 3 OS | `cargo clippy --workspace --all-targets -- --no-deps -D warnings`, `cargo test --workspace` |
+| feature-contracts | 매 PR | dsp/cli `--no-default-features`, app `--features desktop`, dsp `--features scalar` |
+| dependency-policy | 매 PR + 일간 | `cargo deny check`, `cargo vet check` |
+| windows-leaf | leaf/audio/의존성/컴파일러 변경 시 | `cargo test -p impulcifer-sys-win`, `-p impulcifer-audio-io` |
+| miri-models | dsp/state/leaf 모델 변경 시 + 주간 | 고정 nightly로 jobs·dsp(scalar)·sys-win(model-tests) |
+| asan-core / tsan-jobs | 주간 + 관련 변경 시 | Linux, std 재빌드, 별도 target dir |
+| unsafe-inventory | 의존성/leaf PR + 주간, 자문 | 검증된 geiger 바이너리로 JSON 인벤토리 비교 |
+| python-boundary | Python/의존성/컴파일러 변경 시 | maturin 빌드 → pip 설치 → 경계 테스트, FT 인터프리터 포함 |
+| numerical-goldens | dsp/컴파일러/의존성 변경 시 | 스테이지별 f64 골든, WAV 계약 |
+| hardware-release | 오디오 백엔드 변경 릴리스 전 | 통제된 실기 러너 또는 서명된 수동 수락 |
+
+전체 명령과 예상 소요는 `report-11` §3.4에 있습니다. Miri와 sanitizer 인프라 장애는 조용한 continue-on-error가 아니라 소유자와 만료일이 있는 명시적 면제로 처리합니다.
+
+## 7. 정책 한 페이지 (CONTRIBUTING/CLAUDE.md용 초안)
+
+원문은 `report-11` §3.6에 있고 요지는 다음과 같습니다.
+
+- 목표. 모든 애플리케이션 코드는 안전한 Rust이다. `impulcifer-sys-win`만 손수 쓰는 unsafe 예외 후보이며 승인된 연산 0개로 시작한다. 의존성·매크로·std·OS에 unsafe가 없다는 주장은 아니다.
+- 기본. 다른 모든 라이브러리·바이너리·build.rs·테스트·예제는 `#![forbid(unsafe_code)]`와 `unsafe_op_in_unsafe_fn` deny를 쓰고 워크스페이스 린트를 상속한다. 린트 캡, cfg/매크로/생성 파일 뒤에 숨기기, 두 번째 예외 크레이트는 금지.
+- unsafe를 추가하기 전에. 충족되지 않는 요구를 밝히고, 선택한 안전 API가 왜 안 되는지 보이고, 정확한 업스트림/네이티브 계약을 링크하고, 가장 작은 안전 인터페이스와 불변식 장부를 제안하고, 유지보수자 승인을 받는다. DWM, SIMD, 프로세스 환경 변경, zero-copy NumPy 차용, 복사한 네이티브 예제는 자동 예외가 아니다.
+- leaf 계약. 공개 API는 소유 값·검증된 설정·일반 슬라이스·enum·Result만. 공개 원시 포인터/COM 인터페이스/unsafe 함수·트레이트/`static mut`/transmute/수동 Send·Sync 없음. 네이티브 객체는 소유 워커에서 생성·사용·해제하고 COM 초기화는 모든 종속 객체보다 오래 산다.
+- 증명과 정리. 비공개 unsafe 함수는 `# Safety`로 호출자 의무를, 각 unsafe 블록은 바로 앞 `// SAFETY:`로 길이·정렬·초기화·별칭·출처·스레드·수명을 증명한다. "Windows API라서", "예제와 같아서", "포인터가 유효해서"는 증명이 아니다.
+- 예산. 각 unsafe 지점은 승인된 사유 ID를 가진다. 12블록 또는 120줄 초과는 카운터 면제가 아니라 새 아키텍처 검토를 요구한다.
+- Python과 워커. detach/Rayon 작업에는 독립적으로 소유된 Rust 버퍼와 설정만 들어간다. Python 토큰, Bound 값, 차용한 NumPy 메모리, COM 인터페이스, SendWrapper는 금지. 복사는 복사 중 동시 변경을 안전하게 만들지 않으므로 free-threaded 경계의 기본은 불변/직렬화된 입력이다.
+- 의존성. 잠금 파일과 기능 집합을 검토 상태로 유지한다. 에이전트는 감사 증거를 준비할 수 있지만 cargo-vet 인증, 면제 추가, 신뢰 발행자 변경, advisory 억제를 유지보수자 승인 없이 할 수 없다.
+
+## 8. 비용과 편익 (1인 유지보수자 + 코딩 에이전트)
+
+- 검토 부담. 알고리즘·서비스 작업 대부분은 안전한 Rust와 의미 테스트로 검토할 수 있고, 불변식을 바꾸는 네이티브 패치만 집중 검토합니다. 줄어드는 것은 변하는 첫 번째 당사자 unsafe 표면이지 전체 신뢰 코드가 아닙니다.
+- 에이전트 실패 양상. 에이전트는 원시 포인터/COM/SIMD 예제를 복사하거나 async 바운드를 맞추려 `unsafe impl Send`를 넣는 경향이 있습니다. forbid는 그런 패치를 즉시 실패시키며, 작업서는 린트 면제 대신 소유 데이터·동일 스레드 재설계를 요구해야 합니다.
+- 런타임 비용. 버퍼 소유·복사·직렬화·스레드 메시지가 메모리와 시간을 더 쓸 수 있지만 저지연 요구가 없으므로 측정 전에는 최적화하지 않습니다.
+- 빌드 비용. leaf 크레이트 하나는 Tauri/PyO3 컴파일에 비해 미미합니다. Miri, std 재빌드 sanitizer, 다중 OS/인터프리터 잡, 감사 도구 콜드 빌드가 실제 추가 비용입니다.
+- 잔여 위험. 업스트림 래퍼·드라이버·매크로가 여전히 불건전할 수 있고 프로세스는 여전히 죽을 수 있습니다.
+
+## 9. 열린 질문
+
+1. **[U] 완전한 인벤토리 뒤에도 손수 쓰는 unsafe가 실제로 필요한가.** wasapi-rs가 주요 네이티브 연산을, Tauri가 테마를, PyO3/numpy가 소유 변환을, RustFFT가 SIMD를 제공하므로 leaf 예약은 조건부입니다. 12개 연산이 필요하다는 증거는 없습니다.
+2. **[U] wasapi-rs 업스트림 수정 시점.** `WaveFormat::parse`와 SILENT 처리에 대해 이슈나 패치를 올리지 않았습니다. 채택 전 우리가 올리거나 최소 패치를 벤더링해야 합니다.
+3. **[U] SILENT 패킷의 네이티브 메모리 계약.** 실제 하드웨어가 비어 있지 않은 SILENT 패킷에 null이나 미초기화 저장소를 주는지 재현이 필요합니다.
+4. **[U] 실제 forbid 빌드.** Tauri/PyO3 매크로, edition 2024, limited-API, free-threaded Python, 3 OS 조합을 실제로 컴파일한 적이 없습니다. M1 파일럿에서 확인해야 합니다.
+5. **[U] numpy free-threaded 입력 계약.** 차용 가드는 임의의 Python/네이티브 쓰기를 배제하지 못합니다. 초기 경계는 불변 bytes + 메타데이터로 두고, ndarray 편의 API는 별도 계약과 FT 테스트 뒤에 엽니다.
+6. **[U] cargo-geiger 0.13.0이 Rust 1.98.1에서 동작하는지.** 마지막 확인된 수정은 1.89 호환입니다.
+7. **[U] Miri/ASan/TSan용 날짜 고정 nightly와 Kani 버전.** 파일럿에서 고릅니다.
+8. **[U] hound 3.5.1의 유지보수 응답성.** 마지막 발행이 2023-09-25이고, 30/32트랙 기본 채널 마스크가 0x3FFFF로 의미가 없으므로 자체 안전 RIFF writer가 유력합니다.
+
+## 출처
+
+두 보고서의 출처 목록(report-10은 55개 그룹, report-11은 76개)을 그대로 따릅니다. Claude가 직접 재확인한 것은 다음 둘입니다.
+
+- wasapi-rs v0.24.0 `src/waveformat.rs`: https://raw.githubusercontent.com/HEnquist/wasapi-rs/v0.24.0/src/waveformat.rs
+- wasapi-rs v0.24.0 `src/api.rs` 캡처 read 경로: https://raw.githubusercontent.com/HEnquist/wasapi-rs/v0.24.0/src/api.rs

--- a/docs/research/rewrite-stack-2026-09/brief-10-rust-unsafe-inventory.md
+++ b/docs/research/rewrite-stack-2026-09/brief-10-rust-unsafe-inventory.md
@@ -1,0 +1,86 @@
+# Impulcifer rewrite research - shared context (read this first, then your dimension below)
+
+Date: 2026-09-07. You are a research analyst working for the maintainer of an open-source audio tool.
+You are NOT allowed to modify any file under E:/Impulcifer. The only file you may write is the report path named at the end of this brief.
+
+## The project
+
+Impulcifer-py313 (repository root: E:/Impulcifer) is a desktop audio-DSP tool. It plays logarithmic sine sweeps through 1 to 16 loudspeakers, records them with binaural in-ear microphones (2-channel input), deconvolves the recordings into HRIR/BRIR impulse responses, then applies room correction, headphone compensation, parametric EQ (a vendored AutoEQ port with a bounded least-squares biquad fit), virtual bass, microphone-deviation correction and decay shaping, and writes multi-track WAV files for HeSuVi, Hangloose, EqualizerAPO and JamesDSP. It also writes analysis PNGs (matplotlib + seaborn + Pillow) and interactive Bokeh HTML reports.
+
+Size: about 23k lines of Python on numpy/scipy. Nine-language i18n (433 keys per JSON catalogue in E:/Impulcifer/i18n/locales). A vanilla HTML/CSS/JS frontend with no bundler and no node_modules (E:/Impulcifer/webview_ui: app.js 1487 lines, index.html 730, styles.css 743) hosted in pywebview (WebView2 on Windows, WKWebView on macOS, WebKitGTK on Linux), plus a CustomTkinter fallback GUI that will be frozen, and a CLI. The frontend talks to a JSON application service (E:/Impulcifer/application/impulcifer_service.py) with about 22 methods: bootstrap, list_audio_devices, start_recording, start_brir, start_output_recovery, poll_job(job_id, after_seq), cancel_job, get/set ui settings (language, theme, skin), get_system_info, detect_sweep, generate_sweep_set, open_path, check_for_updates, start_update, apply_pending_update, select_file, select_directory, open_url.
+
+Shipped as (a) a PyPI wheel (`pip install impulcifer-py313`, console scripts impulcifer / impulcifer_gui / impulcifer_webview) and (b) Nuitka standalone builds for Windows (Velopack installer and in-app updater), macOS (dmg) and Linux (AppImage + tarball, plus a community AUR package), all built in GitHub Actions from E:/Impulcifer/.github/workflows/publish.yml. The maintainer has spent a lot of effort fighting Nuitka/pywebview packaging drift (plugin whitelist patches, dependency version breakage, free-threaded Python status) and this pain is one motivation for the rewrite.
+
+The maintainer wants to decide what to REWRITE it in: language, GUI shell and architecture. Windows is the primary platform, macOS second, Linux lowest priority ("Linux can fend for itself"). The maintainer already proposed three candidate stacks and wants unlisted alternatives evaluated too. The maintainer works alone and drives development with AI coding agents, so "verifiability by tests", "quality of documentation an LLM can draw on" and "ecosystem stability" matter more than typing speed.
+
+## Hard requirements the new stack must satisfy
+
+R1 Audio I/O: enumerate devices grouped by host API (Windows: MME / DirectSound / WASAPI, ideally ASIO; macOS CoreAudio; Linux ALSA / PulseAudio / JACK). Open an OUTPUT stream with up to 16 float32 channels at 44.1 / 48 / 96 kHz and play a buffer to completion (blocking), while an INPUT stream records 2 channels. The current code uses TWO independent streams (a playback stream in the main thread, a recording stream started in a separate thread), not one duplex stream; alignment is recovered later by sweep detection. Low latency is NOT needed. See E:/Impulcifer/core/recorder.py.
+
+R2 DSP primitives used today (scipy names): rfft / irfft / fft, next_fast_len; fftconvolve / convolve; correlate + correlation_lags; butter + sosfilt (IIR second-order sections); firwin2 (frequency-sampling FIR design); minimum_phase (homomorphic / cepstral); savgol_filter; find_peaks; windows (hann / kaiser / get_window); ndimage.uniform_filter; InterpolatedUnivariateSpline with k=1 and k=3 on a log10 frequency axis; scipy.optimize.least_squares with bounds (Trust Region Reflective; used by the AutoEQ peaking-biquad fit in E:/Impulcifer/autoeq/frequency_response.py lines 350-520); stats.linregress; special.expit; signal.spectrogram; polyphase rational resampling (the nnresample package: Kaiser-windowed FIR, resample_poly-like); RBJ biquad peaking / shelf coefficients (E:/Impulcifer/autoeq/biquad.py and E:/Impulcifer/core/eqapo.py). All in float64.
+
+R3 Outputs: multi-track WAV (32-bit float, up to 32 tracks), PNG plots (frequency response, impulse response, spectrogram, waterfall, decay), interactive HTML analysis (Bokeh today: interaural overlay, ILD, IPD, IACC layouts), CSV/TXT.
+
+R4 Long-running jobs (10 seconds to several minutes) with progress events, log lines and cooperative cancellation. The UI polls a job with a sequence cursor (start_brir / poll_job / cancel_job in the service).
+
+R5 Native file and directory dialogs, open-path, open-url, dark title bar, theme / skin / language switch at runtime, a system-info page.
+
+R6 Packaging: installers for Windows (must keep an in-app auto-updater; Velopack today), macOS dmg (notarization optional), Linux AppImage (nice-to-have). CI on GitHub Actions for 3 platforms. A CLI entry point must remain for headless batch use. Keeping a `pip install`-able PyPI distribution of the DSP core is a strong plus but not mandatory.
+
+R7 External helper: ffmpeg / ffprobe are downloaded at runtime to decode TrueHD/MLP (.mlp) sweep files; this stays an external binary.
+
+R8 Parallelism: the pipeline parallelises per-speaker work (today through free-threaded Python 3.13t/3.14t threads or process pools). A compiled language gets this for free, but the design must still allow it.
+
+R9 Numerical parity: today CI checks that the BRIR output is byte-identical to master (SHA-256 of hesuvi.wav). A rewrite in another language cannot be bit-exact against numpy/scipy. The research must say what parity strategy is realistic (tolerance-based comparison, per-stage golden files and so on).
+
+## The maintainer's own candidate stacks (evaluate them, do not assume them)
+
+S1 Rust + Tauri 2 (webview shell; "Linux can fend for itself").
+S2 C++ + Electron (the maintainer's argument: the Python/Nuitka build is already heavy, so Electron's weight is a wash).
+S3 Go + Wails (the frontend stays vanilla JS like today, no node_modules at runtime, only a type check in CI).
+
+## Rules for your work
+
+- Verify anything you are not certain about with WebSearch and WebFetch. Cite the URL for every non-trivial claim. Prefer primary sources (project docs, GitHub issues / releases / changelogs). Note the version number and the date you saw it.
+- Mark each claim as (a) verified with URL, (b) inference, or (c) unknown / could not verify. Never present an inference as a fact.
+- Do not be diplomatic. If something is a bad fit, say so and why. If two options are genuinely equal, say that.
+- Read files under E:/Impulcifer when the brief points you to them (Read / Grep / Glob). Never edit them.
+- Work in English. Be dense: tables over prose where possible. No filler, no restating the brief.
+- The report must have these sections in this order: 1 Verdict (10 lines max), 2 Findings (with sources), 3 Proposed architecture (if your dimension asks for one), 4 Risks ranked, 5 Open questions you could not settle, 6 Sources (numbered URL list).
+- When done, write the full report to the report path with the Write tool, then print the single line DONE followed by a 10-line executive summary on stdout. Do not finish before the report file exists.
+
+## Decisions already taken (2026-09-07), which your research must build on
+
+The stack study is finished. Its reports live in E:/Impulcifer/docs/research/rewrite-stack-2026-09/ (read 00-synthesis.md, 01-windows-audio-api.md, 02-cpal-vs-portaudio.md and report-01-audio-io.md, report-03-rust-tauri.md at least). The provisional target is:
+
+- Rust core + Tauri 2 shell, keeping the existing vanilla HTML/CSS/JS frontend and the JSON i18n catalogues.
+- Audio: Windows uses WASAPI only (no ASIO, no DirectSound/MME) through the pure-Rust `wasapi` crate (HEnquist wasapi-rs 0.24.0); macOS/Linux use `cpal` 0.18.2. PortAudio is dropped. Playback is "play a whole buffer to completion, then drain"; capture is a separate 2-channel input stream started first; low latency is not needed.
+- DSP: float64 everywhere; RustFFT/RealFFT; ndarray or nalgebra; rayon for per-speaker parallelism; hand-written SciPy-compatible primitives (firwin2, minimum_phase, FITPACK-style splines, Savitzky-Golay, Kaiser polyphase resampling, SOS filters, find_peaks) and possibly a bounded least-squares solver later.
+- I/O: WAV read/write (hound or a custom writer for 32-track files), ffmpeg/ffprobe as external processes, PNG plots (plotters), offline HTML reports (vendored Plotly.js), JSON settings.
+- Python: a PyO3 + maturin wheel exposing the DSP core so `pip install impulcifer-py313` survives; Velopack Rust SDK for the Windows updater; Tauri updater on macOS/Linux.
+- The maintainer's explicit goal for this research: **write zero `unsafe` in our own crates if at all possible.** If some `unsafe` is unavoidable, it must be quarantined in a small, separately reviewed leaf crate behind a sound safe API, the way Tauri keeps platform code inside wry/tao, so that every application crate can carry `#![forbid(unsafe_code)]`.
+
+## Your dimension: where does `unsafe` unavoidably appear in this Rust stack, and can OUR crates stay at zero
+
+Produce an exhaustive inventory. For every capability the product needs, say (a) whether a safe API exists in a maintained crate, (b) whether that crate is itself unsafe-free or contains audited unsafe, (c) whether OUR code would need any `unsafe` to use it, and (d) the fallback if the safe API is missing. Verify each claim against the crate's current source or docs (WebFetch raw GitHub files or docs.rs), and record the crate version you looked at.
+
+Capabilities to cover, at minimum:
+1. WASAPI capture and render through `wasapi` (wasapi-rs 0.24.0): is its public API entirely safe? Look at AudioClient::initialize_client, get_audiorenderclient / get_audiocaptureclient, read/write of the buffer (does it hand out `&[u8]`/`&mut [u8]` safely, or raw pointers?), event handles (`Handle`, WaitForSingleObject), device enumeration (DeviceCollection, IMMDevice), COM initialisation (`initialize_mta`/`initialize_sta`) and the STA/MTA threading rules when the Tauri main thread (STA) and a worker thread both touch audio. Does `wasapi` use `unsafe` internally on every COM call (windows-rs makes COM calls `unsafe fn`)? Count them with the source or cargo-geiger output if available.
+2. cpal 0.18.2 for macOS CoreAudio and Linux ALSA: is the public API safe? Where is its internal unsafe (coreaudio-rs, alsa-sys FFI)? Any known soundness issues (RUSTSEC advisories, open issues mentioning UB, data races in callbacks)?
+3. If a needed WASAPI feature were missing from wasapi-rs, using `windows` 0.62 directly: every COM method is `unsafe`; how much unsafe would a minimal exclusive-mode render+capture path need (estimate lines), and can it be confined to one module?
+4. RustFFT 6.4.1 / RealFFT 3.5.0: safe public API; internal SIMD unsafe (AVX/NEON) and its runtime detection; `#![forbid(unsafe_code)]` compatibility for the caller.
+5. ndarray 0.17 / nalgebra 0.35: safe API for our use (slicing, views, axis iteration, `par_azip`/rayon integration); do we ever need `uninit` or raw pointer constructs for performance? State whether `Vec<f64>` plus safe slicing suffices.
+6. rayon 1.x: safe by construction; note determinism concerns for reductions (not unsafe, but relevant).
+7. WAV I/O: hound 3.5.1 safety; writing 30/32-track float WAV; memory-mapped reads (memmap2 requires `unsafe` for `Mmap::map`) versus plain `std::fs::read` for files of at most a few hundred MB. Recommend the safe option.
+8. Process spawning of ffmpeg/ffprobe: std::process::Command is safe; note Windows-specific concerns (CREATE_NO_WINDOW needs `std::os::windows::process::CommandExt::creation_flags`, which is safe).
+9. Tauri 2 host code: are `#[tauri::command]`, window theming (`WebviewWindow::set_theme`), dialogs (tauri-plugin-dialog), opener, updater (tauri-plugin-updater) all safe APIs? Does Tauri's own crate (not wry/tao) contain unsafe? Where does raw window-handle unsafe live (raw-window-handle, wry, tao)? Is a dark title bar on Windows achievable without our own DWM call (DwmSetWindowAttribute via windows-rs would be unsafe)?
+10. PyO3 0.27/0.29 + numpy crate: the safe surface for accepting NumPy float64 arrays (`PyReadonlyArray1<f64>::as_slice()` is safe; `as_slice_mut`/`as_array_mut` rules; `Bound<PyArray>` uninit constructors like `PyArray::new` are `unsafe`). Which constructors/copies keep us unsafe-free (`PyArray::from_vec`, `from_slice`)? Also `Python::detach`/`allow_threads` safety.
+11. Velopack Rust SDK 1.2.0: safe API? Any FFI inside?
+12. SIMD for DSP hot loops: does autovectorisation with safe iterators suffice, or would `std::arch` intrinsics (unsafe) or `wide`/`pulp`/`portable-simd` (nightly) be needed? Recommend a policy.
+13. Real-time audio callback constraints (no allocation, no locks): which safe lock-free crates (ringbuf 0.4, rtrb, crossbeam) are unsafe internally but audited; do we need any unsafe to use them.
+14. Anything else you find: `static mut`, global state, FFI for font enumeration in plotters, Windows named pipes, shared memory for IPC (not planned, but say whether avoiding it keeps us safe).
+
+Deliver: (1) a table capability -> crate/version -> our-code unsafe needed? (yes/no/only-if) -> crate's internal unsafe and audit status -> fallback; (2) a clear verdict: can every application crate be `#![forbid(unsafe_code)]` with the chosen dependencies; (3) the short list of places where unsafe would leak into our code and exactly why; (4) risks ranked; (5) open questions; (6) sources.
+
+Report path: E:/Impulcifer/docs/research/rewrite-stack-2026-09/report-10-rust-unsafe-inventory.md
+Write the report ONLY to that exact path (create it with the Write tool). Do not write to any other location.

--- a/docs/research/rewrite-stack-2026-09/brief-11-rust-unsafe-quarantine.md
+++ b/docs/research/rewrite-stack-2026-09/brief-11-rust-unsafe-quarantine.md
@@ -1,0 +1,78 @@
+# Impulcifer rewrite research - shared context (read this first, then your dimension below)
+
+Date: 2026-09-07. You are a research analyst working for the maintainer of an open-source audio tool.
+You are NOT allowed to modify any file under E:/Impulcifer. The only file you may write is the report path named at the end of this brief.
+
+## The project
+
+Impulcifer-py313 (repository root: E:/Impulcifer) is a desktop audio-DSP tool. It plays logarithmic sine sweeps through 1 to 16 loudspeakers, records them with binaural in-ear microphones (2-channel input), deconvolves the recordings into HRIR/BRIR impulse responses, then applies room correction, headphone compensation, parametric EQ (a vendored AutoEQ port with a bounded least-squares biquad fit), virtual bass, microphone-deviation correction and decay shaping, and writes multi-track WAV files for HeSuVi, Hangloose, EqualizerAPO and JamesDSP. It also writes analysis PNGs (matplotlib + seaborn + Pillow) and interactive Bokeh HTML reports.
+
+Size: about 23k lines of Python on numpy/scipy. Nine-language i18n (433 keys per JSON catalogue in E:/Impulcifer/i18n/locales). A vanilla HTML/CSS/JS frontend with no bundler and no node_modules (E:/Impulcifer/webview_ui: app.js 1487 lines, index.html 730, styles.css 743) hosted in pywebview (WebView2 on Windows, WKWebView on macOS, WebKitGTK on Linux), plus a CustomTkinter fallback GUI that will be frozen, and a CLI. The frontend talks to a JSON application service (E:/Impulcifer/application/impulcifer_service.py) with about 22 methods: bootstrap, list_audio_devices, start_recording, start_brir, start_output_recovery, poll_job(job_id, after_seq), cancel_job, get/set ui settings (language, theme, skin), get_system_info, detect_sweep, generate_sweep_set, open_path, check_for_updates, start_update, apply_pending_update, select_file, select_directory, open_url.
+
+Shipped as (a) a PyPI wheel (`pip install impulcifer-py313`, console scripts impulcifer / impulcifer_gui / impulcifer_webview) and (b) Nuitka standalone builds for Windows (Velopack installer and in-app updater), macOS (dmg) and Linux (AppImage + tarball, plus a community AUR package), all built in GitHub Actions from E:/Impulcifer/.github/workflows/publish.yml. The maintainer has spent a lot of effort fighting Nuitka/pywebview packaging drift (plugin whitelist patches, dependency version breakage, free-threaded Python status) and this pain is one motivation for the rewrite.
+
+The maintainer wants to decide what to REWRITE it in: language, GUI shell and architecture. Windows is the primary platform, macOS second, Linux lowest priority ("Linux can fend for itself"). The maintainer already proposed three candidate stacks and wants unlisted alternatives evaluated too. The maintainer works alone and drives development with AI coding agents, so "verifiability by tests", "quality of documentation an LLM can draw on" and "ecosystem stability" matter more than typing speed.
+
+## Hard requirements the new stack must satisfy
+
+R1 Audio I/O: enumerate devices grouped by host API (Windows: MME / DirectSound / WASAPI, ideally ASIO; macOS CoreAudio; Linux ALSA / PulseAudio / JACK). Open an OUTPUT stream with up to 16 float32 channels at 44.1 / 48 / 96 kHz and play a buffer to completion (blocking), while an INPUT stream records 2 channels. The current code uses TWO independent streams (a playback stream in the main thread, a recording stream started in a separate thread), not one duplex stream; alignment is recovered later by sweep detection. Low latency is NOT needed. See E:/Impulcifer/core/recorder.py.
+
+R2 DSP primitives used today (scipy names): rfft / irfft / fft, next_fast_len; fftconvolve / convolve; correlate + correlation_lags; butter + sosfilt (IIR second-order sections); firwin2 (frequency-sampling FIR design); minimum_phase (homomorphic / cepstral); savgol_filter; find_peaks; windows (hann / kaiser / get_window); ndimage.uniform_filter; InterpolatedUnivariateSpline with k=1 and k=3 on a log10 frequency axis; scipy.optimize.least_squares with bounds (Trust Region Reflective; used by the AutoEQ peaking-biquad fit in E:/Impulcifer/autoeq/frequency_response.py lines 350-520); stats.linregress; special.expit; signal.spectrogram; polyphase rational resampling (the nnresample package: Kaiser-windowed FIR, resample_poly-like); RBJ biquad peaking / shelf coefficients (E:/Impulcifer/autoeq/biquad.py and E:/Impulcifer/core/eqapo.py). All in float64.
+
+R3 Outputs: multi-track WAV (32-bit float, up to 32 tracks), PNG plots (frequency response, impulse response, spectrogram, waterfall, decay), interactive HTML analysis (Bokeh today: interaural overlay, ILD, IPD, IACC layouts), CSV/TXT.
+
+R4 Long-running jobs (10 seconds to several minutes) with progress events, log lines and cooperative cancellation. The UI polls a job with a sequence cursor (start_brir / poll_job / cancel_job in the service).
+
+R5 Native file and directory dialogs, open-path, open-url, dark title bar, theme / skin / language switch at runtime, a system-info page.
+
+R6 Packaging: installers for Windows (must keep an in-app auto-updater; Velopack today), macOS dmg (notarization optional), Linux AppImage (nice-to-have). CI on GitHub Actions for 3 platforms. A CLI entry point must remain for headless batch use. Keeping a `pip install`-able PyPI distribution of the DSP core is a strong plus but not mandatory.
+
+R7 External helper: ffmpeg / ffprobe are downloaded at runtime to decode TrueHD/MLP (.mlp) sweep files; this stays an external binary.
+
+R8 Parallelism: the pipeline parallelises per-speaker work (today through free-threaded Python 3.13t/3.14t threads or process pools). A compiled language gets this for free, but the design must still allow it.
+
+R9 Numerical parity: today CI checks that the BRIR output is byte-identical to master (SHA-256 of hesuvi.wav). A rewrite in another language cannot be bit-exact against numpy/scipy. The research must say what parity strategy is realistic (tolerance-based comparison, per-stage golden files and so on).
+
+## The maintainer's own candidate stacks (evaluate them, do not assume them)
+
+S1 Rust + Tauri 2 (webview shell; "Linux can fend for itself").
+S2 C++ + Electron (the maintainer's argument: the Python/Nuitka build is already heavy, so Electron's weight is a wash).
+S3 Go + Wails (the frontend stays vanilla JS like today, no node_modules at runtime, only a type check in CI).
+
+## Rules for your work
+
+- Verify anything you are not certain about with WebSearch and WebFetch. Cite the URL for every non-trivial claim. Prefer primary sources (project docs, GitHub issues / releases / changelogs). Note the version number and the date you saw it.
+- Mark each claim as (a) verified with URL, (b) inference, or (c) unknown / could not verify. Never present an inference as a fact.
+- Do not be diplomatic. If something is a bad fit, say so and why. If two options are genuinely equal, say that.
+- Read files under E:/Impulcifer when the brief points you to them (Read / Grep / Glob). Never edit them.
+- Work in English. Be dense: tables over prose where possible. No filler, no restating the brief.
+- The report must have these sections in this order: 1 Verdict (10 lines max), 2 Findings (with sources), 3 Proposed architecture (if your dimension asks for one), 4 Risks ranked, 5 Open questions you could not settle, 6 Sources (numbered URL list).
+- When done, write the full report to the report path with the Write tool, then print the single line DONE followed by a 10-line executive summary on stdout. Do not finish before the report file exists.
+
+## Decisions already taken (2026-09-07), which your research must build on
+
+The stack study is finished. Its reports live in E:/Impulcifer/docs/research/rewrite-stack-2026-09/ (read 00-synthesis.md, 01-windows-audio-api.md, 02-cpal-vs-portaudio.md and report-01-audio-io.md, report-03-rust-tauri.md at least). The provisional target is:
+
+- Rust core + Tauri 2 shell, keeping the existing vanilla HTML/CSS/JS frontend and the JSON i18n catalogues.
+- Audio: Windows uses WASAPI only (no ASIO, no DirectSound/MME) through the pure-Rust `wasapi` crate (HEnquist wasapi-rs 0.24.0); macOS/Linux use `cpal` 0.18.2. PortAudio is dropped. Playback is "play a whole buffer to completion, then drain"; capture is a separate 2-channel input stream started first; low latency is not needed.
+- DSP: float64 everywhere; RustFFT/RealFFT; ndarray or nalgebra; rayon for per-speaker parallelism; hand-written SciPy-compatible primitives (firwin2, minimum_phase, FITPACK-style splines, Savitzky-Golay, Kaiser polyphase resampling, SOS filters, find_peaks) and possibly a bounded least-squares solver later.
+- I/O: WAV read/write (hound or a custom writer for 32-track files), ffmpeg/ffprobe as external processes, PNG plots (plotters), offline HTML reports (vendored Plotly.js), JSON settings.
+- Python: a PyO3 + maturin wheel exposing the DSP core so `pip install impulcifer-py313` survives; Velopack Rust SDK for the Windows updater; Tauri updater on macOS/Linux.
+- The maintainer's explicit goal for this research: **write zero `unsafe` in our own crates if at all possible.** If some `unsafe` is unavoidable, it must be quarantined in a small, separately reviewed leaf crate behind a sound safe API, the way Tauri keeps platform code inside wry/tao, so that every application crate can carry `#![forbid(unsafe_code)]`.
+
+## Your dimension: an architecture that quarantines unavoidable `unsafe`, and the tooling that enforces it
+
+Assume the inventory in the sibling brief finds a few unavoidable unsafe spots (most likely: direct COM calls if wasapi-rs lacks something, PyO3 array constructors, a DWM call, SIMD intrinsics). Design how this workspace keeps them contained, and research how mature Rust projects do it. Verify each pattern against real source or docs and cite it.
+
+1. Study and document the quarantine patterns of: Tauri 2 (which crates hold platform unsafe: wry, tao, tauri-runtime-wry; how tauri itself and application code stay safe; use of `raw-window-handle`), windows-rs (unsafe fn on every COM call; how wrapper crates such as wasapi-rs expose a safe layer; `windows::core::Interface` and lifetime/ownership of COM pointers), PyO3 (how `Bound<T>` and `Python<'py>` tokens make the API safe; where `unsafe` remains and how they document it), cpal (its host modules and the `Device`/`Stream` safe boundary), and one DSP-heavy crate such as rustfft (SIMD unsafe under `#[target_feature]` with runtime detection; how it stays sound). Extract the recurring design rules.
+2. Write the soundness rules for a safe wrapper: invariants, `// SAFETY:` comments, `unsafe fn` versus `unsafe` block, `#![deny(unsafe_op_in_unsafe_fn)]`, `#![forbid(unsafe_code)]` at crate level, encapsulation of raw pointers in newtypes with Drop, Send/Sync reasoning for COM objects (apartment threading), and the Rustonomicon guidance on which invariants must hold. Quote sources.
+3. Propose the concrete workspace layout for Impulcifer with an explicit unsafe budget per crate: which crates are `forbid(unsafe_code)`, which single leaf crate (name it, e.g. `impulcifer-sys-win`) may hold unsafe, its public API sketch (safe types only: owned buffers, `&mut [f32]`, enums, `Result`), its review rules, and how the audio-io crate, the DSP crate, the Tauri app crate, the CLI crate and the PyO3 crate sit relative to it. Show a dependency diagram. State how a contributor or an AI coding agent is prevented from adding unsafe elsewhere (lint config + CI).
+4. Enforcement tooling, verified as of 2026-09: `cargo-geiger` (status: maintained? works on current toolchains?), `cargo-deny` (advisories, licenses, bans), `cargo-audit`, `cargo-vet` and `cargo-crev` (supply-chain review of the unsafe in dependencies), clippy lints `clippy::undocumented_unsafe_blocks`, `clippy::multiple_unsafe_ops_per_block`, `clippy::missing_safety_doc`, rustc lint `unsafe_op_in_unsafe_fn` (default level in edition 2024?), `#![forbid(unsafe_code)]`, Miri (what it can and cannot check for FFI/COM code), sanitizers (ASan/TSan on nightly), Kani or Verus (optional formal checks; scope realistic for a solo maintainer), `cargo +nightly -Zbuild-std`? (probably not). Give the exact CI job list with commands and a rough runtime.
+5. Dependency policy: how to choose crates by unsafe footprint (cargo-geiger counts, `#![forbid(unsafe_code)]` badges, RUSTSEC history), pinning and vetting workflow, and what to do when a needed crate has unaudited unsafe (vendor + review, or write the safe wrapper ourselves).
+6. Edition and toolchain: Rust 2024 edition defaults relevant to unsafe (`unsafe_op_in_unsafe_fn` warn-by-default, `unsafe extern` blocks, `#[unsafe(no_mangle)]`), MSRV policy, and whether `-Zmiri` or sanitizer runs need nightly in CI.
+7. Explain briefly what "quarantine like Tauri" buys and costs for a one-maintainer project driven by AI coding agents: review load, build time, and the failure mode where agents copy unsafe from examples.
+
+Deliver: (1) pattern catalogue with sources; (2) the workspace layout and unsafe budget table; (3) the CI gate list with commands; (4) a one-page "unsafe policy" the maintainer can paste into CONTRIBUTING/CLAUDE.md; (5) risks ranked; (6) open questions; (7) sources.
+
+Report path: E:/Impulcifer/docs/research/rewrite-stack-2026-09/report-11-rust-unsafe-quarantine.md
+Write the report ONLY to that exact path (create it with the Write tool). Do not write to any other location.

--- a/docs/research/rewrite-stack-2026-09/report-10-rust-unsafe-inventory.md
+++ b/docs/research/rewrite-stack-2026-09/report-10-rust-unsafe-inventory.md
@@ -1,0 +1,424 @@
+# Rust unsafe inventory for the Impulcifer rewrite
+
+Observed **2026-09-07**. Target: the later decision, **Rust + Tauri 2; Windows `wasapi`; macOS/Linux CPAL**, not the superseded PortAudio recommendation in the original synthesis.
+
+**[V]** = verified in cited source/docs/upstream test definitions or identified local files. **[I]** = inference, recommendation, estimate. **[U]** = unresolved. A safe function signature is not a soundness proof. “Audit unverified” means no applicable independent audit was established, not that none exists. Versions are those inspected, not necessarily the newest releases. This was source research, not a build, hardware test, exhaustive dependency audit, or execution of UB reproducers.
+
+## 1 Verdict
+
+1. **[I] Yes: every application crate can reasonably retain `#![forbid(unsafe_code)]`, including DSP, audio orchestration, Tauri, CLI, and PyO3. No required capability inherently demands handwritten application `unsafe`.**
+2. **[V] The dependency graph and generated code are not unsafe-free.** Native APIs, FFT/SIMD, array storage, queues, Python, webviews, and updater implementations contain unsafe operations. [1–27, 30–48]
+3. **[V] `wasapi` 0.24.0 is not entirely safe to use indiscriminately:** `Device::from_raw` is explicitly unsafe; safe `WaveFormat::parse(&WAVEFORMATEX)` permits an out-of-bounds read. [2–4]
+4. **[V] `coreaudio-rs` 0.14.2 exposes an unsound safe raw-pointer constructor.** Normal CPAL use reaching that defect was not demonstrated. [13]
+5. **[I] Accept the zero-handwritten-unsafe architecture, not an “audited dependencies” claim.** Audio dependencies need focused review, defective-API exclusion or upstream fixes, and hardware gates.
+6. **[V] PyO3 0.27.0/0.29.0 have upstream forbid-unsafe compile-pass fixtures including module exports.** Their generated FFI remains unsafe internally. [40–42]
+7. **[I] Prefer owned buffers, safe copies, dedicated audio threads, checked lengths, and ordinary file reads; reject premature raw pointers, mmap, custom SIMD, and shared memory.**
+8. **[I] If missing native functionality truly requires direct Win32 calls, use one reviewed leaf-crate exception.** That preserves zero unsafe in application crates, but not zero unsafe in *all owned crates*.
+9. **[U] The complete selected feature/target/Python-ABI matrix has not been compiled under the lint.** Source feasibility is not an accomplished build gate.
+
+## 2 Findings (with sources)
+
+### 2.1 Scope, local evidence, and what the lint means
+
+**[V, local]** Read `00-synthesis.md`, `01-windows-audio-api.md`, `02-cpal-vs-portaudio.md`, `report-01-audio-io.md`, and `report-03-rust-tauri.md`. Also inspected `core/recorder.py:260–549`, `autoeq/frequency_response.py:350–524`, `autoeq/biquad.py:1–120`, and `core/eqapo.py:1–140`. The current recorder starts a recording thread at lines 514–519 and invokes blocking playback at 539; the new implementation must preserve the blocking session contract with separate stream owners. The optimizer actually calls bounded `least_squares` at line 495. Earlier reports' line numbers and DirectSound-first descriptions predate the current WASAPI change. These local files are context, not independent proof of Rust API safety.
+
+**[V]** `unsafe_code` checks unsafe blocks/functions/implementations and potentially unsound attributes such as `no_mangle`, `export_name`, and `link_section`. Applying it to an application crate does not ban unsafe inside separately compiled dependencies. External macro spans also have diagnostic exemptions; PyO3's tests demonstrate why generated unsafe can coexist with the lint. [1, 40–42]
+
+| Statement | Judgment |
+|---|---|
+| All handwritten application Rust can forbid unsafe | **[I] Feasible**, subject to the chosen API restrictions and build gates. |
+| The resulting executable contains no unsafe implementation | **[V] False.** Dependencies, macro-generated FFI, standard library, native libraries, and OS/browser components remain trusted. |
+| Pure Rust means no FFI | **[V] False.** `wasapi` calls Windows COM; CPAL calls Apple and ALSA APIs. [2, 11–13] |
+| A `SAFETY:` comment, tests, Miri, or popularity constitutes an independent audit | **[I] Reject this terminology.** They are different evidence. |
+| Moving unsafe to our own leaf crate achieves zero unsafe in all our crates | **[V] False by definition.** It meets only the explicitly allowed application/leaf separation. |
+| Safe Rust eliminates all security/reliability bugs | **[V] False.** Unsafe dependencies can be unsound; safe code can mishandle permissions, allocation, cancellation, and numerical semantics. [3, 13, 28–29, 39, 44] |
+
+### 2.2 Capability inventory
+
+**Table convention:** API and internal-source cells marked [V] are verified. “No” means no handwritten unsafe is necessary for the prescribed caller path, not that every API in that crate is safe. Unless a row says otherwise, **independent audit coverage for that exact version is [U]**. Release existence is verified; sustained maintenance commitments are addressed separately in §2.11.
+
+| Capability | Crate/version inspected; safe caller path | Our unsafe? | Internal unsafe / audit evidence | Fallback or restriction [I] |
+|---|---|---|---|---|
+| Windows endpoint enumeration, names/IDs, format probes | **[V] wasapi 0.24.0**: `DeviceEnumerator::new`, `get_device_collection`, iterator, `get_device`, `Device::get_id`, `get_iaudioclient` [2–5] | **No** | COM/PROPVARIANT/pointer handling. Safe `WaveFormat::parse` defect; explicit unsafe `Device::from_raw`. No independent audit verified. | Do not expose raw device/format constructors. Exchange owned IDs; enumerate on an audio thread. |
+| WASAPI shared/exclusive render | **[V] wasapi 0.24.0**: `initialize_client`, render-client getter, `write_to_device(...,&[u8],...)`, start/stop/padding/clock [2, 5] | **No** | Native `GetBuffer`/`ReleaseBuffer`, internal mutable raw slice, narrowing arithmetic. | Checked frame/byte counts; preallocated bytes; bounded writes. Direct Win32 only after demonstrated gap. |
+| WASAPI stereo capture | **[V] wasapi 0.24.0**: capture-client getter, `read_from_device(&mut [u8]) -> (u32, BufferInfo)` [2, 5] | **No at call site** | Internal raw slice; SILENT flag is returned but not handled before copying. Conditional soundness concern, §2.3. | Review/fix dependency silence handling; do not claim a post-copy zero-fill prevents internal invalid reads. |
+| COM initialization and event waits | **[V] wasapi 0.24.0**: `initialize_mta/sta`, `deinitialize`, `Handle::wait_for_event` [2, 5–7] | **No** | CoInitializeEx/CoUninitialize, CreateEvent/WaitForSingleObject/CloseHandle. Safe API does not encode apartment lifetime. | Private non-Send COM guard and lexical ownership, finite waits, no COM objects crossing threads. |
+| Direct native fallback | **[V] windows 0.62.2**, Windows audio COM methods [10] | **Yes if used directly** | Generated unsafe COM calls; safe Clone/cast/value helpers do not make audio calls safe. | Upstream safe wrapper fix first; otherwise separate reviewed leaf exception. |
+| macOS capture/render | **[V] cpal 0.18.2 → coreaudio-rs 0.14.2 → objc2-* 0.3 family** [11–13] | **No** | Native callbacks, AudioBufferList pointers, property reads, unsafe Send. CoreAudio wrapper safe-API defect, §2.4. | Use CPAL typed builders only; do not use coreaudio raw helpers directly. |
+| Linux ALSA capture/render | **[V] cpal 0.18.2 → alsa 0.11.0 → alsa-sys 0.4.0**, as in CPAL's packaged lock [11–12] | **No** | libasound C ABI, raw audio buffers, libc self-pipe/thread teardown; explicit unsafe Sync in backend. | ALSA defaults first. Additional JACK/PulseAudio/PipeWire features require their own resolved-graph review. |
+| Complex/real FFT, convolution/correlation building blocks | **[V] RustFFT 6.4.1 / RealFFT 3.5.0**, safe planners and scratch APIs [15–16] | **No** | SIMD/raw-pointer implementations; RealFFT's inspected `lib.rs` has two explicit unsafe blocks. Miri fix in earlier RealFFT 3.4.0, not independent audit. | Standard planner plus reusable initialized buffers; scalar planner for diagnostic comparison. |
+| Multidimensional arrays/views/parallel axes | **[V] ndarray 0.17.2**, slicing, `AxisIterMut`, `par_azip!`, `rayon` feature [17] | **No** | Raw views, pointer offsets, storage invariants internally. | Safe constructors and checked views only; `Vec<f64>` sufficient for ordinary DSP buffers. |
+| Matrix algebra / spline/fit linear solves | **[V] nalgebra 0.35.0**, initialized matrices and safe operations [18] | **No** | Unsafe storage traits, uninitialized allocation, pointer conversions. Historical serde issue fixed before this version. [29] | Do not use raw storage, unchecked indexing, or uninitialized output APIs. |
+| Per-speaker jobs and parallelism | **[V] rayon 1.11.0 / rayon-core 1.13.0**, parallel iterators and scoped work [19] | **No** | Type-erased jobs, unsafe Send/Sync, raw Box/Arc, UnsafeCell. | Collect in fixed speaker order; serial global reductions; never run Rayon jobs from audio callbacks. |
+| SciPy-compatible primitives not supplied by crates | **[I] Owned f64 Rust algorithms**, §2.6; safe slices, numeric methods, FFT, matrices [15–19, 49] | **No inherent need** | Our implementation can be unsafe-free; dependencies are not. No TRF-equivalent solver qualified here. | Port semantics explicitly; keep optional optimizer on Python until qualified if necessary. |
+| WAV input and 30/32-track float32 output | **[V] hound 3.5.1**, `WavReader`, `WavWriter::write_sample`, u16 channels [20] | **No** | Internal transmute/uninitialized storage/unchecked optimized writer operations. Maintenance uncertain; last publication 2023-09-25. | Custom **safe** RIFF writer if default channel mask is unacceptable; explicit format tests. |
+| File loading instead of mapping | **[V] std file/read/buffer APIs**; **memmap2 0.9.9** file-map APIs are unsafe [21, 49] | **No for reads; yes for file mmap** | mmap validity depends on external file mutation/truncation. Read-only and COW do not remove obligation. | Ordinary bounded reads/streaming for files of a few hundred MB. No mmap needed. |
+| Audio bytes / numeric conversion | **[V] std `to_le_bytes/from_le_bytes`; bytemuck 1.25.2 checked slice casts** [49–50] | **No** | bytemuck internal pointer casts; manual `Pod` implementation is unsafe. | std conversion first; checked casts only for built-in primitive types and known endianness/alignment. |
+| PNG plots and font handling | **[V] Plotters 0.3.7**, bitmap output, safe font registration [22] | **No** | Default ttf backend includes lifetime transmute and native font-kit services. `ab_glyph` implementation file has no unsafe blocks; transitive graph not certified. | Disable default ttf; explicitly select bitmap encoding + ab_glyph, bundle licensed fonts. |
+| Offline HTML / TXT / CSV / settings / i18n | **[V] std writing; serde_json 1.0.151 safe serialization; existing pinned Plotly.js asset policy** [51, local research] | **No** | serde_json internally uses unchecked UTF-8/pointer operations; browser/Plotly is outside Rust lint. | Escape HTML/script boundaries and CSV fields; isolate reports from privileged Tauri IPC. Plotly release version not re-audited here. |
+| ffmpeg/ffprobe process lifecycle | **[V] std `Command`, args/env/spawn, Child wait/kill; safe Windows `creation_flags`** [48] | **No** | std encapsulates process FFI. FFmpeg is a separate native executable, not Rust-safe. | Absolute executable path and argument array; no shell, pre_exec, raw handle plumbing, or in-process libav FFI. |
+| Helper download/integrity | **[V] reqwest 0.13.4**, bounded chunk reads; **sha2 0.11.0** Digest API [52] | **No** | Network/TLS/OS dependency graph and SHA acceleration contain unsafe/native operations. Exact complete graph/audit unknown. | Pinned hashes/trusted metadata, size bounds, atomic installation; no claim that TLS or SHA alone authenticates an arbitrary feed. |
+| Tauri commands, control IPC, themes | **[V] tauri 2.11.5**, command macros and `WebviewWindow::set_theme` [30–32] | **No** | Tauri itself contains unsafe, not just wry/tao; WebView2/native menu/event handling. Historical Tauri v2 external security audit, not current whole-graph proof. [39] | Standard decorated opaque window, scoped commands; avoid custom DWM/window procedure. |
+| Native titlebar and native handles | **[V] tao 0.35.0** dark-mode helper; **raw-window-handle 0.6.2** [32–33] | **No for theme; only-if raw integration** | Tao calls DwmSetWindowAttribute internally; `WindowHandle::borrow_raw` is unsafe; safe raw-handle access does not license arbitrary native use. | Use Tauri theme API; test Windows high contrast/system theme; no custom titlebar FFI. |
+| Native file/folder dialogs | **[V] tauri-plugin-dialog 2.7.3**, safe file/folder builders [34] | **No** | Plugin `desktop.rs` itself calls unsafe `borrow_raw`; native rfd backend beneath it. | Nonblocking callback API on UI thread; never blocking dialogs on event-loop thread. |
+| Open path / URL / reveal | **[V] tauri-plugin-opener 2.5.5**, safe methods [35] | **No** | Inspected lib.rs has no unsafe blocks; delegated platform code/dependencies are not established unsafe-free. | Keep URL scheme/path policy; do not equate safe Rust with authorization. |
+| macOS/Linux in-app updater | **[V] tauri-plugin-updater 2.11.0**, safe check/download/install [36] | **No** | Plugin has native unsafe Windows installer code even though this product uses it elsewhere; dependency graph not independently audited here. | Use signature-verifying download flow and idle-only apply. One updater per installation. |
+| Windows updater | **[V] velopack 1.2.0**, safe startup/manager APIs [37] | **No** | `process_win.rs` uses unsafe GetCurrentProcess/TerminateProcess. `unsafe_apply_updates` is a **safe fn with an operationally warning name**. | Prefer coordinated exit/apply; startup hook before Tauri. Keep existing package identity. |
+| Python extension / NumPy exchange | **[V] PyO3+numpy 0.27.0 or 0.29.0**, borrow guards, copies, from_vec/from_slice, detach [40–44] | **No on prescribed path** | Generated extern exports, CPython/NumPy C API, raw array/borrow internals. External macros bypass portions of lint diagnostics. | Copy inputs under an explicit synchronization contract, detach on owned data, return new arrays; no borrowed Python memory in jobs. |
+| Optional SIMD hot loops | **[V] wide 0.7.33, pulp 0.21.5**, safe arithmetic/dispatch surfaces [23–24] | **No; only-if direct intrinsics** | Internal SIMD/pointer casts; wide compile-time selection, pulp runtime dispatch; no exact-version independent audit verified. | Auto-vectorization first; safe SIMD only after profiling. Portable SIMD remains nightly experimental. [25] |
+| Real-time SPSC transfer | **[V] ringbuf 0.4.8 / rtrb 0.3.5**, safe push/pop/slice/batch conveniences [26–27] | **No** | Unsafe shared storage/atomic ownership. Manual uninitialized commit/index advance is unsafe. rtrb earlier versions have a 2026 advisory. [28] | Preallocate numeric ring; do not use low-level commit APIs. rtrb >=0.3.5 within 0.3 line. |
+| General queues / logs | **[V] crossbeam 0.8.4, queue 0.3.12, channel 0.5.15** [27–28] | **No** | Unsafe storage/type-erased concurrency; earlier channel double-free fixed in 0.5.15. | Bounded channels off callback; do not assume every nonblocking API is wait-free or allocation-free. |
+| Globals / cancellation / caches | **[V] std OnceLock/LazyLock, Mutex/Arc, atomics** [53] | **No** | std unsafe internally; no need for `static mut` or handwritten Send/Sync. | Explicit owners; atomic cancellation is a request, not forced thread termination. |
+| System information | **[V] sysinfo 0.39.6**, safe System methods [54] | **No** | Windows system implementation calls unsafe GetSystemInfo; no current full audit established. | Use std constants/build metadata where enough; sysinfo only for required richer information. |
+| Optional named pipes | **[V] tokio 1.53.1 Windows named-pipe ServerOptions::create** [55] | **No on basic path** | Native pipe/runtime internals; raw security-attributes constructor is unsafe. | Not required by planned Tauri control IPC; CLI stdio is simpler. |
+| Shared memory / direct FFI / native extensions | **[I] Not needed by selected architecture** | **Only-if introduced** | File/shared mapping, raw callbacks, OS handles demand lifetime/aliasing/security review. | Keep samples in Rust memory; no shared-memory audio transport through the webview. |
+
+### 2.3 WASAPI 0.24.0: safe caller surface, real defects, and COM discipline
+
+#### Public API versus native memory
+
+**[V]** The ordinary API accepts caller-owned byte slices: render consumes `&[u8]`; capture fills `&mut [u8]`. It does **not** lend application code a native `&mut [u8]` whose lifetime the application must manually end. Internally it obtains native pointers, constructs temporary slices, copies, then releases. Deque variants exist but capture may grow the deque and unwrap a ReleaseBuffer failure. Prefer preallocated slice operations. [2, 5]
+
+**[V]** Safe APIs cover requested stream configuration: `StreamMode::{EventsExclusive,PollingExclusive,EventsShared,PollingShared}`; shared variants have `autoconvert`; `WaveFormat::new` accepts channel count and optional mask. `initialize_client` takes `&mut self`; service getters, start, stop, reset, padding, buffer size and audio clock are safe. Returned COM wrappers and Handle are `!Send`/`!Sync` in the inspected docs. [2, 4–5]
+
+**[V]** `Device::from_raw(IMMDevice, Direction)` is `pub unsafe fn`; the caller must ensure actual data-flow direction matches. `from_immdevice` determines it safely. Thus the blanket assertion “every public method is safe” is false even before considering soundness. [2, 4]
+
+#### Source-level soundness defect: safe WaveFormat parser
+
+**[V, source diagnosis; not executed]** `WaveFormat::parse(&WAVEFORMATEX)` is public, exported, and declared safe. At `waveformat.rs:123–137`, when `wFormatTag` is extensible and `cbSize` is at least the structure-size difference, it casts the supplied reference to `*const WAVEFORMATEXTENSIBLE` and reads the larger structure. A standalone initialized WAVEFORMATEX whose fields claim tag extensible and cbSize=22 is still a valid Rust value. Header fields do not prove that additional storage exists. The larger read goes outside that object's allocation. This is an unsound safe API, not merely a malformed-file error. [3–4]
+
+**[V]** `parse_from_blob_bytes(&[u8])` instead checks actual byte length and uses unaligned reads. `get_device_format` uses that byte parser; `get_mixformat` and format negotiation read COM-allocated structures through their own code. The exposed parser defect does not establish that normal device enumeration automatically triggers it. [2–3]
+
+**[I] Policy:** prohibit `WaveFormat::parse` in our adapter and request an upstream fix that changes the contract (unsafe pointer constructor or genuinely length-bounded input). Use validated `new`, validated explicit structures, or the byte parser. Do not import raw Windows format values from arbitrary application input. An upstream review of the other native-format reads remains necessary. A safe wrapper that never calls the defective method reduces exposure; it does not make the dependency globally sound.
+
+#### Capture silence: verified omission, conditional UB concern
+
+**[V]** Both capture methods decode `BufferInfo` and then unconditionally construct a slice and copy native bytes for a nonempty packet; neither checks SILENT before accessing the pointer (`api.rs:1931–2004`). Microsoft requires treating all packet samples as silence and ignoring actual data values when SILENT is set. [2, 8]
+
+**[I]** If the caller records those bytes without replacing them with zeros, signal content can be wrong. If an actual native response supplies null or otherwise invalid/uninitialized storage for such a packet, the wrapper's slice creation/read is invalid before application code receives the flag. That possible memory-safety consequence needs a native-contract/reproduction investigation.
+
+**[U]** The inspected Microsoft GetBuffer page does **not** say SILENT always returns null. Its explicit null discussion concerns `AUDCLNT_E_BUFFER_ERROR`; the official sample sets its own `pData = NULL` after seeing SILENT to tell its sink to synthesize zeros. Do not cite that assignment as proof Windows returned null. No silent-packet UB reproduction was performed. [8]
+
+**[I]** Correct wrapper behavior should branch on SILENT before dereferencing native data and fill initialized destination bytes with zero. Post-copy application zero-filling handles signal semantics only, not the conditional internal invalid-read problem. Require this review before claiming production-ready capture safety.
+
+#### Lengths, lifetimes, and operational errors
+
+| Verified source observation | Consequence / policy [I] |
+|---|---|
+| Render zero-frame writes return early; ordinary writes check byte-slice length, but multiply usize lengths and cast frame count to u32 without checked conversion. [2] | Cap frames by queried capacity and u32 range; checked multiplication. Do not market safe signatures as validation of arbitrary huge requests. |
+| WaveFormat::new computes block alignment/rate and narrows integer fields without complete validation. [3] | Own config validation: channel/rate/container/valid-bit/mask limits, positive values, checked sizes. |
+| Capture too-small destination releases the returned packet and errors. [2] | Allocate for maximum packet, not just an earlier padding snapshot; exclusive capture packet can grow before GetBuffer. [9] |
+| Event creation followed by failed SetEventHandle does not establish Handle ownership first. [2] | Source-visible error-path handle-leak concern; seek upstream fix and test failed initialization. |
+| Handle wait maps all non-success statuses to EventTimeout. [2] | Do not infer every timeout is merely lack of audio; bound retries and propagate terminal device errors. |
+| Safe deinitialize is an unconditional CoUninitialize wrapper with no ownership token. [2] | Private RAII protocol must balance initialization and prevent early teardown. |
+| Service wrappers own COM interfaces but are not Rust-lifetime-borrowed from AudioClient. [2] | No automatic UAF conclusion: COM references own native lifetime. Microsoft says stream lives until audio-client and service references are released. Still drop services before client and COM guard. [8] |
+
+**[V]** Issue #62's “unsafe” 24-bit WAVEFORMATEX fallback concerns format interpretation/noise and underruns; it is not the newly identified parser-overread proof. [6]
+
+#### COM and Tauri STA/MTA rules
+
+**[V]** CoInitializeEx applies to the calling thread. Both S_OK and S_FALSE must be balanced by CoUninitialize; RPC_E_CHANGED_MODE is failure, not permission to continue or tear down someone else's COM initialization. OLE initializes STA; incompatible MTA initialization fails. Microsoft retains a specifically Windows 8 warning that first IAudioClient use should be on STA. This is not a documented blanket ban on MTA audio workers on Windows 10/11. [7]
+
+**[I] Required pattern:**
+
+1. Leave Tauri's main/UI apartment alone. Do not call `initialize_mta` or `deinitialize` there to repurpose it for audio.
+2. On each dedicated audio OS thread, initialize MTA and check HRESULT. Create enumerator, device, AudioClient, services and event there; use and destroy them there.
+3. Send owned IDs, metadata, settings and sample buffers between UI/coordinator/audio threads, never COM wrappers. Even enumeration requested by the UI runs on an audio-management worker.
+4. Use a private COM guard which cannot be sent to another thread (for example a `PhantomData<Rc<()>>` marker). Construct it before nested client owners, and scope/destroy all native owners before its Drop calls safe `wasapi::deinitialize`.
+5. Do not add `unsafe impl Send/Sync` to “fix” a compiler error. Ordinary async jobs can migrate threads; never hold apartment-bound audio state across executor migration. Dedicated threads avoid this problem.
+6. Windows 8 compatibility would need a separate STA-first design/test. It is outside this Windows 10/11 target; do not quietly claim it.
+
+#### Source count, not a geiger certificate
+
+**[V, source-text inventory]** Inspected v0.24.0 files contain the following explicit `unsafe {` sites: `api.rs` **99**, `waveformat.rs` **5**, `events.rs` **15**, of which **5 are tests**. The inspected `lib.rs` and `errors.rs` contain none. This gives **114 production sites and 5 test sites in those files**, plus **one public unsafe function** (`Device::from_raw`); no explicit unsafe impl was found there. [2–3]
+
+`api.rs` subtotal: module helpers 5; DeviceEnumerator 5; device-registration Drop 1; DeviceCollection 3; Device 12; AudioClient 33; session manager/enumerator/control 1/2/8; meter 5; session-registration Drop 1; clock 2; render 6; capture 9; Handle 2; effects 3; AEC 1.
+
+**[U]** These are source-text counts, not executed cargo-geiger/AST counts; exclude macro expansions, dependency source, examples and any uninspected/generated code. A proposed archive-count command did not run because it required approval. Grouping many operations inside one block lowers the count without reducing the proof obligation. All native COM audio calls inspected are inside unsafe blocks, but there is not one block per native call.
+
+### 2.4 CPAL 0.18.2, CoreAudio, ALSA, and soundness history
+
+**[V]** Typed and `*_raw` input/output builders are safe. The raw suffix means runtime sample-format dispatch, not an unsafe pointer requirement. Callbacks require `FnMut + Send + 'static`, not Sync. `Data::bytes/as_slice` and mutable counterparts are safe; `Data::from_parts` is explicitly unsafe and belongs in backend implementation, not application code. Borrowed callback buffers must not escape. [11]
+
+**[V] Version correction:** coreaudio-rs **0.14.2 uses objc2-* 0.3 dependencies, not coreaudio-sys**. CPAL's inspected package resolves ALSA **0.11.0 / alsa-sys 0.4.0**, not latest ALSA 0.12.1. Library package lockfiles are evidence about that package, not the future application's resolution. [11–12]
+
+**[V] Internal implementation:** CoreAudio wraps AudioBufferList pointers, native callbacks/properties and timestamps. ALSA creates worker threads with start/stop coordination, native PCM and libc self-pipe operations, raw-buffer wrapping, and an explicit unsafe Sync implementation relying on ALSA thread safety. Optional realtime features add native scheduling concerns and should not be enabled by habit for a non-low-latency recorder. [12]
+
+**[V, source diagnosis; not executed]** Public safe `coreaudio::audio_unit::render_callback::action_flags::Handle::from_ptr` stores an arbitrary raw pointer; safe `get()` dereferences it internally without a null/lifetime guard. `Handle::from_ptr(std::ptr::null_mut()).get()` is expressible entirely in safe Rust and dereferences null. This is a wrapper API soundness defect. **[U]** Reachability through normal CPAL builders and a RustSec advisory for it were not established. Keep the defect's scope precise. [13]
+
+**[V]** Coreaudio AudioUnit is Send while its direct callback setter bounds omit Send. **[I]** Capturing non-Send state and moving/invoking/destroying the unit across threads merits a separate soundness review. CPAL requires Send itself; this contrast is not proof of a CPAL callback data race. [13]
+
+**[V] CPAL changelog records actual historical fixes:** CoreAudio callbacks after drop (0.16.0); ALSA shutdown race and CoreAudio null/alignment UB (0.17.0); ALSA drop race (yanked 0.17.2); CoreAudio loopback UB and startup/reentrancy fixes (0.18.0). 0.18.2's unsound Send+Sync fix is **WebAudio +atomics**, not a macOS/ALSA finding. [14]
+
+**[V, reported; not reproduced]** Open #215 is an old ALSA/PulseAudio 32-channel crash report, #704 concerns macOS device removal silently choosing a default, and #873 concerns short/distorted Linux recordings. None proves a current 0.18.2 UB reproduction. The closed ARM timestamp report #1134 and merged #1137 are distinct. [14]
+
+**[U]** Searches did not find a matching CPAL/coreaudio-rs/alsa advisory; the entire RustSec database and a resolved application lockfile were not audited. Do not say “RustSec clean” or “no known vulnerabilities.”
+
+### 2.5 Direct `windows` fallback: size and containment
+
+**[V]** In inspected windows **0.62.2**, audio COM methods such as Initialize, Start, Stop, GetBufferSize, GetService, render/capture GetBuffer and ReleaseBuffer are unsafe, even when their signatures hide raw output pointers. Clone, Interface::cast, GUID/value construction, and obtaining a raw pointer are safe helpers. “Every windows method is unsafe” is false; “direct WASAPI transport requires unsafe” is true. [10]
+
+**[I, estimate, not measured implementation]** Minimal exclusive render+capture, fixed accepted format, event handles, start/stop/join and failure cleanup would require approximately **25–40 distinct unsafe call/pointer-operation sites**, **60–150 executable lines inside unsafe blocks**. Add robust enumeration, property names, format/alignment retries, recovery and scheduling: approximately **40–65 sites, 120–250 unsafe-block lines**. Overall adapter code is larger. Counting one giant unsafe block is meaningless.
+
+**[I]** One module can contain the operations, but a separate `impulcifer-platform-wasapi` leaf crate gives stronger policy separation: no native handles/pointers leave it; public API returns owned metadata/buffers/session commands. Prove same-thread GetBuffer/ReleaseBuffer, bounds/overflow/alignment, SILENT handling, COM reference and event lifetime, failure cleanup, no panic across FFI. This is an **explicit exception to zero unsafe in all owned code**, not a trick for satisfying that stronger claim. Prefer a narrow upstream wasapi fix over duplicating its entire backend.
+
+### 2.6 Every DSP primitive can use safe Rust; algorithm parity remains work
+
+| Required operation | Unsafe-free application implementation plan [I] |
+|---|---|
+| rfft/irfft/fft and next_fast_len | RustFFT/RealFFT safe planners and scratch APIs; explicit normalization; checked factor-search/length arithmetic matching the intended SciPy variant. |
+| fftconvolve/convolve/correlate/correlation_lags | Safe padded vectors, FFT products, checked index/crop arithmetic; direct convolution for small kernels. Fix lag sign, mode and length in tests. |
+| butter/SOS and RBJ peaking/shelves | f64/complex arithmetic, fixed coefficient arrays, mutable per-channel state. Validate order, Q, frequencies and finite values; no foreign DSP library is inherently necessary. |
+| firwin2/minimum_phase | Safe interpolation/FFT/log/exp/window loops; explicit floor, odd/even rules and output-length semantics. |
+| Savitzky–Golay and FITPACK-style splines | Safe matrix factorization and coefficient evaluation. Preserve `interp` edges, log-frequency x values, extrapolation and k=1/2/3 behavior identified by existing research. |
+| find_peaks and windows | Slice scans plus explicit plateau/tie/distance rules; hann/kaiser/window equations. |
+| uniform_filter | Checked sliding sums and explicit boundary extension/origin rules; separable axis passes. |
+| linregress / expit | Safe scalar reductions and stable logistic branches; preserve degeneracy/NaN policy. |
+| spectrogram, waterfall, decay analysis | Safe windowed block iteration and FFT; analysis arrays separate from rendering. |
+| nnresample-style polyphase rational resampling | Safe initialized FIR/polyphase buffers and checked phase indices; match filter design, padding and trim, not merely sample rate. |
+| bounded least_squares/TRF | Implement or qualify a solver through safe vectors/matrices; no qualified SciPy drop-in established here. A solver gap is algorithm work, not evidence unsafe is needed. |
+
+**[V]** The underlying safe slice/FFT/array operations exist. **[I]** Feasibility of implementing the missing algorithms in safe Rust does not establish that those implementations already exist or are numerically correct. [15–19, 49]
+
+**[V]** RustFFT's default planner dispatches supported SIMD; x86 AVX acceleration requires AVX and FMA. Safe explicit SIMD planners check availability; scalar fallback exists. RealFFT does not normalize automatically. Its inspected source has exactly two explicit unsafe blocks in `lib.rs` (424–428, 745–749), reinterpreting real storage as complex storage. Callers do not do these casts. [15–16]
+
+**[I]** Start with `Vec<f64>`, `vec![0.0; n]`, safe slices, `split_at_mut`, `chunks_exact_mut` and worker-local scratch. Neither ndarray nor nalgebra requires our use of `uninit`, `set_len`, raw views or unchecked indexing. Zero-initialization/copy cost must be measured before discussing an exception. The NumPy binding need not impose its ndarray version on the core if the interface uses Vec/slices.
+
+**[I] SIMD policy:** first profile safe scalar code, allocations and cache behavior; let optimized Rust compile ordinary loops. This does not guarantee vectorization or a speedup. Reuse RustFFT's dispatch; if a measured non-FFT hotspot remains, prefer safe wide or pulp operations. Avoid `std::arch` pointer/load operations and unchecked target-feature dispatch in application code. wide commonly selects at compile time; pulp supplies runtime dispatch. Never ship a general binary compiled blindly with `target-cpu=native`. Portable SIMD has safe arithmetic but remains nightly experimental in the inspected documentation. [23–25]
+
+**[V]** Rayon floating reductions have unspecified grouping; floating addition is not associative. **[I]** Parallelize independent speakers, gather in fixed order, and use a deterministic serial/fixed-tree global reduction. No data race does not mean bit-identical output. [19]
+
+**[I] Numerical gates:** retain pinned Python reference inputs and per-stage f64 goldens; exact tests for channel order, shape, integer peak/trim decisions and sample counts; magnitude-aware absolute/relative tolerances for arrays and FR/ILD/IPD/ITD/IACC/decay metrics. Initial `atol=1e-12`, `rtol=1e-10` and 0.01 dB diagnostic thresholds from the existing study are proposals, not approved universal bounds. SIMD/FMA, reduction grouping, FFT plans, libm and optimizer choices can change low bits without introducing UB. Keep SHA reproducibility tests within a pinned implementation/environment; do not require Python-to-Rust SHA equality as the only acceptance gate.
+
+### 2.7 WAV, files, plots, processes, and callbacks
+
+**[V] WAV:** Hound permits >18 channels and f32 samples. For 30 or 32 channels it writes the channel count, but its default extensible mask is `(1 << min(channels,18)) - 1`, hence **0x3FFFF**, not a meaningful mapping of 30/32 independent BRIR tracks. WavSpec has no caller mask field. [20]
+
+**[I]** Use Hound only if consumer tests accept the exact header, or write a small safe RIFF/WAVEFORMATEXTENSIBLE writer with explicit zero/approved mask, channel order, block align, sizes, padding and finalization. Ordinary Write/Seek and `to_le_bytes` require no unsafe. Keep today's PCM_32 output compatibility distinct from the brief's proposed float32 format. Classic RIFF size limits, RF64 and 64-bit-float support are separate requirements, not solved by u16 channels.
+
+**[V] File mapping:** memmap2 file-backed mappings are unsafe because concurrent external file modification/truncation can invalidate assumptions. Anonymous maps have safe constructors but are unnecessary here. **[I]** Use bounded standard reads or buffered streaming; metadata checks alone do not cap a file that grows during reading. No mmap for a few hundred MB is a reasonable default; cap parallel materialization to avoid multiplying memory demand. [21, 49]
+
+**[V] Plotters:** ordinary PNG plotting and font registration are safe caller APIs. Default ttf code uses native font services and an internal lifetime transmute. The ab_glyph backend accepts static font bytes and uses a synchronized font registry. **[I]** Explicitly disable ttf/default features if avoiding native font discovery; enabling ab_glyph while leaving ttf active may still select ttf. Bundle glyph coverage for nine languages and test actual labels. Safe Rust does not provide complex shaping/bidi/font fallback automatically. [22]
+
+**[V] Processes:** `Command::new/arg/env/spawn`, Child wait/kill and Windows `creation_flags(CREATE_NO_WINDOW)` are safe. Unix `pre_exec` is unsafe. In Rust 2024, process-global `env::set_var/remove_var` are unsafe APIs; Windows has a documented soundness exception but the signature remains unsafe. [48, 53]
+
+**[I]** Launch ffmpeg/ffprobe directly with an absolute path, not cmd/bat/sh. Configure child environment with Command::env, not process-global mutation after threads start. Drain stderr/stdout to avoid pipe deadlock, check exit status, kill then wait on cancellation, and validate staged output before promotion. Do not promise Child::kill recursively kills every descendant; process-tree cleanup is a separate requirement. Native helper vulnerabilities and command/option injection are outside Rust's memory-safety lint.
+
+**[V] Queue safety versus realtime:** rtrb 0.3.5 advertises allocation-free post-construction wait-free read/write; ringbuf 0.4.8 advertises lock-free SPSC. Their ordinary push/pop APIs are safe; raw chunk commit/index advancement APIs can be unsafe. crossbeam queues/channels are safe caller APIs but their behaviors differ: SegQueue can allocate, bounded send can block, and nonblocking does not imply wait-free. [26–28]
+
+**[I] Callback policy:** preallocate f32 playback/capture storage or a bounded numeric SPSC; callback only copies/fills slices, advances counters and records minimal error state. No formatting/logging, disk I/O, locks, allocations, Rayon spawn, Python calls, UI calls or waiting. Process errors/logs on an ordinary worker. Check overflow/underflow and mark measurement failure rather than silently dropping samples. `Send + 'static` does not enforce these realtime rules; neither does `forbid(unsafe_code)`. Whole-buffer playback reduces the need for a queue; use one only where ownership/stream duration actually needs it.
+
+### 2.8 Tauri, titlebars, plugins, and the real audit boundary
+
+**[V]** Tauri **2.11.5** command-wrapper generation contains no introduced unsafe block or linker export attribute. Inspected context-generation source also did not introduce an explicit unsafe block, although nested macro expansion was not exhaustively compiled. `set_theme` is safe; on Linux/macOS its effects are application-wide. [30–31]
+
+**[V]** Tauri **itself** uses unsafe in `app.rs`: Windows accelerator pointer handling/TranslateAcceleratorW, native menu theming, and other target-specific operations. Its 2.11.5 runtime manifest requests Wry **0.55.0**, Tao **0.35.0**, raw-window-handle **0.6**; these are compatibility requirements, not exact locks and not upstream latest versions. Tao 0.35.0 dark-mode code calls DwmSetWindowAttribute internally. Raw-window-handle 0.6.2 `borrow_raw` is unsafe; safe handle retrieval does not transfer its proof obligations to arbitrary application FFI. [30–33]
+
+**[I]** A normal decorated window with `set_theme(Some(Dark))` needs no application DWM call. Verify OS builds, high-contrast behavior and live theme changes. If a genuine platform defect remains, report/fix the dependency first rather than adding undocumented DWM retries.
+
+**[V]** Dialog 2.7.3 itself uses unsafe raw-handle borrowing; opener 2.5.5 exposes safe methods and delegates platform work; updater 2.11.0 exposes safe methods and includes a Windows ShellExecuteW unsafe block. Public `Update::install(bytes)` must not be treated as synonymous with the signature-verifying download flow. [34–36]
+
+**[V]** Radically Open Security performed an external Tauri v2 pre-release security audit; Tauri's **2024-08-01** release-candidate announcement says findings were fixed and retested. **[U]** The precise report commit/scope was not extracted here, and that historical audit does not certify every unsafe block or the current 2.11.5/plugin/dependency graph. Do not label all Wry/Tao/browser code audited on that basis. [39]
+
+**[I]** Keep Tauri commands as narrow request/response adapters. No remote web content receives privileged commands. Untrusted filenames/labels in exported HTML need correct escaping and an unprivileged browser context. These are security requirements despite requiring no unsafe. WebView2/WKWebView/WebKitGTK remain large native trusted components; retain normal browser servicing and sandbox behavior.
+
+### 2.9 PyO3 / NumPy: zero handwritten unsafe, not zero generated FFI
+
+| Operation | Verified safe path | Avoid / qualification |
+|---|---|---|
+| float64 input | `PyReadonlyArray1<f64>`; guard `as_slice()` or `as_array()` [43] | `as_slice` rejects noncontiguous input; use owned copy from a strided view or reject it explicitly. |
+| mutable array access | `try_readwrite` then guard `as_slice_mut/as_array_mut` with `&mut self` [43] | Direct PyArrayMethods slice/view methods are unsafe; safe mutable guard is a different API. |
+| Rust-owned processing | guarded `as_slice()?.to_vec()` or owned ndarray copy [43] | Copying must not race external writes/resizes. Borrow guards do not synchronize arbitrary Python/C/Fortran access. |
+| output | `PyArray::from_vec`, `from_slice` [43] | from_vec transfers Rust allocation ownership with resize restrictions; from_slice copies. Neither needs our unsafe. |
+| uninitialized / borrowed raw array | not needed | `PyArray::new`, `borrow_from_array`, raw pointer constructors and manual initialization are unsafe. |
+| long job | safe `Python::detach` operating on owned Rust data [44] | 0.27 has deprecated allow_threads; 0.29 uses detach and no longer has it. Ungil/Send alone is not a proof that arbitrary Python-backed memory is safe. |
+
+**[V]** Matching Rust crate versions matter: numpy **0.27.0** requests PyO3 0.27.0 and ndarray `>=0.15,<0.17`; numpy **0.29.0** requests PyO3 0.29.0 and declares ndarray `>=0.15,<=0.17`. These are manifest requirements, not proof of compatibility with every ndarray 0.17 patch. Resolve and test the actual lock; a Vec boundary avoids ndarray type coupling. [43]
+
+**[V]** PyO3 0.27.0's `tests/ui/forbid_unsafe.rs` enables both forbid unsafe lints and includes hygiene tests containing real `#[pymodule]` exports; its pass registration excludes limited-API and experimental-inspect configurations. 0.29.0 has a `//@check-pass` fixture with module generation and its own limited-API exclusion. Upstream fixture existence is verified; this session did not run them. [40]
+
+**[V]** PyO3 macros nevertheless emit `unsafe extern "C"` initialization/export code and `export_name`. Rust 1.90.0 lint source suppresses relevant external-macro-span diagnostics by default; `forbid` does not mean expanded foreign code disappears. PyO3 fixed an external-macro span/forbid regression in 0.22.4. **[I]** Keep a small compile-pass fixture in our actual toolchain/ABI matrix rather than weakening the crate lint preemptively. [41–42]
+
+**[V]** Free-threaded Python's `Python<'py>` token means attached, not exclusive access. Rust-numpy borrow checks coordinate cooperating rust-numpy borrows, not arbitrary Python/native writes. NumPy 2.3 documents crashes from concurrent array resizing. PyO3 0.27 needs explicit free-threading opt-in; 0.29 defaults to declaring thread safety, with `gil_used=true` opt-out. [44]
+
+**[I]** Contract: caller must not mutate or resize input during the synchronous copy; adapter obtains guarded access, validates dtype/shape/layout/limits, copies, releases all Python borrows, and detaches using owned Rust arrays only. Output is a fresh owned NumPy array. For an API that must tolerate arbitrary concurrently mutated inputs, accepting immutable bytes plus shape/rate metadata is safer than pretending a borrow guard freezes NumPy. That alternate input can remain zero-unsafe but is not a drop-in NumPy signature. Do not advertise free-threaded support until aliasing/copy and module-state tests pass.
+
+### 2.10 Updater, global state, and optional IPC
+
+**[V]** Velopack **1.2.0** exposes safe startup/check/download/apply APIs and has internal Windows process FFI. `unsafe_apply_updates` is not an unsafe Rust function; its name warns about update lifecycle. [37]
+
+**[I]** Call Velopack startup handling before Tauri; preserve Windows install/package identity. Use Velopack only for Windows-managed installs and Tauri updater for its macOS/AppImage artifacts. An internal provider trait can be safe. Apply only after audio/DSP/output writes stop. Neither safe signatures nor a file hash proves the feed is authenticated; keep download verification and signing policy separate.
+
+**[V]** OnceLock/LazyLock/Arc/Mutex/atomics provide safe shared state. Basic Tokio named-pipe creation is safe, while raw security-attribute construction is unsafe. [53, 55]
+
+**[I]** No `static mut`, own UnsafeCell abstraction, global process-environment edits, raw DLL loading, native signal handlers, or shared-memory IPC is required. Configuration can be passed explicitly; callbacks send owned messages/counters; CLI communication can use stdio. If a future Windows job-object, custom ACL, device notification or priority feature lacks a sufficient safe abstraction, treat it as new leaf-crate work, not permission to relax all crate lints.
+
+### 2.11 Maintenance, advisories, and what was not audited
+
+| Component | Verified evidence | Honest conclusion |
+|---|---|---|
+| wasapi 0.24.0 | Published 2026-08-12; versioned source and open format/probing issues [2, 6] | Release activity exists; independent soundness audit not verified. Source defects prevent blanket endorsement. |
+| CPAL 0.18.2 | Published 2026-08-16; SECURITY policy supports master/latest stable; documented fixes [11, 14] | Maintained latest line, not a promise to backport to every old release. |
+| coreaudio-rs 0.14.2 | Published 2026-04-29; source inspected [13] | Recent release does not cancel identified safe-API defect. |
+| Hound 3.5.1 | Published 2023-09-25 [20] | Safe usable APIs exist; current maintenance responsiveness unverified. Do not call it recently maintained. |
+| RealFFT 3.5.0 | Changelog documents 3.4.0 Miri UB correction and 3.5.0 feature work [16] | Evidence of remediation, not complete audit. |
+| Tauri v2 | External pre-release audit announced 2024-08-01 [39] | Historical security audit; exact current code/whole graph not certified. |
+| Other numerical, queue, helper and Python dependencies | Versioned APIs and selected internals inspected | Sustained maintenance, bus factor and independent exact-version audit generally unverified by this task. |
+
+**[V] Relevant advisories:**
+
+- **rtrb RUSTSEC-2026-0274**, published **2026-09-01**: ReadChunk commit with panicking element Drop can double-free/use freed memory in versions `<0.3.5`. Patched ranges `^0.3.5` or `>=0.4.0`. Numeric f32 has no panicking destructor, but use the fixed release anyway. [28]
+- **crossbeam-channel RUSTSEC-2025-0024**: Drop race/double-free introduced in 0.5.12, fixed 0.5.15. Audit resolved subcrates, not just crossbeam's umbrella version. [28]
+- **nalgebra RUSTSEC-2021-0070**: inconsistent deserialized storage dimensions allowed out-of-bounds access; affected `>=0.11.0,<0.27.1`, fixed `>=0.27.1`. The inspected 0.35.0 is beyond that range. [29]
+
+**[U]** No whole dependency lockfile exists for this proposed rewrite. No cargo-audit/geiger run, Miri run, native sanitizer run, callback stress test, or hardware test occurred. No independent current unsafe-code audit was verified for wasapi, CPAL, coreaudio-rs, the selected FFT/array/queue versions, Python binding stack, or Velopack. The searches are not an exhaustive absence-of-advisories proof.
+
+## 3 Proposed architecture
+
+All prescriptions here are **[I]**, grounded in the safe APIs above.
+
+### 3.1 Crates and ownership
+
+| Crate | Contract | Policy |
+|---|---|---|
+| `impulcifer-dsp` | f64 primitives, config defaults, stages; Vec/slice interfaces; deterministic gathering | `#![forbid(unsafe_code)]`; no GUI/Python/OS dependency |
+| `impulcifer-audio` | safe backend trait, checked config, dedicated thread sessions, owned metadata | Same lint; target-gated wasapi/CPAL; exclude known defective raw/parse APIs |
+| `impulcifer-analysis` | numerical analysis model, PNG/HTML and WAV/text exports | Same lint; explicit fonts and output headers |
+| `impulcifer-jobs` | sequence journal, polling, bounded progress/logs, cancellation, stage ownership | Same lint; no native callbacks or borrowed Python data |
+| `impulcifer-app` | thin Tauri commands/settings/dialogs/theme/updater provider | Same lint; no audio objects in UI thread/state |
+| `impulcifer-cli` | batch entry point with no Tauri initialization | Same lint; safe std process/file operations |
+| `impulcifer-python` | PyO3 module, guarded-copy-in / owned-compute / new-array-out | Same lint; macro-generated FFI tracked separately |
+| Optional `impulcifer-platform-wasapi` | Only if required safe upstream implementation cannot be obtained | Explicit reviewed exception; never describe it as zero owned unsafe |
+
+A private safe facade can restrict risky dependency APIs, but the facade's lint does not repair unsoundness inside code it calls. Track dependency fixes and exclusions by version. No explicit unsafe leaf is needed merely to use the documented happy-path APIs.
+
+### 3.2 Two independent streams, finite playback, and drain
+
+1. Validate requested rates, channel mappings, capacity, memory budgets and native format before starting. DSP remains f64; audio conversion to f32 is explicit/tested.
+2. Dedicated capture thread initializes COM on Windows, creates/opens/starts capture, then acknowledges readiness. Playback thread independently initializes/opens render. Use IDs and owned buffers, not COM pointers transferred from UI enumeration.
+3. Capture first; playback begins only after readiness. Track actual frames/discontinuities, not just elapsed wall time.
+4. Render precomputed samples in bounded chunks. For WASAPI shared or **exclusive polling**, queried padding describes queued endpoint frames. Exclusive **event** mode processes complete buffers and cannot blindly reuse a padding-based fill/drain algorithm. Safe APIs exist for both; prefer the simpler polling model initially because latency is not a requirement. [5, 9]
+5. End-of-source, endpoint queue empty, device-clock progress and actual acoustic completion are different facts. Model drain explicitly; preserve sufficient capture post-roll. Establish final physical tail behavior on hardware, not by assuming `stop_stream()` drains.
+6. On cancellation/error, stop/abort both sides, propagate both errors, drop service/client/event owners on the owning thread, uninitialize COM, join workers, and only then publish terminal job state. No worker may keep writing after cancellation completion.
+7. CPAL callbacks only copy/fill bounded buffers and signal progress. A coordinator provides the blocking whole-session interface; CPAL itself does not supply a portable whole-buffer physical-drain guarantee.
+
+### 3.3 Exact leak list and prevention
+
+| What would introduce our unsafe | Why | Zero-unsafe alternative |
+|---|---|---|
+| Calling windows COM/DWM/MMCSS/custom security APIs directly | Native lifetime/thread/pointer contracts not encoded in safe signatures | Existing safe wrapper; omit optional tweak; upstream fix; otherwise explicit leaf |
+| Forcing COM/native wrappers Send/Sync | Native apartment/ownership may forbid transfer | Construct/use/drop on dedicated thread; message IDs/results |
+| `WaveFormat::parse` or coreaudio Handle raw constructor | **Already safe syntactically but unsound**; lint will not catch use | Exclude them; do not pass arbitrary headers/pointers; upstream repair |
+| File-backed memmap2 mapping | External mutation/truncation can invalidate memory | Bounded reads or streaming |
+| Raw NumPy/new/uninitialized/borrowed Rust memory | Initialization, aliasing and owner lifetime obligations | Borrow guards, synchronized copy, from_vec/from_slice |
+| Handwritten Python/C exports | Unsafe FFI contracts and export attributes | PyO3 external macros, compile fixtures; generated code remains trusted |
+| Pointer SIMD, unchecked indexing, assume_init/set_len | Bounds, alignment, CPU features, initialization | Safe slices/Vec, RustFFT planner, safe wide/pulp if justified |
+| Raw ring commits/index advance | Must prove initialized slots and publication order | Safe numeric push/pop/slice-copy APIs |
+| `static mut`, unsafe Send/Sync/Pod implementations | Global aliasing or incorrect trait invariant | Explicit owners, atomics/locks/OnceLock; built-in POD types |
+| Global env mutation or Unix pre_exec | Thread/process runtime safety contracts | Config structs; Command::env and purpose-built safe setters |
+| Shared-memory/raw-handle IPC or custom callbacks | Lifetime, peer mutation, FFI unwind/security obligations | Tauri JSON/binary owned responses, stdio, ordinary safe named pipes |
+
+### 3.4 Verification gates before implementation is called safe
+
+- Put the crate-level forbid attribute in **every owned Rust target**, including library, binary, integration test, example and build script as applicable; workspace lint inheritance is useful but not automatic unless each member opts in. Do not pass a global RUSTFLAGS forbid setting to every dependency and mistake expected dependency failures for application failures.
+- Compile the exact Windows/macOS/Linux feature matrix and Python ABI combinations. Include PyO3 module-export and representative Tauri macro fixtures under forbid; especially test limited-API/abi3 combinations excluded by upstream fixtures.
+- Maintain lockfile/toolchain/target-feature records. Review new dependencies and macro-generated native boundaries; run RustSec tooling against resolved transitive versions. geiger counts are an inventory, not a safety score.
+- Keep known-unsound API exclusions testable/reviewable. Upstream or separately review fixes for the audio issues; do not use `catch_unwind` as a UB remedy.
+- Use Miri for pure Rust unsafe-dependent components where supported, fuzz parsers/config/shape arithmetic and WAV headers, test queue/drop/panic boundaries, and use platform sanitizers/stress tests where feasible. Miri does not execute arbitrary WASAPI/CoreAudio drivers.
+- Hardware gates: 2/8/12/14/16 output configurations where physically available; 44.1/48/96 kHz accepted/rejected tuples; capture SILENT/discontinuity; startup failure, hot-unplug, cancellation during waits/drain, reopen and repeated teardown. Test real output channel identity and tail completion.
+- Concurrency gates: overlapping Python calls and aliases, explicit no-mutation contract during copies, free-threaded module state, callback zero-allocation expectations, deterministic reduction/order tests.
+- Preserve per-stage numerical goldens and final scientific metrics separately from memory-safety and packaging gates.
+
+## 4 Risks ranked
+
+Rankings and mitigations are **[I]**; factual bases are cited in Findings.
+
+| Rank | Severity | Risk | Required response |
+|---:|---|---|---|
+| 1 | High | Safe APIs in audio dependencies have source-confirmed soundness defects; silence path has unresolved native-memory assumptions. | Exclude defective entry points, obtain/review upstream fixes, investigate silence before claiming production readiness. [2–4, 8, 13] |
+| 2 | High | COM apartment teardown, callback lifetime and native thread contracts are not guaranteed by a safe-looking orchestration API. | Dedicated owners, no unsafe Send, checked init balancing, join-before-terminal, teardown tests. [7–14] |
+| 3 | High | NumPy borrowed memory can be mutated/resized outside rust-numpy guards, especially free-threaded Python. | Synchronized copy-in contract; owned detached jobs; no retained views; test module defaults/version differences. [43–44] |
+| 4 | High | False assurance from forbid, “pure Rust,” or historical audits masks dependency/native/generated code risk. | Separate policy metrics: handwritten unsafe, generated FFI, dependency unsafe, actual audit coverage and known defects. [1, 39–42] |
+| 5 | High | Wrong channel mapping or truncated final audio despite successful stream calls; WASAPI f32 exclusive availability is device-dependent. | Hardware format/routing/drain acceptance, explicit conversion policy, no silent downmix. [5, 8–9] |
+| 6 | High | SciPy/FITPACK/resampling/optimizer semantics differ while safe Rust tests only shape or plausible output. | Stage goldens, exact discrete decisions, scientific tolerance gates; no cross-language SHA-only test. |
+| 7 | Medium–high | Hound default multitrack mask, RIFF limits, memory amplification and malformed sizes. | Explicit header/consumer tests, checked arithmetic, safe custom writer if needed, bounded allocations. [20–21, 49] |
+| 8 | Medium | Callback allocations/blocking, queue overflow and old dependency soundness bugs. | Preallocated SPSC numeric buffers; fixed rtrb/crossbeam versions; worker-side logs; overflow as measurement error. [26–28] |
+| 9 | Medium | Updater/helper/privileged-webview vulnerabilities are not prevented by Rust memory safety. | Scoped IPC, escaped unprivileged reports, authenticated verified downloads, idle-only apply. [34–39, 48, 52] |
+| 10 | Medium | Macro/lint or ABI/feature drift breaks promised zero-unsafe builds. | Pinned toolchain, own compile fixtures and full platform/Python matrix; no blanket allow. [40–44] |
+| 11 | Medium | Feature creep reintroduces raw DWM, mmap, native fonts, custom SIMD or shared memory without measured need. | Maintain explicit no-unsafe API policy; review exceptions separately and keep them leaf-only. |
+
+## 5 Open questions you could not settle
+
+1. **[U] Audio upstream resolution:** when will wasapi's safe parser and coreaudio's safe raw Handle constructor be corrected, and what versions will include fixes? No issue or patch was posted by this task.
+2. **[U] Silent capture memory contract/reproduction:** does target hardware ever supply invalid/null/uninitialized storage with nonempty SILENT packets? The source omission is verified; native UB reproduction is not.
+3. **[U] Complete audio-wrapper soundness:** COM deinitialization misuse, event lifetime/error cleanup, service ownership, malformed formats and callback trait contracts need a focused audit. This inventory is not that audit.
+4. **[U] CPAL reachability:** normal CPAL 0.18.2 use triggering the identified coreaudio Handle defect or non-Send callback issue was not established.
+5. **[U] Actual all-crate forbid build:** no Rust workspace/prototype was built. Exact Tauri/PyO3 macro, Rust edition, limited-API, free-threaded Python and target combinations remain untested.
+6. **[U] Dependency resolution:** no application Cargo.lock or complete feature graph exists. CPAL's packaged lock and manifest requirements do not select the future graph, including numpy/ndarray compatibility.
+7. **[U] Audit scope:** exact current-version independent unsafe audits were not established for most components. Tauri's historical audit scope/commit was not extracted; it is not a complete dependency certificate.
+8. **[U] Hardware behavior:** independent 16-out/2-in streams, exclusive native f32 support, shared conversion, drain completion, drift, hotplug and Apple microphone permissions still need actual devices.
+9. **[U] WAV consumer contract:** explicit mask/header expectations for 30/32-track HeSuVi/Hangloose/EAPO/JamesDSP output, PCM_32 versus float32 default, and any RF64 need are not settled.
+10. **[U] Performance:** no evidence that safe initialization/copies are a bottleneck; no justification yet for mmap/raw SIMD/uninitialized buffers. Peak job memory and callback slack remain unmeasured.
+11. **[U] Numerical budget and optimizer:** tolerances need maintainer approval against the golden corpus; no qualified bounded TRF replacement was selected.
+12. **[U] Cross-platform fonts and updates:** packaged nine-language glyph/layout behavior, upgrade continuity from the current Velopack app, macOS/AppImage updater artifacts and helper lifecycle were not executed.
+13. **[U] Maintenance beyond release metadata:** Hound responsiveness and sustained maintenance/audit commitments of every selected numerical/helper dependency were not established.
+
+## 6 Sources
+
+All accessed **2026-09-07**. Version-pinned links are preferred. Grouped URLs under one number support the same topic. Rolling std/Microsoft docs and issue pages are explicitly snapshots. Local research paths are identified in §2.1. A raw PDF fetch could not be decoded into usable audit text; only the official audit announcement supports the historical-audit claim. No cargo/compile/hardware verification is implied.
+
+1. Rust unsafe-code lint and external macro diagnostic implementation: https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#unsafe-code ; https://raw.githubusercontent.com/rust-lang/rust/1.90.0/compiler/rustc_lint/src/builtin.rs ; https://raw.githubusercontent.com/rust-lang/rust/1.90.0/compiler/rustc_middle/src/lint.rs ; https://raw.githubusercontent.com/rust-lang/rust/1.90.0/compiler/rustc_lint_defs/src/lib.rs
+2. wasapi 0.24.0 source, exports, manifest and release metadata: https://raw.githubusercontent.com/HEnquist/wasapi-rs/v0.24.0/src/api.rs ; https://raw.githubusercontent.com/HEnquist/wasapi-rs/v0.24.0/src/lib.rs ; https://raw.githubusercontent.com/HEnquist/wasapi-rs/v0.24.0/src/errors.rs ; https://raw.githubusercontent.com/HEnquist/wasapi-rs/v0.24.0/src/events.rs ; https://docs.rs/wasapi/0.24.0/src/wasapi/events.rs.html ; https://raw.githubusercontent.com/HEnquist/wasapi-rs/v0.24.0/Cargo.toml ; https://crates.io/api/v1/crates/wasapi/0.24.0
+3. wasapi format parsing source: https://raw.githubusercontent.com/HEnquist/wasapi-rs/v0.24.0/src/waveformat.rs ; https://docs.rs/wasapi/0.24.0/src/wasapi/waveformat.rs.html
+4. Public WaveFormat/Device API: https://docs.rs/wasapi/0.24.0/wasapi/struct.WaveFormat.html ; https://docs.rs/wasapi/0.24.0/wasapi/struct.Device.html
+5. wasapi safe stream/enumeration/event surfaces: https://docs.rs/wasapi/0.24.0/wasapi/struct.AudioClient.html ; https://docs.rs/wasapi/0.24.0/wasapi/struct.AudioRenderClient.html ; https://docs.rs/wasapi/0.24.0/wasapi/struct.AudioCaptureClient.html ; https://docs.rs/wasapi/0.24.0/wasapi/struct.DeviceEnumerator.html ; https://docs.rs/wasapi/0.24.0/wasapi/struct.DeviceCollection.html ; https://docs.rs/wasapi/0.24.0/wasapi/struct.Handle.html ; https://docs.rs/wasapi/0.24.0/wasapi/enum.StreamMode.html
+6. wasapi issue inventory and distinct 24-bit fallback issue: https://github.com/HEnquist/wasapi-rs/issues ; https://github.com/HEnquist/wasapi-rs/issues/62 ; https://github.com/HEnquist/wasapi-rs/issues/63
+7. COM/apartment rules and Windows 8 caveat: https://learn.microsoft.com/en-us/windows/win32/api/combaseapi/nf-combaseapi-coinitializeex ; https://learn.microsoft.com/en-us/windows/win32/api/audioclient/nn-audioclient-iaudioclient
+8. Capture buffer, silence and service-reference lifetime contracts: https://learn.microsoft.com/en-us/windows/win32/api/audioclient/nf-audioclient-iaudiocaptureclient-getbuffer ; https://learn.microsoft.com/en-us/windows/win32/api/audioclient/ne-audioclient-_audclnt_bufferflags ; https://learn.microsoft.com/en-us/windows/win32/coreaudio/capturing-a-stream
+9. Padding and exclusive-mode behavior: https://learn.microsoft.com/en-us/windows/win32/api/audioclient/nf-audioclient-iaudioclient-getcurrentpadding ; https://learn.microsoft.com/en-us/windows/win32/coreaudio/exclusive-mode-streams
+10. windows 0.62.2 metadata/core plus generated Windows audio docs (generated site snapshot): https://docs.rs/crate/windows/0.62.2 ; https://docs.rs/windows-core/0.62.2/windows_core/struct.GUID.html ; https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/Media/Audio/struct.IAudioClient.html ; https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/Media/Audio/struct.IAudioRenderClient.html ; https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/Media/Audio/struct.IAudioCaptureClient.html ; https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/Media/Audio/struct.IMMDevice.html ; https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/System/Com/fn.CoCreateInstance.html
+11. CPAL 0.18.2 API, version, dependency/maintenance records: https://docs.rs/crate/cpal/0.18.2 ; https://docs.rs/cpal/0.18.2/cpal/traits/trait.DeviceTrait.html ; https://docs.rs/cpal/0.18.2/cpal/struct.Data.html ; https://docs.rs/crate/cpal/0.18.2/source/Cargo.toml ; https://docs.rs/crate/cpal/0.18.2/source/Cargo.lock ; https://docs.rs/crate/cpal/0.18.2/source/SECURITY.md
+12. CPAL/ALSA internals: https://docs.rs/crate/cpal/0.18.2/source/src/host/alsa/mod.rs ; https://docs.rs/crate/cpal/0.18.2/source/src/host/coreaudio/mod.rs ; https://docs.rs/crate/cpal/0.18.2/source/src/host/coreaudio/macos/device.rs ; https://docs.rs/crate/alsa/0.11.0/source/src/pcm.rs ; https://docs.rs/crate/alsa/0.11.0/source/Cargo.toml ; https://docs.rs/crate/alsa-sys/0.4.0/source/build.rs
+13. coreaudio-rs 0.14.2 public unsafe-behind-safe boundary: https://docs.rs/coreaudio-rs/0.14.2/coreaudio/ ; https://docs.rs/coreaudio-rs/0.14.2/coreaudio/audio_unit/render_callback/action_flags/struct.Handle.html ; https://docs.rs/crate/coreaudio-rs/0.14.2/source/src/audio_unit/render_callback.rs ; https://docs.rs/crate/coreaudio-rs/0.14.2/source/src/audio_unit/mod.rs ; https://docs.rs/coreaudio-rs/0.14.2/coreaudio/audio_unit/struct.AudioUnit.html
+14. CPAL fix history and issue reports: https://docs.rs/crate/cpal/0.18.2/source/CHANGELOG.md ; https://github.com/RustAudio/cpal/issues/215 ; https://github.com/RustAudio/cpal/issues/704 ; https://github.com/RustAudio/cpal/issues/873 ; https://github.com/RustAudio/cpal/issues/1134 ; https://github.com/RustAudio/cpal/pull/1137
+15. RustFFT 6.4.1 safe planning and unsafe SIMD: https://docs.rs/rustfft/6.4.1/rustfft/ ; https://docs.rs/rustfft/6.4.1/rustfft/struct.FftPlanner.html ; https://docs.rs/rustfft/6.4.1/src/rustfft/plan.rs.html ; https://docs.rs/rustfft/6.4.1/src/rustfft/avx/avx64_butterflies.rs.html
+16. RealFFT 3.5.0 APIs, internal casts and change history: https://docs.rs/realfft/3.5.0/realfft/trait.RealToComplex.html ; https://docs.rs/realfft/3.5.0/src/realfft/lib.rs.html ; https://docs.rs/crate/realfft/3.5.0/source/README.md
+17. ndarray 0.17.2 safe array/parallel APIs and unsafe internals: https://docs.rs/ndarray/0.17.2/ndarray/ ; https://docs.rs/ndarray/0.17.2/ndarray/parallel/index.html ; https://docs.rs/ndarray/0.17.2/src/ndarray/impl_views/conversions.rs.html
+18. nalgebra 0.35.0 and storage internals: https://docs.rs/nalgebra/0.35.0/nalgebra/ ; https://docs.rs/nalgebra/0.35.0/src/nalgebra/base/vec_storage.rs.html
+19. Rayon 1.11.0 / core 1.13.0, safe disjoint work and nondeterministic reductions: https://docs.rs/rayon/1.11.0/src/rayon/slice/mod.rs.html ; https://docs.rs/rayon/1.11.0/rayon/iter/trait.ParallelIterator.html#method.sum ; https://docs.rs/rayon-core/1.13.0/src/rayon_core/job.rs.html
+20. Hound 3.5.1 version/WAV fields/writer/mask: https://docs.rs/crate/hound/3.5.1 ; https://docs.rs/hound/3.5.1/hound/struct.WavSpec.html ; https://docs.rs/hound/3.5.1/src/hound/write.rs.html ; https://github.com/ruuda/hound
+21. memmap2 0.9.9 mapping safety: https://docs.rs/memmap2/0.9.9/memmap2/struct.MmapOptions.html ; https://docs.rs/memmap2/0.9.9/src/memmap2/lib.rs.html
+22. Plotters 0.3.7 features/fonts/internals: https://docs.rs/plotters/0.3.7/plotters/ ; https://docs.rs/plotters/0.3.7/src/plotters/style/font/ttf.rs.html ; https://docs.rs/plotters/0.3.7/src/plotters/style/font/ab_glyph.rs.html ; https://docs.rs/plotters/0.3.7/src/plotters/style/font/mod.rs.html ; https://docs.rs/plotters/0.3.7/plotters/style/fn.register_font.html
+23. wide 0.7.33 internals and usage policy: https://docs.rs/wide/0.7.33/src/wide/f32x4_.rs.html ; https://github.com/Lokathor/wide
+24. pulp 0.21.5 safe dispatch and unsafe internals: https://docs.rs/pulp/0.21.5/pulp/ ; https://docs.rs/pulp/0.21.5/src/pulp/lib.rs.html
+25. Portable SIMD status, inspected versioned std docs: https://doc.rust-lang.org/1.98.1/std/simd/index.html
+26. ringbuf 0.4.8 safe and raw producer operations: https://docs.rs/ringbuf/0.4.8/ringbuf/ ; https://docs.rs/ringbuf/0.4.8/ringbuf/traits/producer/trait.Producer.html
+27. rtrb/crossbeam versions and internals: https://docs.rs/rtrb/0.3.5/rtrb/ ; https://docs.rs/rtrb/0.3.5/rtrb/chunks/struct.WriteChunkUninit.html ; https://docs.rs/crossbeam/0.8.4/crossbeam/ ; https://docs.rs/crossbeam-channel/0.5.15/crossbeam_channel/ ; https://docs.rs/crossbeam-queue/0.3.12/src/crossbeam_queue/array_queue.rs.html
+28. Queue/channel soundness advisories: https://rustsec.org/advisories/RUSTSEC-2026-0274.html ; https://rustsec.org/advisories/RUSTSEC-2025-0024.html
+29. Historical nalgebra storage advisory: https://rustsec.org/advisories/RUSTSEC-2021-0070.html
+30. Tauri 2.11.5 safe commands and internal unsafe: https://raw.githubusercontent.com/tauri-apps/tauri/tauri-v2.11.5/crates/tauri-macros/src/command/wrapper.rs ; https://raw.githubusercontent.com/tauri-apps/tauri/tauri-v2.11.5/crates/tauri-codegen/src/context.rs ; https://raw.githubusercontent.com/tauri-apps/tauri/tauri-v2.11.5/crates/tauri/src/app.rs
+31. Tauri theme/IPC APIs: https://docs.rs/tauri/2.11.5/tauri/webview/struct.WebviewWindow.html ; https://v2.tauri.app/develop/calling-rust/ ; https://v2.tauri.app/security/capabilities/
+32. Actual Tauri runtime requirements and Tao 0.35.0 native titlebar implementation: https://raw.githubusercontent.com/tauri-apps/tauri/tauri-v2.11.5/crates/tauri-runtime-wry/Cargo.toml ; https://raw.githubusercontent.com/tauri-apps/tao/tao-v0.35.0/src/platform_impl/windows/dark_mode.rs
+33. raw-window-handle 0.6.2 API; additional pinned runtime/native source inspected: https://docs.rs/raw-window-handle/0.6.2/raw_window_handle/struct.WindowHandle.html ; https://raw.githubusercontent.com/tauri-apps/tauri/tauri-v2.10.2/crates/tauri-runtime-wry/src/lib.rs ; https://raw.githubusercontent.com/tauri-apps/wry/wry-v0.54.0/src/webview2/mod.rs
+34. Dialog 2.7.3 APIs and plugin's own unsafe: https://docs.rs/tauri-plugin-dialog/2.7.3/tauri_plugin_dialog/struct.FileDialogBuilder.html ; https://docs.rs/tauri-plugin-dialog/2.7.3/src/tauri_plugin_dialog/desktop.rs.html
+35. Opener 2.5.5: https://docs.rs/tauri-plugin-opener/2.5.5/tauri_plugin_opener/struct.Opener.html ; https://docs.rs/tauri-plugin-opener/2.5.5/src/tauri_plugin_opener/lib.rs.html
+36. Updater 2.11.0 safe API/native implementation and signature policy: https://docs.rs/tauri-plugin-updater/2.11.0/tauri_plugin_updater/struct.Update.html ; https://docs.rs/tauri-plugin-updater/2.11.0/src/tauri_plugin_updater/updater.rs.html ; https://v2.tauri.app/plugin/updater/
+37. Velopack 1.2.0 safe startup/manager and internal process FFI: https://docs.rs/velopack/1.2.0/velopack/struct.VelopackApp.html ; https://docs.rs/velopack/1.2.0/src/velopack/manager.rs.html ; https://docs.rs/crate/velopack/1.2.0/source/src/process_win.rs ; https://docs.velopack.io/getting-started/rust
+38. Velopack update API reference: https://docs.rs/velopack/1.2.0/velopack/
+39. Tauri historical external audit announcement (usable evidence), report location (scope not extracted): https://v2.tauri.app/blog/tauri-2-0-0-release-candidate/ ; https://github.com/tauri-apps/tauri/blob/dev/audits/Radically_Open_Security-v2-report.pdf
+40. PyO3 0.27/0.29 forbid compile-pass fixtures and registration conditions: https://raw.githubusercontent.com/PyO3/pyo3/v0.27.0/tests/ui/forbid_unsafe.rs ; https://raw.githubusercontent.com/PyO3/pyo3/v0.27.0/tests/test_compile_error.rs ; https://raw.githubusercontent.com/PyO3/pyo3/v0.27.0/src/tests/hygiene/pymodule.rs ; https://raw.githubusercontent.com/PyO3/pyo3/v0.29.0/tests/ui/forbid_unsafe.rs ; https://raw.githubusercontent.com/PyO3/pyo3/v0.29.0/tests/test_compile_error.rs
+41. PyO3 generated unsafe exports: https://raw.githubusercontent.com/PyO3/pyo3/v0.27.0/pyo3-macros-backend/src/module.rs ; https://raw.githubusercontent.com/PyO3/pyo3/v0.29.0/src/impl_/pymodule.rs
+42. PyO3 forbid/macro regression correction: https://github.com/PyO3/pyo3/pull/4574
+43. Rust-numpy paired requirements, guards, constructors and unsafe methods: https://raw.githubusercontent.com/PyO3/rust-numpy/v0.27.0/Cargo.toml ; https://raw.githubusercontent.com/PyO3/rust-numpy/v0.29.0/Cargo.toml ; https://docs.rs/numpy/0.27.0/numpy/array/trait.PyArrayMethods.html ; https://docs.rs/numpy/0.29.0/numpy/array/trait.PyArrayMethods.html ; https://docs.rs/numpy/0.29.0/numpy/array/struct.PyArray.html ; https://docs.rs/numpy/0.29.0/numpy/borrow/struct.PyReadonlyArray.html ; https://docs.rs/numpy/0.29.0/numpy/borrow/struct.PyReadwriteArray.html
+44. Python detachment and concurrent NumPy ownership: https://docs.rs/pyo3/0.27.0/pyo3/marker/struct.Python.html ; https://docs.rs/pyo3/0.29.0/pyo3/marker/struct.Python.html ; https://raw.githubusercontent.com/PyO3/pyo3/v0.29.0/src/marker.rs ; https://docs.rs/numpy/0.27.0/numpy/borrow/index.html ; https://docs.rs/numpy/0.29.0/numpy/borrow/index.html ; https://pyo3.rs/v0.27.0/free-threading.html ; https://pyo3.rs/v0.29.0/free-threading.html ; https://numpy.org/doc/2.3/reference/thread_safety.html
+45. PyO3 API-removal change record: https://raw.githubusercontent.com/PyO3/pyo3/v0.29.0/CHANGELOG.md
+46. CPAL platform Stream trait documentation: https://docs.rs/cpal/0.18.2/cpal/platform/struct.Stream.html
+47. RustSec index (search only, not full lockfile audit): https://rustsec.org/advisories/
+48. Safe process spawning, flags and unsafe pre-exec distinction: https://doc.rust-lang.org/std/process/struct.Command.html ; https://doc.rust-lang.org/std/os/windows/process/trait.CommandExt.html ; https://doc.rust-lang.org/std/os/unix/process/trait.CommandExt.html
+49. Safe slices, file reads and endian conversions: https://doc.rust-lang.org/std/primitive.slice.html ; https://doc.rust-lang.org/std/fs/fn.read.html ; https://doc.rust-lang.org/std/primitive.f32.html#method.to_le_bytes
+50. bytemuck 1.25.2 checked caller API/internal unsafe: https://docs.rs/bytemuck/1.25.2/bytemuck/ ; https://docs.rs/bytemuck/1.25.2/src/bytemuck/internal.rs.html
+51. serde_json 1.0.151 APIs/internal unsafe: https://docs.rs/serde_json/1.0.151/serde_json/ ; https://raw.githubusercontent.com/serde-rs/json/v1.0.151/src/read.rs
+52. Helper network/hash APIs and acceleration: https://docs.rs/reqwest/0.13.4/reqwest/ ; https://docs.rs/reqwest/0.13.4/reqwest/struct.Response.html ; https://docs.rs/sha2/0.11.0/sha2/ ; https://docs.rs/sha2/0.11.0/src/sha2/sha256.rs.html
+53. Safe global initialization and unsafe environment mutation: https://doc.rust-lang.org/std/sync/struct.OnceLock.html ; https://doc.rust-lang.org/std/env/fn.set_var.html
+54. sysinfo 0.39.6 safe system-info API/native implementation: https://docs.rs/sysinfo/0.39.6/sysinfo/ ; https://docs.rs/crate/sysinfo/0.39.6/source/src/windows/system.rs
+55. Tokio 1.53.1 optional named-pipe API: https://docs.rs/tokio/1.53.1/tokio/net/windows/named_pipe/struct.ServerOptions.html

--- a/docs/research/rewrite-stack-2026-09/report-11-rust-unsafe-quarantine.md
+++ b/docs/research/rewrite-stack-2026-09/report-11-rust-unsafe-quarantine.md
@@ -1,0 +1,622 @@
+# Rust unsafe quarantine: architecture and enforcement
+
+Observation date: **2026-09-07**. This report builds on the selected Rust/Tauri target; it does not reopen the stack decision.
+
+**Evidence labels:** **[V]** verified in a cited source or identified local file; **[I]** engineering inference, proposal, estimate, or suggested test; **[U]** not established. Source inspection is not a complete soundness audit. Labels apply to the paragraph or table row containing them. Numbered references resolve to §6. Proposed APIs and CI commands were not compiled or executed. No new Rust workspace exists for this study.
+
+## 1 Verdict
+
+1. **[I] Default to zero handwritten unsafe; reserve one optional Windows leaf, `impulcifer-sys-win`, only for demonstrated native-API gaps.**
+2. **[V] Tauri itself contains unsafe, as do runtime-wry, wry, and tao.** Copy the safe-interface pattern, not an imaginary transitive ban [1–5].
+3. **[I] DSP, audio coordination, jobs, service, analysis/I/O, Tauri app, CLI, Python bridge, and build helpers must forbid unsafe.**
+4. **[V] PyO3 owned APIs, rust-numpy owned-output constructors, and RustFFT do not require handwritten unsafe at ordinary call sites [22–31].**
+5. **[I] Keep COM interfaces on their creating worker; send endpoint IDs, owned buffers, commands, and results instead.**
+6. **[I] Enforce the boundary with compiler lints and a protected workspace-policy check; cargo-geiger is inventory, not certification.**
+7. **[V] cargo-vet’s default deployment criterion is not an absolute soundness requirement; define a project-specific review criterion [42–45].**
+8. **[I] Use Miri for pure/modelled code, native Windows tests for COM, and separate sanitizer jobs; none replaces review.**
+9. **[I] Start on pinned Rust 1.98.1, edition 2024; keep dated nightly tooling separate from shipping builds [64–70].**
+10. **[I] Reject speculative SIMD, zero-copy borrowed NumPy storage, copied COM examples, and hand-written DWM work until evidence requires them.**
+
+## 2 Findings (with sources)
+
+### 2.1 Local baseline and scope corrections
+
+**[V, local]** Read `00-synthesis.md`, `01-windows-audio-api.md`, `02-cpal-vs-portaudio.md`, the relevant portions of `report-01-audio-io.md` and `report-03-rust-tauri.md`, and ADR 0001 under `E:/Impulcifer/docs/`. The earlier synthesis recommends PortAudio; the later two audio decisions and this task explicitly supersede it with **wasapi 0.24.0 on Windows and cpal 0.18.2 on macOS/Linux**. This report follows that decision. ADR 0001 remains applicable: no proposal here forces CTk through the WebView service.
+
+**[V, local]** The current `core/recorder.py:514–519` starts capture on a thread; `:539` performs blocking playback; `:568` joins capture on the normal path. `:341–365` already configures per-direction WASAPI settings. Historical reports’ old fallback line numbers are not the current file. **[I]** Preserve the blocking measurement-session contract and independent streams, but add capture-ready acknowledgement and cleanup on every failure path. Do not copy the current incidental ordering into a soundness argument.
+
+**[I]** There are three different claims to track:
+
+| Claim | Meaning | What establishes it |
+|---|---|---|
+| No handwritten unsafe in an application crate | Maintainer-controlled Rust source uses no unsafe blocks/functions/impls/attributes | Compiler policy plus source/manifest checks |
+| No unsafe in the compiled dependency graph | Includes macros, standard library, platform bindings, third-party code | Not a realistic target for this application |
+| Sound safe interface | Safe callers cannot cause undefined behavior through the interface | Invariants, implementation review, appropriate tests; no single lint proves it |
+
+### 2.2 Pattern catalogue: what mature projects actually do
+
+| Project / inspected version | Verified pattern | Extracted rule / qualification |
+|---|---|---|
+| **[V] Tauri 2.11.5** | `tauri/src/lib.rs` has unsafe blocks and `unsafe impl<T> Send for UnsafeSend<T>`; no crate-root unsafe prohibition [1]. | **[I]** Application crates can forbid unsafe while using Tauri. Do not claim Tauri itself is unsafe-free. |
+| **[V] tauri-runtime-wry 2.11.4** | Main-thread dispatch wraps native state; `WindowsStore`, `DispatcherMainThreadContext<T>`, and native-handle wrappers have unsafe trait implementations. Source checks thread identity or sends through the event-loop proxy [2]. | **[I]** Thread-affinity enforcement is the substance; the wrapper name and unsafe Send declaration are not proof. Never copy those impls without the dispatch invariant. |
+| **[V] wry 0.55.0** | Windows WebView2 implementation makes unsafe COM calls behind normal WebView operations [3]. | **[I]** Own lifecycle and platform contracts below a safe API; callers should not manage controller pointers. |
+| **[V] tao 0.35.0** | Safe window operations internally call Win32 functions such as `SetWindowTextW` and `IsIconic` [4]. | **[I]** Prefer its/Tauri’s existing window operations over new application-level FFI. |
+| **[V] raw-window-handle 0.6.2** | Safe `HasWindowHandle` returns lifetime-bound `WindowHandle<'_>`; creating one from a raw handle is unsafe. Deprecated `HasRawWindowHandle` is an unsafe trait [7–9]. | **[I]** Borrow native handles for the duration of the operation; a copied integer handle is not ownership. |
+| **[V] windows-core 0.62.0 / windows 0.62 family** | `Interface` is an unsafe trait; owning interface values implement reference-counted ownership. Direct IAudioClient methods require unsafe, but `Interface::cast`, `Clone`, and `Drop` hide COM calls behind safe operations [10–12]. | **[I]** Reuse owning interface types; separately prove apartment and buffer contracts. “Every COM call is an unsafe Rust call” is false. |
+| **[V] wasapi 0.24.0** | Safe format, initialization, start/stop, capture/render APIs call windows-rs internally. `AudioClient` is `!Send + !Sync`; COM initialization helpers return HRESULT rather than an owning apartment guard [15–16]. | **[I]** A safe call surface still needs lifecycle review. Put apartment/session ownership in the adapter; do not move interfaces through Rayon/Tokio. |
+| **[V] cpal 0.18.2** | Host modules implement backend-specific native work behind `Host`, `Device`, and `Stream` APIs and callback slices. Windows platform Device/Stream docs expose Send+Sync; current upgrade notes say streams are Send+Sync everywhere [19–21]. | **[I]** Rely on the selected backend’s reviewed safe boundary, not old claims that all CPAL streams are non-Send. Platform implementation remains trusted code. |
+| **[V] PyO3 0.29.2** | Attachment token `Python<'py>`, lifetime-bound `Bound<'py,T>`, detached computation, owning `Py<T>`, safe extraction/conversion APIs; unsafe lives in interpreter/FFI and generated glue [22–26]. | **[I]** Do not use raw C API operations just because an example does. Owned Rust data crosses into workers. |
+| **[V] rust-numpy 0.29.0** | Safe owned-array transfer/copy constructors; unsafe borrowed-memory constructors and unchecked array views [27–29]. | **[I]** Owned conversion avoids application unsafe, but an input copy can still race with external mutation. |
+| **[V] RustFFT 6.4.1** | Safe planner selects SIMD or scalar implementations; feature-specific kernels contain unsafe intrinsics and target-feature declarations [30–32]. | **[I]** Reuse tested runtime dispatch. There is no initial justification for handwritten SIMD in Impulcifer. |
+
+**[V] Version qualification.** Tauri 2.11.5’s runtime dependency family uses runtime-wry 2.11.4 with requirements `wry ^0.55.0` and `tao ^0.35.0`; upstream latest versions are not necessarily the resolved versions [5]. Inspected package releases include wasapi 0.24.0 (2026-08-12), cpal 0.18.2 (2026-08-16), PyO3 0.29.2 (2026-08-05), rust-numpy 0.29.0 (2026-09-05), and RustFFT 6.4.1 (2026-07-26). **[U]** No actual future Impulcifer Cargo.lock was resolved. Mutable Microsoft/standard-library documentation is identified as such in §6.
+
+#### Tauri is useful precedent, not a blanket assurance
+
+**[V]** runtime-wry justifies some unsafe thread traits with “we ensure this type is only used on the main thread” [2]. That is a claim about every access and teardown path, not just construction. Tauri 2.11.5 also retains deprecated safe `Manager::unmanage`, whose documentation says “This method is unsafe, since it can cause dangling references” and recommends mutable managed state such as `Mutex<Option<T>>` instead [1]. **[I]** Forbid use of `unmanage` in this app. A safe signature can contain an upstream soundness defect; do not treat the signature as an audit.
+
+**[V]** Tauri `Window::set_theme(&self, Option<Theme>) -> Result<()>` is a safe desktop API; on macOS/Linux the theme affects the application [6]. **[I]** Use it before considering a DWM call. Its existence does not prove every desired titlebar appearance on every Windows release; reproduce a visual defect first.
+
+#### Handle borrowing is narrower than owning a window
+
+**[V]** `WindowHandle::borrow_raw` requires the relevant non-null/nonzero pointers to remain valid for the borrow. `WindowHandle` and `RawWindowHandle` are not Send/Sync; RawWindowHandle is Copy/Clone but does not own the native window. X11/web IDs have documented qualifications to the pointer-lifetime guarantee [7–9]. **[I]** Neither casting HWND to an integer nor cloning a COM controller extends the native window’s lifetime. Keep borrowed access on the window thread, prevent concurrent destruction, and do not store raw handles in a job object.
+
+### 2.3 COM ownership, threading, and WASAPI packets
+
+**[V]** `windows::core::Interface` is an unsafe trait with `Sized + Clone`, not `Send + Sync`, as supertraits [10].
+
+| Operation | Verified ownership semantics [10–12] | Required application policy [I] |
+|---|---|---|
+| `as_raw(&self)` | Borrowed pointer; no reference increment or ownership transfer | Never feed it to an owning constructor without acquiring a reference |
+| `into_raw(self)` | Transfers ownership of the held COM reference; prevents that wrapper’s Release | Avoid; otherwise record exactly which owner releases it |
+| `unsafe from_raw(ptr)` | Takes an already-owned reference; does not AddRef | Private leaf only, with provenance and reference-count justification |
+| `unsafe from_raw_borrowed(&ptr)` | Borrows a compatible live interface pointer | Keep lifetime local; no storage in queued work |
+| `cast::<T>()` | Safe QueryInterface, returning an owned interface on success | Prefer to manual vtable calls |
+| `Clone` / `Drop` | AddRef / Release internally | Prefer to handwritten reference counting; obey thread rules |
+
+**[V]** COM apartment rules are separate from reference counts. STA objects normally require calls in their apartment; cross-apartment use requires the appropriate marshalling/proxy or documented agility. Successful CoInitializeEx calls must be balanced, including `S_FALSE`; `RPC_E_CHANGED_MODE` is a failure [13–14]. **[I]** Arc, Mutex, AddRef, and integer pointer casts do not marshal an object. Do not add unsafe Send/Sync to work around a compiler error. MTA initialization alone is not a permission slip to move a `!Send` Rust wrapper.
+
+**[V]** WASAPI adds specific constraints: capture GetBuffer/ReleaseBuffer pairs execute on the same thread, packet storage is usable only until ReleaseBuffer, and the capture interface must be released on the thread that obtained it through GetService [17]. **[I]** These rules justify owning each stream and its interfaces entirely on one worker, even if a general COM explanation would permit more threading flexibility.
+
+**[V]** wasapi 0.24.0 exposes safe `initialize_mta()` and `deinitialize()` without a RAII apartment type [15]. **[I]** Wrap initialization in private thread-confined ownership, count successful initialization correctly, and drop all native interfaces before the last apartment guard. The guard must be retained by every object that needs the apartment; a public temporary guard plus independently escaping session is insufficient.
+
+**[V, source concern; not a confirmed vulnerability]** The pinned wasapi capture readers construct a slice for a nonempty packet before returning flags; they do not first branch on SILENT. Microsoft says to treat SILENT packets as silence and ignore actual data values [15,18]. **[U]** This study did not establish that the OS returns a null pointer in that case, or reproduce UB. **[I]** Review packet validity/initialization and SILENT handling before adoption. If slice construction itself violates the native contract, post-return checks in an outer adapter cannot fix it; patch or bypass the affected implementation.
+
+**[V]** CPAL has a safe WASAPI `Device::immdevice()` accessor, but its running WASAPI Stream does not expose the internal audio clients. A default-device accessor can resolve the current endpoint rather than the endpoint of a previously opened stream [21]. **[I]** Do not reinterpret CPAL internals to reuse its COM state. Windows is already assigned to wasapi; no CPAL-to-WASAPI stream surgery is necessary.
+
+### 2.4 Python and DSP: avoid creating more unsafe exceptions
+
+**[V]** `Python<'py>` denotes interpreter attachment; on a GIL build that includes holding the GIL, but on a free-threaded build it does not confer exclusive access. `Python` and `Bound` are not Send/Sync. `Bound::unbind` produces owning `Py<T>`; accessing Python APIs still requires attachment. Long Rust-only work should detach on both interpreter models [22–25].
+
+**[V]** PyO3 0.29.2 explicitly tests `#![forbid(unsafe_code, unsafe_op_in_unsafe_fn)]` with pyclass/pymodule/pyfunction macros [26]. The macros still generate unsafe code. **[I]** The Python bridge can meet the handwritten-code policy; this is not a claim that its expanded binary contains no unsafe. Compile the actual bridge/macros on the pinned compiler to catch expansion/lint regressions.
+
+**[V]** Stable PyO3 approximates `Ungil` through Send; its documentation demonstrates that `SendWrapper` can defeat the intended attachment boundary using safe syntax. PyO3’s nightly-feature implementation is more precise [25]. **[I]** Ban `send_wrapper` and equivalent escape hatches in first-party dependencies. This is not a reason to move the shipping product to nightly: pass only owned Rust buffers/configuration to detach, never Python borrows.
+
+| rust-numpy operation | Caller-authored unsafe? [V,27–28] | Policy [I] |
+|---|---:|---|
+| `IntoPyArray::into_pyarray` / `PyArray::from_owned_array` | No; consumes owned storage | Default output path |
+| `PyArray::from_array` | No; copies | Acceptable when ownership transfer is inconvenient |
+| `PyReadonlyArray::as_array()` followed by ndarray `.to_owned()` | No; checked Rust-side borrow then copy | Only with a credible no-concurrent-writer input contract |
+| Direct `PyArrayMethods::as_array` / `as_slice` | Yes | Prohibited in the first-party bridge |
+| `PyArray::borrow_from_array` | Yes; lifetime/reallocation/aliasing obligations | Prohibited initially; no evidence warrants it |
+
+**[V]** rust-numpy guards coordinate rust-numpy borrows, not arbitrary Python/NumPy/native accesses. NumPy warns about concurrent read/write and resize hazards [28–29]. **[I]** Copying ends subsequent sharing but does not make a racing copy safe. Do not advertise unrestricted free-threaded ndarray input as memory-safe merely because there is no handwritten unsafe.
+
+**[I] Recommended first Python boundary:** accept files, immutable Python `bytes` containing a validated little-endian f64 payload, or other independently owned serialized data; return newly owned arrays. For convenience ndarray APIs, define a separate caller-level concurrency contract and qualify/free-thread-test that surface before promising support. Reject or defer borrowed ndarray entry points when that contract cannot be enforced. Immutable bytes avoid a mutable NumPy allocation during Rust’s read, at the cost of explicit serialization/copying. Do not add a `sys-python` crate to hide the problem.
+
+**[V]** RustFFT’s safe `FftPlanner<f64>` chooses AVX/SSE/Neon/WASM/scalar implementations as applicable; AVX construction checks AVX+FMA. SSE source checks CPU support before feature-specific construction [30–31]. `#[target_feature]` alone does not perform detection; compiler-enabled features can make `is_x86_feature_detected!` constant true [32]. **[I]** No shipping `target-cpu=native`, global forced AVX/FMA, application SIMD intrinsics, unchecked indexing, or transmute-based casts. Use scalar compatibility code plus the dependency’s safe planner. SIMD changes also require numerical golden tests; memory safety is not numerical parity.
+
+### 2.5 Soundness rules for any approved wrapper
+
+**[V]** Rustonomicon defines a sound unsafe implementation as one where “safe code cannot cause Undefined Behavior through it.” It also says the unsafe obligation depends on “the state established by otherwise ‘safe’ operations” and that privacy limits the relevant scope at the module boundary [33]. **[I]** Review the entire invariant-owning module and its safe mutators, not just the red lines containing `unsafe`.
+
+| Rule [I] | Proof obligation / evidence |
+|---|---|
+| Write an invariant ledger before implementation | For each resource: origin, allocation/OS owner, extent, alignment, initialization, aliasing, permitted thread, valid states, finalizer. List all methods that can change these facts [33]. |
+| Validate at the safe boundary | Channel/rate/layout limits, `checked_mul(frames, channels)`, checked byte counts, representable lengths, supported negotiated format, sufficient slice capacity. Invalid safe input returns Err or a documented panic, never UB. |
+| Use private owned types | Prefer windows-rs owning interfaces. Where raw ownership is unavoidable, private NonNull/newtype fields with a correct Drop; no public pointer fields, Deref-to-raw, public unsafe constructors, or unsafe traits [10–11,33]. |
+| Distinguish call contract from proof site | An internal `unsafe fn` documents caller obligations under `# Safety`. Each actual unsafe operation has its own explicit unsafe block and a local `// SAFETY:` argument. `unsafe fn` does not discharge its body’s obligations [64]. |
+| Comments must prove something | State which checked length, retained owner, state transition, and thread make this particular call valid. “Windows API”, “same as example”, and “pointer is valid” are not sufficient arguments. |
+| No public repair obligations | If ordinary safe callers can break the invariant by calling in the wrong order, leaking, closing, cloning, or using invalid input, fix the API. Private state machines/typestates enforce transitions. |
+| Do not assume Drop always runs | `mem::forget` is safe. Rustonomicon: “unsafe code cannot rely on destructors to be run in order to be safe” [34]. Forgotten values may leak resources, but must not leave active callbacks pointing into freed memory. |
+| Model panic and partial construction | Acquisition guards release exactly once; partially opened streams clean up successfully acquired resources only; no panic unwinds through an incompatible foreign callback boundary. Prefer owned worker state and no custom native callbacks where blocking polling suffices. |
+| Prove Send and Sync independently | Both are unsafe traits with different promises [35]. Initial leaf policy permits neither manual impl. A private `PhantomData<Rc<()>>` can conservatively prevent automatic Send/Sync without unstable negative impls. |
+| Keep foreign borrows internal | Acquire packet, validate flags/counts, copy/decode or zero-fill, release in the same operation. No returned slice points into a driver packet; no application callback runs while such a borrow exists. |
+| Protect teardown order | Stop use, unregister callbacks if any, release stream services/client/endpoint, then release apartment ownership on the same thread. A join timeout cannot authorize freeing memory still used by a worker. |
+| Keep raw code small, not artificially one-line | Small blocks aid audit, but the state machine and safe validation remain part of the soundness review. Complexity and public states matter more than keyword count. |
+
+### 2.6 Enforcement tools: verified status and realistic role
+
+| Tool / observed version | Verified capabilities and status | Decision [I] |
+|---|---|---|
+| **[V] rustc `unsafe_code`** | Rejects unsafe constructs and potentially unsound attributes including no_mangle/export_name/link_section. `forbid` prevents ordinary nested allow, but lint caps/force-warn can alter invocation-level behavior [36–37]. | Required; control the invocation and inspect configuration. Not transitive to dependencies. |
+| **[V] Cargo workspace lints** | Since Cargo 1.74; every member must opt in with `[lints] workspace = true` [38]. | Required plus metadata checks; workspace membership alone does not inherit policy. |
+| **[V] Clippy** | `undocumented_unsafe_blocks` and `multiple_unsafe_ops_per_block` are restriction lints, off by default. `missing_safety_doc` is style, normally warn. Macro expansions have exclusions; comments are not semantically proved [39–41,76]. | Explicit deny for all three in the leaf. Apply missing-safety documentation to private unsafe helpers by project review too. |
+| **[V] cargo-deny 0.20.2**, 2026-07-09 | Advisories/licenses/bans/sources; current package MSRV 1.88.0 [46–49]. | Mandatory dependency-policy gate. Has recent release evidence; not a code soundness scanner. |
+| **[V] cargo-audit 0.22.2**, 2026-06-05 | RustSec advisory checking; binary auditing also exists [50–51]. | Weekly and release audit. Overlaps cargo-deny; useful standalone artifact/report, not independent source review. |
+| **[V] cargo-vet 0.10.2**, 2026-01-13 | Tracks full/delta audits, criteria, imports, exemptions, and publisher trust [42–45,75]. | Preferred review ledger/gate. Use custom unsafe review criterion for critical dependencies; human approval required for new exemptions. |
+| **[V] cargo-crev 0.27.1**, 2026-04-12 | Signed reviews and web-of-trust; actual verify command is `cargo crev crate verify` [57–58]. | Optional evidence source, not a second mandatory ledger. Signed opinion is not a memory-safety proof. |
+| **[V] cargo-geiger 0.13.0**, 2025-08-31 | Unsafe usage statistics; changelog fixes Rust 1.89 compilation. Source uses syntactic parsing/build-associated source information, not a whole-program proof [52–56,74]. | Advisory inventory/diff only. **[U]** Successful build and correct counting on 1.98.1 untested; maintenance cadence not established. |
+| **[V] Miri, nightly component** | Detects several UB classes/races in executed Rust paths; most FFI/platform APIs unsupported, Windows has less system support than Linux [59]. | Required selected pure/model tests; cannot execute/verify real WASAPI or WebView2 COM integration. |
+| **[V] ASan/TSan, nightly `-Zsanitizer`** | Instrument executed code; Linux x86_64 supported. Instrumenting std recommended; TSan synchronization visibility/atomics limitations remain [60]. | Separate periodic jobs on selected pure/worker targets, not the whole desktop process. |
+| **[V] Kani** | Bit-precise harness-based verification including unsafe use cases; `cargo kani --harness <name>` and bounded unwinding documented [61–62]. | Optional integer length/routing/state helpers with small bounds. Do not promise entire f64 DSP or COM proofs. |
+| **[V] Verus** | Specification-driven verification of a supported Rust subset, with support for some raw-pointer reasoning; active development/incomplete coverage [63]. | No initial gate. Solo-maintainer cost is unjustified absent a small invariant that tests/review cannot handle. |
+
+**[V] Important geiger installation warning:** open issue #564 reports `cargo install --locked` selecting yanked `crossbeam-channel 0.5.14`, affected by RUSTSEC-2025-0024; it links a proposed fix, not a verified release [54]. **[I]** Do not blindly install that locked toolchain into privileged release jobs. Use an independently reviewed fixed tool lock/binary in a no-secrets inventory job, or report geiger unavailable. Do not “fix” it by unpinning everything and ignoring advisories. The report does **not** claim installation necessarily fails.
+
+**[I] Tool distinction:** deny/audit answer known-advisory/policy questions; vet/crev record human trust/review; geiger helps locate unsafe; Clippy checks syntax/documentation patterns; Miri/sanitizers test paths; Kani/Verus prove specified properties within supported models. None audits Windows drivers or WebView2 itself.
+
+### 2.7 Edition, compiler, and nightly policy
+
+| Item | Verified behavior | Proposed policy [I] |
+|---|---|---|
+| **[V] Edition 2024** | Stable since Rust 1.85.0 [68]. | Use edition 2024; this is an edition floor, not the actual dependency MSRV. |
+| **[V] `unsafe_op_in_unsafe_fn`** | Warn by default in edition 2024 [64]. | Deny explicitly, including the leaf; no reliance on edition warning defaults. |
+| **[V] Foreign declarations** | `unsafe extern` block required; individual items can be explicitly safe if their caller contract permits it [65]. | No first-party extern blocks outside the leaf. Do not relabel a pointer-taking foreign function safe merely to silence callers. |
+| **[V] Unsafe attributes** | `#[unsafe(no_mangle)]`, `#[unsafe(export_name = ...)]`, `#[unsafe(link_section = ...)]` required in 2024 [66]. | Forbid handwritten instances outside leaf; PyO3 macro expansions are separately reviewed dependencies. |
+| **[V] Newly unsafe std functions** | `set_var`, `remove_var`, Unix `before_exec` become unsafe in 2024 [67]. | Read environment; keep runtime configuration in Rust objects; set child environment through safe `Command::env`/`env_remove`. Do not open another exception for process-global mutations. |
+| **[V] Rust 1.98.1** | Published 2026-09-03, fixes 1.98.0 vtable-generation miscompilation potentially causing UB [69]. | Pin 1.98.1 for the first candidate, not 1.98.0. Re-run all gates on compiler updates. |
+| **[V] `-Zbuild-std`** | Needs nightly Cargo/rustc and rust-src; rebuilds std [70]. | No use for normal release builds. Useful deliberately in sanitizer jobs, despite being unnecessary for ordinary compilation. |
+| **[V] Miri** | `cargo +nightly miri test`; interpreter options go through MIRIFLAGS [59]. | Pin a dated nightly after a successful pilot. There is no generic stable `cargo -Zmiri` substitute. |
+
+**[I] MSRV policy:** initially declare `rust-version = "1.98"` for first-party packages and require shipping/CI toolchain 1.98.1. This avoids an untested historical support promise while not treating the edition floor as dependency compatibility. If an older source-build MSRV matters, determine the full resolved graph’s requirements, test that exact compiler separately, and only then lower the declared floor. Update MSRV deliberately in release notes; independent audit tools may have their own compiler requirement. Maintain stable shipping and dated-nightly analysis pins separately. **[U]** Actual minimum for the final Tauri/PyO3/wasapi graph remains untested.
+
+## 3 Proposed architecture
+
+All of §3 is **[I] proposed design**, except explicitly cited compiler/tool behavior. No repository implementation or workflow was changed.
+
+### 3.1 Workspace and unsafe budget
+
+A budget is permission for named operations after approval, not a target number to consume. Start with no first-party unsafe at all. Instantiate or relax the one reserved leaf only if the inventory proves a needed operation lacks a sound safe dependency API.
+
+| Crate / target | Responsibility / dependencies | First-party unsafe budget |
+|---|---|---|
+| `impulcifer-types` | Checked configuration, channel/layout types, errors; serde | **0; forbid** |
+| `impulcifer-dsp` | f64 SciPy-compatible primitives, RustFFT/RealFFT, ndarray/nalgebra, Rayon | **0; forbid**; no home-grown SIMD |
+| `impulcifer-io` | WAV/CSV/TXT, ffmpeg process management, safe byte parsing | **0; forbid** |
+| `impulcifer-analysis` | Analysis arrays, plotters PNG, offline Plotly assets | **0; forbid** |
+| `impulcifer-audio-io` | Backend selection, measurement orchestration, owned PCM, readiness/drain/cancel; cpal on macOS/Linux | **0; forbid** |
+| `impulcifer-sys-win` | Private Windows endpoint/session implementation using wasapi; optional direct windows-rs operations | **Only permitted leaf**; initial allowance **0**, additions individually approved; hard review tripwire **12 blocks / 120 lines inside unsafe blocks** |
+| `impulcifer-jobs` | seq journal, job lifecycle, cooperative cancellation, bounded work queues | **0; forbid** |
+| `impulcifer-service` | JSON-safe application operations, settings, validation | **0; forbid** |
+| `impulcifer-app` | Tauri commands, dialogs/theme/opener, updater adapters | **0; forbid**, including build.rs and targets |
+| `impulcifer-cli` | Headless CLI over the same core/service | **0; forbid** |
+| `impulcifer-python` | PyO3/maturin, immutable/owned input boundary, owned NumPy output | **0 handwritten; forbid**, PyO3-generated glue reviewed separately |
+| `impulcifer-policy` | Safe Rust CI checker using Cargo metadata + syntax/TOML parsing | **0; forbid** |
+| tests/examples/benches/build scripts | Same policy as owning crate; root attributes on each crate target | No separate exception |
+
+The tripwire is an initial scope constraint, **not a soundness metric or a statement that 12 blocks are needed**. In the leaf: **0 public unsafe functions, 0 handwritten unsafe Send/Sync impls, 0 static mut, 0 transmute, 0 SIMD/assembly, 0 exported raw pointers**. Required generated bindings remain the `windows` dependency, not checked-in binding code. Exceeding the tripwire or needing another category requires a maintainer-approved ADR before implementation.
+
+Do not create one universal `unsafe-utils` crate. If future Python/SIMD unsafe is truly indispensable, reject that patch under this policy and explicitly decide a new domain-specific leaf; do not put Python or SIMD into the Windows crate to game the “one leaf” rule.
+
+```text
+existing vanilla UI + JSON catalogues
+                 |
+         impulcifer-app (Tauri)
+                 |
+        impulcifer-service <---------- impulcifer-cli
+                 |
+          impulcifer-jobs
+           /           \
+impulcifer-dsp      impulcifer-audio-io
+     ^              /              \
+     |      [Windows only]      [macOS/Linux only]
+impulcifer-python   impulcifer-sys-win       cpal
+     |                 |
+ owned bridge         wasapi ---> windows/windows-core
+                       |
+             approved missing native operations only
+
+io + analysis + types: shared safe crates; no Tauri/Python dependency
+app ---> Tauri/runtime-wry/wry/tao (upstream native trust boundary)
+app ---> Velopack (Windows), Tauri updater (macOS/Linux)
+policy checker: build-time only, no application dependency
+```
+
+All arrows are dependency/call direction, not a process isolation boundary. The Windows leaf depends on small common types if needed, never on audio-io/service/app. DSP and Python do not depend on the Windows leaf. The headless CLI need not link Tauri; the DSP wheel need not include native recording backends unless that becomes an explicit Python requirement.
+
+### 3.2 Windows leaf safe API sketch
+
+Illustrative Rust declarations, **not compiled**. Private fields and validated constructors matter more than exact spelling. Error types own their diagnostic data. No HWND, COM interface, native pointer, unsafe trait, or callback taking a raw buffer crosses this boundary.
+
+```rust
+// impulcifer-sys-win/src/lib.rs
+#![deny(unsafe_op_in_unsafe_fn)]
+#![deny(clippy::undocumented_unsafe_blocks)]
+#![deny(clippy::multiple_unsafe_ops_per_block)]
+#![deny(clippy::missing_safety_doc)]
+
+pub struct EndpointId { /* owned stable identifier; private */ }
+pub struct Endpoint { /* owned metadata; private */ }
+pub enum Direction { Input, Output }
+pub enum ShareMode { Exclusive, SharedAutoConvert }
+pub struct StreamSpec { /* checked rate, channels, routing, format */ }
+pub struct PlaybackBuffer { /* checked interleaved Vec<f32> */ }
+pub struct CancelToken { /* cloneable Arc<AtomicBool>; private */ }
+pub struct PlaybackReport { /* submitted/drained frames, mode, xruns */ }
+pub struct CaptureRead { /* frame count, discontinuity, timestamps */ }
+pub struct Error { /* stable kind and owned details */ }
+
+// Both are intentionally !Send and !Sync; all native fields are private.
+pub struct OutputSession { /* interfaces + retained apartment owner */ }
+pub struct CaptureSession { /* interfaces + retained apartment owner */ }
+
+pub fn enumerate(direction: Direction) -> Result<Vec<Endpoint>, Error>;
+pub fn open_output(id: &EndpointId, spec: StreamSpec)
+    -> Result<OutputSession, Error>;
+pub fn open_capture(id: &EndpointId, spec: StreamSpec)
+    -> Result<CaptureSession, Error>;
+
+impl OutputSession {
+    pub fn play_to_completion(
+        &mut self,
+        buffer: PlaybackBuffer,
+        cancel: &CancelToken,
+    ) -> Result<PlaybackReport, Error>;
+}
+impl CaptureSession {
+    // Returns only after capture has actually started, not just queued.
+    pub fn start(&mut self) -> Result<(), Error>;
+    // Returns initialized interleaved f32 samples in caller-owned storage.
+    // Checks capacity/alignment in frames; timeout is a typed result/error.
+    pub fn read_into(
+        &mut self,
+        dst: &mut [f32],
+        cancel: &CancelToken,
+    ) -> Result<CaptureRead, Error>;
+    pub fn stop(&mut self) -> Result<(), Error>;
+}
+```
+
+**Ownership implementation rules.**
+
+- Open/create on the actual worker, not the UI thread followed by a send. An internal thread-local weak reference to a private `Rc<Apartment>` can share one initialized apartment across sessions on that thread. Each session retains a strong reference. Constructors return owned metadata only from enumeration.
+- Track successful COM initialization and balance it even for S_FALSE. Never call deinitialize after an initialization failure. Native interfaces must be dropped before the session releases its apartment ownership. Use explicit `Option::take` cleanup or audited field order, not an undocumented accident.
+- Do not export the guard or deinitialize function. Leaking a session must leak its necessary apartment/native ownership, not terminate COM underneath another live object. Miri/model tests cover ownership bookkeeping; native tests cover actual COM behavior.
+- Use windows-rs RAII interface types; a custom pointer newtype is justified only where they cannot represent ownership. `Drop` must not panic. A foreign callback, if introduced later, requires registration lifetime and in-flight-call synchronization review.
+- Safe numeric conversion is adequate here: use validated `to_le_bytes`/`from_le_bytes` or a reviewed safe cast dependency, not application `from_raw_parts` on `Vec<u8>`. `Vec<u8>` does not promise f32 alignment. Checked lengths and negotiated block alignment must agree.
+- A packet guard is private and never returned. For SILENT, fill zero without reading unspecified payload. Check discontinuity/device invalidation and report them; do not treat “all samples submitted” as “drained”. Cancellation stops the session and reports cancellation rather than a successful drain.
+- Even a zero-byte slice has Rust pointer validity/alignment rules. Branch on empty/silent cases before constructing any raw slice in an approved native fallback.
+
+**Two-stream orchestration in the safe audio crate.**
+
+1. Capture worker resolves its endpoint and opens/starts capture; only then sends Ready or Error.
+2. Playback worker creates its own output session on its own thread, submits the owned buffer, and waits for the selected backend’s drain condition.
+3. Coordinator requests capture stop after the specified tail, joins both workers, and returns the measurement result. Errors and cancellation take the same cleanup path.
+4. Progress snapshots contain owned metadata/counters. Driver buffers and Python references never appear in event messages.
+5. All waits check cancellation and device loss. If a driver is stuck, do not free state still used by its worker or kill a Rust thread. A leaked/quarantined worker or process-level recovery may be necessary; document that operational failure separately from memory safety.
+
+Use wasapi’s safe operations wherever valid. A missing operation involving existing AudioClient state must be implemented where that state is owned, potentially by a reviewed upstream patch/vendor fork. Do not invent a leaf `extend_stream(raw_pointer)` escape that forces audio-io to extract private pointers.
+
+**DWM exception policy.** Initially no DWM API in this leaf: use `Window::set_theme`. If a reproduced requirement later needs one, keep it a synchronous safe operation over a borrow tied to a live window, invoked by the app on its UI thread with destruction excluded. Never expose `set_dark_titlebar(hwnd: usize, ...)` as a supposedly safe public API; arbitrary integers cannot guarantee a live owned window or correct dispatch. If that proof needs a Tauri-specific adapter, revise the architecture rather than making the Windows leaf depend on the app and creating a cycle.
+
+### 3.3 Lint configuration and tamper-resistant checks
+
+**[V]** Workspace lints require member opt-in and apply to that package, not its dependencies [38]. **[I]** Use a workspace default, redundantly put the attribute in every safe crate root, and let the sole leaf explicitly define its own policy.
+
+```toml
+# Workspace Cargo.toml, proposed
+[workspace]
+resolver = "3"
+members = ["crates/*"]
+
+[workspace.package]
+edition = "2024"
+rust-version = "1.98"
+
+[workspace.lints.rust]
+unsafe_code = "forbid"
+unsafe_op_in_unsafe_fn = "deny"
+
+[workspace.lints.clippy]
+undocumented_unsafe_blocks = "deny"
+multiple_unsafe_ops_per_block = "deny"
+missing_safety_doc = "deny"
+```
+
+```toml
+# Each ordinary member
+[lints]
+workspace = true
+```
+
+```rust
+// Every ordinary lib.rs/main.rs/build.rs/test/example crate root
+#![forbid(unsafe_code)]
+#![deny(unsafe_op_in_unsafe_fn)]
+```
+
+```toml
+# Sole approved leaf's Cargo.toml; deliberately does not inherit forbid
+[lints.rust]
+unsafe_op_in_unsafe_fn = "deny"
+[lints.clippy]
+undocumented_unsafe_blocks = "deny"
+multiple_unsafe_ops_per_block = "deny"
+missing_safety_doc = "deny"
+```
+
+The leaf’s root still forbids unsafe until an approved exception removes that attribute. `unsafe_code = "deny"` globally with local allow is weaker than the proposed forbid policy; do not use it for ordinary members. Lint-table priorities order groups versus specific lints but cannot authorize weakening inherited forbid [37–38].
+
+**Protected policy checker specification.** `impulcifer-policy` must be implemented before native work, not assumed to exist. Its proposed `check` command does the following:
+
+- Uses `cargo metadata` to enumerate workspace packages/targets; checks every lib/bin/build/test/example/bench root, including explicit nonstandard target paths.
+- Requires ordinary members to inherit lints and root attributes; exactly one named Windows leaf may opt out. A new crate is zero-unsafe by default, including internal helper tools and path dependencies.
+- Parses first-party Rust/TOML rather than relying on a text grep. Records unsafe blocks/functions/impls/extern blocks/unsafe attributes, source path, reason ID, and budget; rejects public unsafe or unapproved categories in the leaf. Comment-only occurrences do not count.
+- Checks platform/feature-gated source too. Compiler checks execute only active configurations; the source policy scan catches forbidden syntax hidden under `cfg(any())` or another target.
+- Audits all first-party `.cargo/config*`, build scripts, manifests and CI environment for lint caps, force-warn overrides, compiler wrappers, generated includes, proc-macro additions, arbitrary rustc flags, and bypassed target roots. No trusted build script downloads/generates new native code without approval.
+- Resolves direct dependency ownership: only the leaf may directly use windows/windows-core/wasapi; only audio-io may directly use cpal; only python may use PyO3/numpy; only app may use Tauri/Velopack. Upstream transitive use is allowed and audited separately.
+- Rejects first-party `send_wrapper`, raw-pointer transport helpers, global target-cpu=native/forced SIMD release flags, and the deprecated Tauri unmanage API. No all-features run that accidentally enables ASIO.
+- Tests itself with fixtures that deliberately remove inheritance, add forbidden unsafe to build.rs, hide it behind cfg, change lint flags, add a second exception crate, and exceed the leaf budget. These fixtures are data, not runnable application crates.
+
+**Limits and governance.** rustc documents that `--cap-lints` can lower even forbid and `--force-warn` has special precedence [37]. External macro expansion has lint-hygiene exclusions; a handwritten-unsafe lint is not complete expanded-code accounting [26,39–41]. Use approved pinned macro dependencies and inspect expansion changes when updating them. Do not promise a source parser can prove generated code safe.
+
+The check’s source/config, workflows, toolchain files, manifests, audit ledger, exceptions, and leaf changes require maintainer review. Branch protection must require policy success, disallow unattended direct pushes/bypass, and keep signing/publishing credentials out of PR jobs. An AI agent can edit a checker it is allowed to edit; CI alone cannot protect against a maintainer approving its removal. A solo maintainer supplies the approval; an independent AI review is useful evidence, not a substitute approver.
+
+### 3.4 Exact proposed CI gate list
+
+These are **[I] commands for the proposed workspace**, not executed verification. Install OS libraries and supported Python required by Tauri/cpal/PyO3 first; GUI/native builds run on their own OS. Use approved feature lists per platform, not indiscriminate `--all-features`. Here `desktop` is a proposed service/app feature set, and `scalar` a proposed DSP feature disabling SIMD-dependent test execution; create/test those features before adopting the commands.
+
+**Shared pins and tooling setup.** Initial shipping toolchain is 1.98.1. `$NIGHTLY` below must be an exact dated nightly selected by a successful Miri/sanitizer pilot, not a floating value; no known-working date was established here. All shell snippets below use Bash (also available on GitHub Windows runners). Verify/cache tool binaries by version and checksum; source installation commands are shown for reproducibility, not an instruction to rebuild them in every job.
+
+```sh
+rustup toolchain install 1.98.1 --profile minimal --component rustfmt --component clippy
+cargo +1.98.1 install --locked cargo-deny --version 0.20.2
+cargo +1.98.1 install --locked cargo-audit --version 0.22.2
+cargo +1.98.1 install --locked cargo-vet --version 0.10.2
+```
+
+| Job / frequency | Commands | Rough wall time [I], not measured |
+|---|---|---:|
+| **policy-format**, every PR, Linux | `cargo +1.98.1 fmt --all -- --check`; `cargo +1.98.1 run --locked -p impulcifer-policy -- check` | 1–3 min warm; checker first build extra |
+| **stable-native**, every PR, Windows/macOS/Linux | `cargo +1.98.1 clippy --locked --workspace --all-targets -- --no-deps -D warnings`; `cargo +1.98.1 test --locked --workspace --all-targets`; `cargo +1.98.1 test --locked --workspace --doc` | 3–10 min warm per OS; 10–30+ cold |
+| **feature-contracts**, every PR, each relevant OS | `cargo +1.98.1 check --locked -p impulcifer-dsp --no-default-features`; `cargo +1.98.1 check --locked -p impulcifer-cli --no-default-features`; `cargo +1.98.1 check --locked -p impulcifer-app --features desktop`; `cargo +1.98.1 test --locked -p impulcifer-dsp --features scalar` | 2–8 min warm |
+| **dependency-policy**, every PR + daily schedule | `cargo deny --locked check advisories bans licenses sources`; `cargo vet check --locked` | 1–4 min after tool setup |
+| **dependency-refresh**, scheduled trusted review job | `cargo vet check`; `cargo vet suggest`; `cargo audit --file Cargo.lock` | 1–4 min, human audit excluded |
+| **windows-leaf**, every PR touching leaf/audio/dependency/compiler | `cargo +1.98.1 test --locked -p impulcifer-sys-win --all-targets`; `cargo +1.98.1 test --locked -p impulcifer-audio-io --all-targets` | 1–5 min warm |
+| **miri-models**, every PR touching DSP/state/leaf models; weekly otherwise | Dated nightly setup and commands below | 5–20 min for deliberately small fixtures |
+| **asan-core**, weekly + native-memory changes | Separate ASan command below | 10–25 min cold; 3–10 warm |
+| **tsan-jobs**, weekly + concurrency changes | Separate TSan command below | 10–25 min cold; 3–10 warm |
+| **unsafe-inventory**, dependency/leaf PRs + weekly, advisory | Reviewed geiger binary commands below; archive JSON and compare to approved baseline | 2–10+ min; tool/build failure must be reported |
+| **python-boundary**, Python/dependency/compiler PRs, selected regular + free-threaded interpreters | `python -m maturin build --locked --manifest-path crates/impulcifer-python/Cargo.toml --out dist`; `python -m pip install --no-deps --force-reinstall dist/*.whl`; `python -m pytest tests/python_boundary -q` | 3–12 min per interpreter/OS warm |
+| **numerical-goldens**, every DSP/compiler/dependency PR | `cargo +1.98.1 test --locked -p impulcifer-dsp --test golden_parity --release`; `cargo +1.98.1 test --locked -p impulcifer-io --test wav_contract` | 2–10 min warm, corpus-dependent |
+| **hardware-release**, controlled Windows/macOS device runner or signed maintainer acceptance | `cargo +1.98.1 test --locked -p impulcifer-audio-io --test hardware_acceptance -- --ignored --test-threads=1` | 10–30+ min plus setup |
+| **packaged-smoke**, release candidate, each OS | Existing release-specific installer/launch/update tests, expanded for Rust shell and leaf; no generic honest one-command substitute | Measure prototype; not included in estimates above |
+
+`desktop`, `scalar`, `golden_parity`, `wav_contract`, `hardware_acceptance`, `tests/python_boundary`, and `impulcifer-policy` are **new specified fixtures/features to implement**, not existing files. Unit tests must not unexpectedly access microphones; real-device tests are ignored by default and invoked only in the controlled hardware job. PyO3 extension linking differs from embedding/test linking: keep extension-module build configuration separate if necessary, and exercise both rather than forcing an invalid all-features matrix. Use one clean `dist` per wheel job so the install command selects one wheel. Pip/maturin/test dependencies require their own pinned tooling environment.
+
+**Miri setup and exact interpreter invocation [I, based on 59].**
+
+```sh
+rustup toolchain install "$NIGHTLY" --profile minimal --component miri --component rust-src
+cargo +"$NIGHTLY" miri setup
+MIRIFLAGS="-Zmiri-many-seeds=0..8" \
+  cargo +"$NIGHTLY" miri test --locked -p impulcifer-jobs --lib
+cargo +"$NIGHTLY" miri test --locked -p impulcifer-dsp --no-default-features --features scalar --lib
+cargo +"$NIGHTLY" miri test --locked -p impulcifer-sys-win --lib --features model-tests
+```
+
+The leaf’s proposed `model-tests` feature builds platform-independent state/length/apartment-accounting models with a fake foreign backend on Linux. Native Windows modules remain cfg-gated out. Passing these tests is **not** passing the COM implementation. Keep fixtures tiny and no huge FFTs. Miri checks exercised executions and seeds, not all schedules. Do not disable isolation/checks simply to make desktop/FFI tests pass. Its experimental native-library support on Unix does not turn it into a WASAPI verifier [59].
+
+**Sanitizers [I, based on 60,70].** Use independent target directories; rebuild std intentionally. Explicit target prevents instrumentation flags leaking into host build scripts/proc macros.
+
+```sh
+rustup toolchain install "$NIGHTLY" --profile minimal --component rust-src
+CARGO_TARGET_DIR=target/asan \
+RUSTFLAGS="-Zsanitizer=address" RUSTDOCFLAGS="-Zsanitizer=address" \
+  cargo +"$NIGHTLY" test --locked -Zbuild-std \
+  --target x86_64-unknown-linux-gnu \
+  -p impulcifer-dsp -p impulcifer-io --lib
+
+CARGO_TARGET_DIR=target/tsan \
+RUSTFLAGS="-Zsanitizer=thread" RUSTDOCFLAGS="-Zsanitizer=thread" \
+  cargo +"$NIGHTLY" test --locked -Zbuild-std \
+  --target x86_64-unknown-linux-gnu -p impulcifer-jobs --lib
+```
+
+Provide llvm-symbolizer. Do not combine ASan/TSan in one binary. `-Zbuild-std` instruments Rust std, not every native library. TSan requires visibility into synchronization and has documented limitations around atomic fences/assembly [60]. Test the actual Rayon/queue dependency combination before promoting this job to a required gate. Neither Linux command instruments Windows COM. Windows OS/runtime verification and optional native diagnostic tooling are complementary, not replaced by these jobs.
+
+**Geiger [I, based on 52–56,74].** After qualifying a fixed tool binary independently:
+
+```sh
+cargo geiger --locked --all-targets --output-format Json > unsafe-inventory.json
+cargo geiger --locked --forbid-only --output-format Json > forbid-inventory.json
+```
+
+Here geiger’s `--all-targets` concerns target dependency inclusion, not proof that every target-specific body or macro expansion was compiled. Avoid `--all-features`: it may add unwanted ASIO and change the trust surface. Run resolved/platform-specific inventories as appropriate, record enabled features and tool version, and retain the policy checker as the authoritative first-party gate. An inventory failure must show `unavailable/failed`, not an empty green report.
+
+**Optional Kani proof pilot [I,61–62].**
+
+```sh
+cargo kani --harness checked_frame_bytes --default-unwind 32
+```
+
+Pin/install Kani separately after selecting a release; no current working Kani version was verified. Bound frames/channels and prove arithmetic/offset/state properties, retain unwinding assertions, and distinguish assumptions from conclusions. A passing proof with a fake COM backend establishes the model property only. No initial Verus gate: proof annotations and solver maintenance are additional implementation work, not free safety.
+
+**Gate policy.** Standard lints/tests/dependency-policy and relevant boundary tests are required. Hardware acceptance is mandatory before publishing a changed audio backend, not on arbitrary untrusted PR hardware access. Miri/sanitizer infrastructure outages are visible and require an explicit temporary waiver with owner/expiry, not silent continue-on-error. Geiger and optional formal proofs are advisory until qualified. Cold compiler/tool installs are not included in warm estimates. These times are planning ranges, not performance claims.
+
+**Release sequencing.** Preserve `publish.yml` and its PyPI OIDC identity from the existing project. Integrate the new required checks before publishing wheels; keep desktop distribution gated on the established release decision. Do not publish a wheel and only then discover an unsafe-policy failure. CI design and approval remain maintainer-owned.
+
+### 3.5 Dependency selection, audit, and update workflow
+
+1. **Start from required semantics.** Prefer a maintained safe API with bounded, reviewed unsafe over a zero-unsafe crate that cannot implement the contract. `forbid` badges and geiger counts are selection signals, not sufficient evidence; neither accounts for all transitive/proc-macro/native behavior [36,52–56].
+2. **Record provenance.** Commit Cargo.lock; pin git dependencies by full revision and use registries with checksums. List target/features and native system libraries. Audit release artifacts’ actual graph, build dependencies, and proc macros. All these can affect the product even if application source has zero unsafe.
+3. **Prioritize sensitive dependencies.** Review wasapi packet/lifecycle routines, cpal’s selected hosts, windows-core ownership, PyO3/rust-numpy boundary operations, FFT dispatch, Tauri runtime state/thread logic, and updater code. Review current RustSec history and fixes; absence of an advisory is not an audit. The known geiger-tool advisory is a reminder that CI tools also have dependencies [54].
+4. **Use cargo-vet as the record.** Import only explicitly trusted audits; inspect new packages and deltas, then certify after review. Example commands: `cargo vet inspect wasapi 0.24.0`, `cargo vet diff wasapi OLD NEW`, `cargo vet certify wasapi 0.24.0`. OLD/NEW are reviewed versions, not literal CLI values [44]. An agent may prepare findings but may not certify or change exemptions without approval.
+5. **Add a strict custom criterion for critical unsafe.** Built-in safe-to-deploy says ideally all unsafe is sound but permits auditor judgment; do not misrepresent it as the project goal [42]. A proposed criterion below requires review of all reachable unsafe and relevant safe invariant-maintaining code for the declared platform/features, documented limitations, and no known unresolved soundness hole in that scope. Explicitly list scope in audit notes; reassess when enabling features.
+6. **Use exemptions honestly.** Initial vet onboarding/exemptions can make coverage appear complete without source review. Do not exempt the critical audio/Python unsafe surface merely to get a green dashboard. For unavoidable wider-framework exemptions, record unresolved scope, owner, and a review deadline in the project ledger. Do not claim native dependencies have been completely audited.
+7. **Do not replace audits with publisher trust.** Publisher trust/wildcards authorize future releases under assumptions; the publisher need not inspect every contribution [45]. Do not apply them to the custom soundness criterion. cargo-crev may supply useful outside reviews; record which identity and scope were trusted rather than blindly importing popularity [58].
+8. **Upgrade in small reviewed changes.** Pin the old/new graph, inspect unsafe and safe invariant changes, refresh advisory/audit records, rerun platform/macros/goldens/hardware tests as applicable. Compiler updates also rerun numerical and boundary gates. Never auto-merge native dependency bumps because SemVer says patch.
+9. **If a needed crate has unaudited unsafe:** first review the relevant implementation and upstream documentation; prefer an upstream fix. A temporary vendored fork must preserve provenance/license, carry a minimal patch and tests, and have an update/removal plan. Treat vendored code as first-party-reviewed even if its source is outside `crates/`.
+10. **If the safe API is actually unsound, a safe façade alone cannot repair UB that occurs inside it.** Patch/bypass the offending operation or reject/defer the dependency. Writing a wrapper ourselves means taking responsibility for the native contract, not sprinkling checks after the dangerous call. A crate boundary offers no memory isolation; if crash containment is required, use a separately designed process boundary.
+
+Proposed audit configuration, based on cargo-vet’s documented syntax [43]; package policy must be completed against the actual resolved graph:
+
+```toml
+# supply-chain/audits.toml
+[criteria.impulcifer-soundness-reviewed]
+description = "Reviewed reachable unsafe and invariant-maintaining safe code for the explicitly recorded targets/features; no known unresolved soundness defect in that scope."
+implies = "safe-to-deploy"
+```
+
+```toml
+# supply-chain/config.toml (illustrative direct-dependency requirements)
+[policy.impulcifer-sys-win]
+dependency-criteria = { wasapi = "impulcifer-soundness-reviewed", windows = "impulcifer-soundness-reviewed", windows-core = "impulcifer-soundness-reviewed" }
+
+[policy.impulcifer-python]
+dependency-criteria = { pyo3 = "impulcifer-soundness-reviewed", numpy = "impulcifer-soundness-reviewed" }
+```
+
+Do not stamp this criterion after reading only one method while leaving reachable operations unexamined. Large framework reviews may exceed a solo maintainer’s capacity; distinguish imported audited coverage from a documented risk acceptance instead of lowering the definition. Add explicit policies for CPAL/RustFFT and the selected Tauri graph after deciding tractable review scope.
+
+**[V]** cargo-deny’s bans `wrappers` setting constrains direct dependents of a banned crate; it is not arbitrary workspace-root path analysis [48]. **[I]** Use it where expressible, but do not globally ban windows-rs and accidentally reject Tauri. The project metadata checker enforces first-party ownership of platform dependencies.
+
+### 3.6 One-page unsafe policy for CONTRIBUTING / CLAUDE.md
+
+The following is **[I] proposed paste-ready policy**.
+
+> ## Unsafe Rust policy
+>
+> **Goal.** All application code is safe Rust. `impulcifer-sys-win` is the only crate eligible for a handwritten unsafe exception; it starts with zero approved operations. This does not claim dependencies, macros, the standard library, or the OS contain no unsafe.
+>
+> **Default.** Every other library, binary, build script, test, example, and helper uses `#![forbid(unsafe_code)]`, denies `unsafe_op_in_unsafe_fn`, and inherits workspace lints. Do not remove these rules, add lint caps, hide code behind cfg/macros/generated files, or create another exception crate.
+>
+> **Before adding unsafe.** Identify the unmet requirement; show why the selected safe API cannot satisfy it; link the exact upstream/native contract; propose the smallest safe interface and an invariant ledger. Obtain maintainer approval before writing it. DWM, SIMD, process-environment mutation, zero-copy NumPy borrowing, and copied native examples are not automatic exceptions.
+>
+> **Leaf contract.** Public APIs expose owned values, checked configurations, borrowed ordinary slices, enums, and Result. No public raw pointers/COM interfaces, unsafe functions/traits, static mut, transmute, or manual Send/Sync. Native objects are created, used, and released on the owning worker; COM initialization outlives every dependent object. Native packet borrows never escape. Invalid safe inputs cannot cause UB.
+>
+> **Proof and cleanup.** Document caller obligations of private unsafe functions under `# Safety`. Put an operation-specific `// SAFETY:` explanation immediately before each unsafe block/impl. Prove lengths, alignment, initialization, aliasing, provenance, thread/apartment and lifetime. Handle cancellation, panic, partial construction, device loss, and repeated close. Drop must not panic; forgetting a value may leak but must not enable use-after-free.
+>
+> **Budget.** Each unsafe site has an approved reason ID. More than 12 blocks or 120 lines inside unsafe blocks requires a new architecture review, not a waived counter. Safe code maintaining the same invariants is part of that review. Counters and comments do not prove soundness.
+>
+> **Python and workers.** Only independently owned Rust buffers/configuration enter detached/Rayon work. Do not send Python attachment tokens, Bound values, borrowed NumPy memory, or COM interfaces. Do not use SendWrapper. A copy does not make concurrent mutation during copying safe; immutable/serialized inputs are the default free-threaded boundary.
+>
+> **Dependencies.** Keep reviewed locks and feature sets. Review unsafe-related source changes and RustSec history. Agents may prepare audit evidence but may not certify cargo-vet audits, add exemptions, change trusted publishers, or suppress advisories without maintainer approval. Unsafe inside an unsound dependency is not repaired by calling it from a safe crate.
+>
+> **Required evidence.** Run policy/format, platform Clippy/tests, dependency checks, selected Miri/model tests, numerical goldens, and relevant Python/audio tests. Native audio changes require controlled hardware acceptance. Report failures, skips, and unsupported tools. Miri cannot verify COM; geiger is inventory. Compiler, workflow, audit-ledger, and leaf changes require maintainer review; no agent self-approval or unattended bypass.
+
+### 3.7 Cost and benefit for one maintainer using coding agents
+
+| Effect | Assessment [I] |
+|---|---|
+| Review workload | Most algorithm/service work can be reviewed as safe Rust plus semantic tests. Invariant-changing native patches remain exceptional and receive concentrated review. This reduces the changing first-party unsafe surface, not the total transitive trusted code. |
+| Agent failure mode | Agents often copy raw-pointer/COM/SIMD examples or add unsafe Send to satisfy async bounds. Forbid fails the patch early; a task should explicitly demand owned-data/same-thread redesign rather than a lint waiver. |
+| Architectural overhead | One adapter, checked data types, private apartment/session ownership, a policy checker, and audit ledger are real work. They are cheaper than debugging undefined behavior spread across UI/DSP/jobs. This is an estimate, not measured effort. |
+| Runtime cost | Buffer ownership/copies, serialization, and thread messages may cost memory/time. Low-latency is not required here; measure before optimizing. Trait/crate boundaries do not inherently require copying or dynamic dispatch. |
+| Build cost | An extra small Rust leaf is unlikely to dominate Tauri/PyO3 compilation. Miri, rebuilt-std sanitizers, multiple OS/interpreter jobs, and cold audit-tool builds are the significant added CI costs. Cache pins; keep expensive tests selective. |
+| Residual failure | An upstream wrapper, driver, or macro may still be unsound; the process can still crash. “Quarantine like Tauri” is a review/ownership boundary, not a sandbox. |
+| Maintainer bottleneck | Independent automated review helps identify issues, but approval and any incomplete-audit risk acceptance remain explicit human decisions. Do not manufacture an audit record that overstates what one maintainer reviewed. |
+
+## 4 Risks ranked
+
+| Rank | Risk / status | Consequence | Mitigation / stop condition [I] |
+|---:|---|---|---|
+| 1 | **[V/I] Soundness mistaken for zero unsafe keywords**; dependencies/macros remain trusted [1,25–29,33] | Safe callers can still trigger upstream UB; green counts create false assurance | Review invariant owners and actual safe interfaces; do not claim full binary certification |
+| 2 | **[V/I] COM apartment, Release, packet, or shutdown error** [10–18] | Crash, dangling packet access, use after apartment teardown, hung capture | Thread-confined ownership; paired acquire/release; failure/leak/panic tests; hardware stress before release |
+| 3 | **[V/I] Python/NumPy concurrent mutation during copy or detached borrow** [22–29] | Data race/interpreter crash despite a safe Rust signature | Immutable/owned input default; qualified ndarray API; no SendWrapper; FT tests |
+| 4 | **[V/I] Unsound or incompletely reviewed upstream native API**; Tauri deprecated unmanage is concrete, wasapi packet concern remains unconfirmed [1,15,18] | Outer safe wrapper cannot repair internal UB | Ban known bad operation; investigate concerns; upstream patch/vendor minimal fix or stop adoption |
+| 5 | **[V/I] Policy circumvention through manifests/build scripts/macros/CI** [26,37–41] | Unsafe appears outside the leaf or checks silently weaken | Protected policy files, metadata/syntax fixtures, explicit macro inventory, required checks |
+| 6 | **[V/I] Miri/sanitizer coverage mistaken for COM proof** [59–60] | FFI-specific errors escape and get certified | Label native/model coverage separately; real Windows test matrix |
+| 7 | **[V/I] “Audited” dependency graph built from exemptions/trust** [42–45] | Review claims exceed evidence; native changes auto-approved | Strict custom criterion, scoped notes, no unattended exemptions/publisher wildcard soundness claims |
+| 8 | **[V/I] Toolchain/tool drift**; geiger locked dependency warning; Rust 1.98.0 compiler UB fix [54,69] | CI breakage or insecure tool; invalid release assumptions | Pin qualified stable/nightly/tools; periodic update review; tool failures visible |
+| 9 | **[I] Quarantine grows into generic unsafe utility library** | Python/SIMD/UI invariants mix; review becomes impractical | Windows-only purpose, budget tripwire, new ADR for a new domain |
+| 10 | **[I] Numerical semantics regress independently of memory safety** | Different BRIR despite no UB | Per-stage f64 golden arrays, exact discrete decisions, justified tolerances; keep Python SHA checks for Python regressions |
+
+**[I] Numerical parity reminder.** Rust/scipy cross-language SHA identity is not the acceptance criterion. Keep the existing research’s per-stage oracle comparison, exact crop/peak/layout decisions, waveform/FR/ILD/ITD tolerance checks, and optimizer response comparison. Treat provisional tolerances as measurements to qualify, not universal constants. Miri/ASan cannot detect wrong spline boundary conditions or a wrong normalization factor.
+
+## 5 Open questions you could not settle
+
+1. **[U] Is any handwritten unsafe actually necessary after the complete inventory?** wasapi already supplies the principal native operations, Tauri supplies theme changes, PyO3/numpy owned conversions exist, and RustFFT hides SIMD. The leaf reservation is conditional, not evidence that 12 operations are needed.
+2. **[U] wasapi 0.24.0 packet validity/SILENT handling:** source and native flags warrant focused review; a null/uninitialized-packet UB reproduction was not established. Do not label it a confirmed vulnerability from this report.
+3. **[U] Final COM guard design against all safe wasapi calls:** initial proposals need compile tests, leak/Drop-order review, and actual failure injection. Wrapper helper initialization can interact with existing thread apartment state.
+4. **[U] rust-numpy’s complete free-threaded input contract:** borrow docs and NumPy warnings do not establish exclusion against arbitrary native writers. Immutable payload input is the conservative initial choice; legacy ndarray API compatibility remains a product decision.
+5. **[U] Final resolved versions/MSRV/features:** no Cargo workspace was built. Versioned evidence is not a lockfile or a proof that every listed version interoperates.
+6. **[U] cargo-geiger 0.13.0 on Rust 1.98.1:** latest verified release is old relative to the compiler; documented 1.89 fix and an open install advisory warning do not establish current success or abandonment. Qualify separately or omit its non-gating report.
+7. **[U] Exact working dated nightly for Miri/ASan/TSan and Kani/Verus version:** select by pilot; no date/version was invented. The proposed command shapes are documented, not locally run.
+8. **[U] Dependency-audit availability:** no claim that current imported vet/crev audits cover all selected versions, features, generated code, or native hosts. Whole-framework strict review may exceed the maintainer’s capacity; record incomplete coverage honestly.
+9. **[U] Hardware and driver behavior:** 16-out/2-in on physical devices, shared conversion/exclusive fallback, 44.1/48/96 kHz, unplug/sleep, tails/drain, and repeated cancellation remain native acceptance work. Virtual-endpoint success in prior research is not universal hardware validation.
+10. **[U] DWM fallback need and API:** Tauri theme API exists, but exact titlebar behavior is not tested. Do not create speculative raw-handle code or promise a safe generic integer-HWND API.
+11. **[U] CI wall times and proof value:** all runtime estimates are planning ranges; no whole-DSP f64 formal proof is promised. Reduce fixtures if Miri/sanitizer jobs overwhelm review throughput, not their declared guarantees.
+12. **[V/U] Execution limitation:** web documentation and local sources were read; a grouped GitHub CLI metadata request required approval and did not execute. Release metadata was instead verified from primary web/package sources. No compilation, native tests, repository code changes, or CI changes were performed.
+
+## 6 Sources
+
+All sources were consulted for this report on **2026-09-07**, directly or by read-only research agents. Versioned URLs are preferred; `main`, `master`, and documentation portals are mutable snapshots. Local project files are named in §2.1; the supplied later audio decisions take precedence over older stack reports. Quotes are short extracts, not independent demonstrations of soundness.
+
+1. Tauri 2.11.5 source, unsafe use and deprecated unmanage: https://docs.rs/tauri/2.11.5/src/tauri/lib.rs.html
+2. tauri-runtime-wry 2.11.4 source, thread dispatch and unsafe trait implementations: https://docs.rs/tauri-runtime-wry/2.11.4/src/tauri_runtime_wry/lib.rs.html
+3. WRY 0.55.0 WebView2 native implementation: https://docs.rs/crate/wry/0.55.0/source/src/webview2/mod.rs
+4. tao 0.35.0 Windows window implementation: https://docs.rs/crate/tao/0.35.0/source/src/platform_impl/windows/window.rs
+5. tauri-runtime-wry 2.11.4 package/dependencies: https://docs.rs/crate/tauri-runtime-wry/2.11.4
+6. Tauri 2.11.5 Window API, set_theme: https://docs.rs/tauri/2.11.5/tauri/window/struct.Window.html#method.set_theme
+7. raw-window-handle 0.6.2 HasWindowHandle: https://docs.rs/raw-window-handle/0.6.2/raw_window_handle/trait.HasWindowHandle.html
+8. raw-window-handle 0.6.2 WindowHandle / borrow_raw: https://docs.rs/raw-window-handle/0.6.2/raw_window_handle/struct.WindowHandle.html
+9. raw-window-handle 0.6.2 legacy trait and raw enum: https://docs.rs/raw-window-handle/0.6.2/raw_window_handle/trait.HasRawWindowHandle.html ; https://docs.rs/raw-window-handle/0.6.2/raw_window_handle/enum.RawWindowHandle.html
+10. windows-core 0.62.0 Interface source: https://docs.rs/crate/windows-core/0.62.0/source/src/interface.rs
+11. windows-core 0.62.0 IUnknown source, Clone/Drop: https://docs.rs/crate/windows-core/0.62.0/source/src/unknown.rs
+12. Microsoft windows-rs IAudioClient API (mutable generated docs): https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/Media/Audio/struct.IAudioClient.html
+13. Microsoft COM processes, threads, and apartments: https://learn.microsoft.com/en-us/windows/win32/com/processes--threads--and-apartments
+14. Microsoft CoInitializeEx return/cleanup contract: https://learn.microsoft.com/en-us/windows/win32/api/combaseapi/nf-combaseapi-coinitializeex
+15. wasapi 0.24.0 pinned source, revision 63ad5a26c3f6bda360816e4b25a613fb94ca3f72: https://raw.githubusercontent.com/HEnquist/wasapi-rs/63ad5a26c3f6bda360816e4b25a613fb94ca3f72/src/api.rs
+16. wasapi 0.24.0 AudioClient and package metadata: https://docs.rs/wasapi/0.24.0/wasapi/struct.AudioClient.html ; https://docs.rs/crate/wasapi/0.24.0
+17. Microsoft IAudioCaptureClient GetBuffer and Release threading: https://learn.microsoft.com/en-us/windows/win32/api/audioclient/nf-audioclient-iaudiocaptureclient-getbuffer ; https://learn.microsoft.com/en-us/windows/win32/api/audioclient/nn-audioclient-iaudiocaptureclient
+18. Microsoft AUDCLNT_BUFFERFLAGS, SILENT semantics: https://learn.microsoft.com/en-us/windows/win32/api/audioclient/ne-audioclient-_audclnt_bufferflags
+19. CPAL 0.18.2 API and Windows Stream traits: https://docs.rs/cpal/0.18.2/cpal/ ; https://docs.rs/cpal/0.18.2/x86_64-pc-windows-msvc/cpal/platform/struct.Stream.html
+20. CPAL 0.18.2 changelog/upgrade notes: https://docs.rs/crate/cpal/0.18.2/source/CHANGELOG.md ; https://docs.rs/crate/cpal/0.18.2/source/UPGRADING.md
+21. CPAL pinned WASAPI device and 0.18.2 stream implementation: https://raw.githubusercontent.com/RustAudio/cpal/e1612d5d98152f8dc2a62e1b51ef7cbf4f7f26b7/src/host/wasapi/device.rs ; https://docs.rs/crate/cpal/0.18.2/source/src/host/wasapi/stream.rs
+22. PyO3 0.29.2 free-threading guide: https://pyo3.rs/v0.29.2/free-threading.html
+23. PyO3 Python attachment token (mutable latest documentation): https://docs.rs/pyo3/latest/pyo3/marker/struct.Python.html
+24. PyO3 Bound (mutable latest documentation): https://docs.rs/pyo3/latest/pyo3/struct.Bound.html
+25. PyO3 0.29.2 Ungil and stable SendWrapper limitation: https://docs.rs/pyo3/0.29.2/pyo3/marker/trait.Ungil.html
+26. PyO3 0.29.2 forbid compile-pass test; macro regression fix: https://raw.githubusercontent.com/PyO3/pyo3/v0.29.2/tests/ui/forbid_unsafe.rs ; https://github.com/PyO3/pyo3/pull/4574
+27. rust-numpy 0.29.0 PyArray / IntoPyArray constructors: https://docs.rs/numpy/0.29.0/numpy/array/struct.PyArray.html ; https://docs.rs/numpy/0.29.0/numpy/convert/trait.IntoPyArray.html
+28. rust-numpy 0.29.0 borrowing and implementation: https://docs.rs/numpy/0.29.0/numpy/borrow/index.html ; https://docs.rs/numpy/0.29.0/src/numpy/array.rs.html
+29. NumPy thread-safety guidance: https://numpy.org/doc/stable/reference/thread_safety.html
+30. RustFFT 6.4.1 planner and AVX planner: https://docs.rs/rustfft/6.4.1/src/rustfft/plan.rs.html ; https://docs.rs/rustfft/6.4.1/rustfft/struct.FftPlannerAvx.html
+31. RustFFT 6.4.1 SSE checked dispatch/kernels: https://docs.rs/rustfft/6.4.1/src/rustfft/sse/sse_radix4.rs.html ; https://docs.rs/rustfft/6.4.1/src/rustfft/sse/sse_common.rs.html
+32. Rust Reference target_feature and detection macro: https://doc.rust-lang.org/reference/attributes/codegen.html ; https://doc.rust-lang.org/std/macro.is_x86_feature_detected.html
+33. Rustonomicon, Working with Unsafe: https://doc.rust-lang.org/nomicon/working-with-unsafe.html
+34. Rustonomicon, Leaking / mem::forget: https://doc.rust-lang.org/nomicon/leaking.html
+35. Rustonomicon, Send and Sync: https://doc.rust-lang.org/nomicon/send-and-sync.html
+36. rustc unsafe_code lint: https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#unsafe-code
+37. rustc lint levels, forbid/caps/force-warn: https://doc.rust-lang.org/rustc/lints/levels.html
+38. Cargo workspace/package lint configuration: https://doc.rust-lang.org/cargo/reference/workspaces.html#the-lints-table ; https://doc.rust-lang.org/cargo/reference/manifest.html#the-lints-section
+39. Clippy undocumented unsafe blocks implementation: https://raw.githubusercontent.com/rust-lang/rust-clippy/master/clippy_lints/src/undocumented_unsafe_blocks.rs
+40. Clippy multiple unsafe operations per block implementation: https://raw.githubusercontent.com/rust-lang/rust-clippy/master/clippy_lints/src/multiple_unsafe_ops_per_block.rs
+41. Clippy missing_safety_doc implementation: https://raw.githubusercontent.com/rust-lang/rust-clippy/master/clippy_lints/src/doc/mod.rs
+42. cargo-vet built-in criteria: https://mozilla.github.io/cargo-vet/built-in-criteria.html
+43. cargo-vet custom criteria and policy configuration: https://mozilla.github.io/cargo-vet/config.html
+44. cargo-vet commands: https://mozilla.github.io/cargo-vet/commands.html
+45. cargo-vet publisher trust: https://mozilla.github.io/cargo-vet/trusting-publishers.html
+46. cargo-deny checks overview: https://embarkstudios.github.io/cargo-deny/
+47. cargo-deny CLI options: https://embarkstudios.github.io/cargo-deny/cli/common.html
+48. cargo-deny bans/wrappers semantics: https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
+49. cargo-deny 0.20.2 package and changelog: https://docs.rs/crate/cargo-deny/0.20.2 ; https://github.com/EmbarkStudios/cargo-deny/blob/main/CHANGELOG.md
+50. cargo-audit 0.22.2 release metadata: https://docs.rs/crate/cargo-audit/0.22.2
+51. cargo-audit project documentation: https://github.com/rustsec/rustsec/tree/main/cargo-audit
+52. cargo-geiger 0.13.0 package metadata: https://docs.rs/crate/cargo-geiger/0.13.0
+53. cargo-geiger changelog, Rust 1.89 compatibility fix: https://github.com/geiger-rs/cargo-geiger/blob/master/CHANGELOG.md
+54. cargo-geiger issue #564, vulnerable locked installation dependency warning: https://github.com/geiger-rs/cargo-geiger/issues/564
+55. cargo-geiger argument definitions: https://raw.githubusercontent.com/geiger-rs/cargo-geiger/master/cargo-geiger/src/args.rs
+56. geiger syntax inspection / scan implementation: https://raw.githubusercontent.com/geiger-rs/cargo-geiger/master/geiger/src/lib.rs ; https://raw.githubusercontent.com/geiger-rs/cargo-geiger/master/cargo-geiger/src/scan.rs
+57. cargo-crev 0.27.1 package metadata: https://docs.rs/crate/cargo-crev/0.27.1
+58. cargo-crev getting-started commands and trust: https://github.com/crev-dev/cargo-crev/blob/main/cargo-crev/src/doc/getting_started.md
+59. Miri README, support, setup and limitations: https://github.com/rust-lang/miri
+60. Rust sanitizer documentation: https://doc.rust-lang.org/unstable-book/compiler-flags/sanitizer.html
+61. Kani project and harness scope: https://github.com/model-checking/kani
+62. Kani invocation and unwinding: https://model-checking.github.io/kani/usage.html
+63. Verus project and supported-scope caveats: https://github.com/verus-lang/verus
+64. Rust 2024 unsafe_op_in_unsafe_fn default: https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html
+65. Rust 2024 unsafe extern blocks: https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-extern.html
+66. Rust 2024 unsafe attributes: https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-attributes.html
+67. Rust 2024 newly unsafe environment/process functions: https://doc.rust-lang.org/edition-guide/rust-2024/newly-unsafe-functions.html
+68. Rust 1.85.0 / edition 2024 announcement: https://blog.rust-lang.org/2025/02/20/Rust-1.85.0/
+69. Rust 1.98.1 compiler soundness fix, 2026-09-03: https://blog.rust-lang.org/2026/09/03/Rust-1.98.1/
+70. Cargo -Zbuild-std requirements: https://doc.rust-lang.org/cargo/reference/unstable.html#build-std
+71. Clippy CLI --no-deps and warning control: https://doc.rust-lang.org/clippy/usage.html
+72. wasapi 0.24.0 render-client safe buffer API: https://docs.rs/wasapi/0.24.0/wasapi/struct.AudioRenderClient.html
+73. RustFFT 6.4.1 Fft trait / buffer API: https://docs.rs/rustfft/6.4.1/rustfft/trait.Fft.html
+74. cargo-geiger purpose and limitations: https://github.com/geiger-rs/cargo-geiger
+75. cargo-vet 0.10.2 package metadata: https://docs.rs/crate/cargo-vet/0.10.2
+76. Clippy lint category/default table: https://rust-lang.github.io/rust-clippy/master/index.html


### PR DESCRIPTION
## 요약

재작성 스택 조사의 후속으로, Rust로 짤 때 손수 쓰는 `unsafe`를 0으로 유지할 수 있는지와 피할 수 없을 때의 격리 아키텍처를 ASTRA 워커 2기로 조사한 결과를 `docs/research/rewrite-stack-2026-09/`에 추가합니다.

- `03-rust-unsafe.md`: 한국어 종합. 결론은 모든 애플리케이션 크레이트에 `#![forbid(unsafe_code)]`가 가능하고, Windows 전용 leaf 크레이트 하나만 조건부 예외(초기 허용 0)라는 것입니다.
- `report-10-rust-unsafe-inventory.md`: 기능별 unsafe 인벤토리. wasapi-rs 0.24.0의 안전 함수 `WaveFormat::parse`와 캡처 read의 SILENT 처리가 건전하지 않다는 소스 진단이 있고, 원본 소스로 재확인했습니다.
- `report-11-rust-unsafe-quarantine.md`: 워크스페이스 배치, unsafe 예산, 린트·CI 게이트, 정책 초안.
- `brief-10`, `brief-11`: 작업서 원문.

문서만 바뀌므로 릴리스 게이트는 should_release=false로 끝나야 합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)