### PR TITLE
docs(adr): wasapi-rs 업스트림 이슈 결정 갱신 (Copilot 자동 리뷰 확인, WaveFormat::parse 건전성 문제 #65 보고)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ updater/
 3.x는 Rust 코어 + Tauri 2 셸로 재작성 중이다. 정본은 `docs/rust/ARCHITECTURE.md`와 `docs/adr/0002-rust-tauri-rewrite.md`이며, 조사 근거는 `docs/research/rewrite-stack-2026-09/`에 있다. 2.x Python 트리는 그대로 유지되고(오라클 역할), 저장소 루트의 `Cargo.toml` 워크스페이스에 `crates/*`와 `apps/impulcifer-app`이 추가됐다.
 
 - **IPC와 프론트엔드는 2.x 그대로다.** `webview_ui/`와 i18n 카탈로그는 수정하지 않는다. Tauri 커맨드는 `pywebview_api(method, args)` 하나이고 `apps/impulcifer-app/src/bridge.js`가 `window.pywebview.api`를 폴리필한다.
-- **unsafe는 손수 쓰지 않는다.** 모든 크레이트 루트에 `#![forbid(unsafe_code)]`. `unsafe-budget.toml`의 허용치는 전부 0이며 올리려면 ADR이 필요하다. wasapi-rs의 `WaveFormat::parse`, `Device::from_raw`는 쓰지 않는다. 업스트림 이슈는 올리지 않는다.
+- **unsafe는 손수 쓰지 않는다.** 모든 크레이트 루트에 `#![forbid(unsafe_code)]`. `unsafe-budget.toml`의 허용치는 전부 0이며 올리려면 ADR이 필요하다. wasapi-rs의 `WaveFormat::parse`, `Device::from_raw`는 쓰지 않는다. 업스트림에는 `parse`의 건전성 문제를 HEnquist/wasapi-rs#65로 보고했고(ADR 0002 7항), 그 밖의 이슈는 올리지 않는다.
 - **기능 게이트.** 새 기능은 반드시 루트 `features.toml`에 등록하고, `status = "implemented"`로 바꿀 때는 `tests = ["crate-name::test_fn"]`에 실제로 존재하는 검증 테스트를 적는다. `cargo test -p impulcifer-policy`가 누락을 실패로 만든다. 검증 테스트 없는 구현은 머지하지 않는다.
 - **Windows 오디오는 WASAPI만.** ASIO·DirectSound·MME 없음. exclusive 우선, shared+auto-convert 폴백.
 - **작업 분배.** unsafe 단인 `impulcifer-sys-win`은 Daybreak 워커, 나머지 크레이트(`impulcifer-audio-io` 포함)는 ASTRA 워커가 작업서 단위로 구현한다. 작업서는 `docs/rust/packets/`에 둔다.

--- a/docs/adr/0002-rust-tauri-rewrite.md
+++ b/docs/adr/0002-rust-tauri-rewrite.md
@@ -16,7 +16,7 @@
 4. **Windows 오디오는 WASAPI만 쓴다.** ASIO는 지원하지 않는다. DirectSound/MME 폴백도 없다. 백엔드는 wasapi-rs(exclusive 우선, shared+auto-convert 폴백), macOS/Linux는 cpal이다. PortAudio는 버린다.
 5. **PyPI를 유지한다.** PyO3 + maturin으로 DSP 코어를 wheel로 내고 CLI 진입점을 보존한다.
 6. **손수 쓰는 unsafe는 0이 기본이다.** 모든 크레이트가 `#![forbid(unsafe_code)]`로 시작한다. 예외 후보는 `impulcifer-sys-win` 하나뿐이며, 예외를 여는 것은 개별 승인 사항이다.
-7. **wasapi-rs의 불건전한 안전 API(`WaveFormat::parse`, `Device::from_raw`)는 어댑터에서 쓰지 않는다.** 업스트림 이슈는 올리지 않는다. 저장소에 AI 작성 이슈를 허용하는 명시적 분위기가 없기 때문이다(README·CONTRIBUTING·이슈 템플릿에 관련 언급 없음, 2026-09-07 확인).
+7. **wasapi-rs의 불건전한 안전 API(`WaveFormat::parse`, `Device::from_raw`)는 어댑터에서 쓰지 않는다.** 업스트림 이슈는 올리지 않는 것을 우선하되, 저장소가 AI 자동 리뷰를 받아들이는 분위기가 확인되면 올린다. 2026-09-07에는 README·CONTRIBUTING·이슈 템플릿에 관련 언급이 없어 올리지 않았다. 2026-09-08에 다시 확인하니 유지보수자가 자기 PR(#57, #60, #61, #64)에 GitHub Copilot 자동 리뷰를 켜 두고 있어 조건이 충족됐고, wasapi 0.24에서 `Device::from_raw`는 이미 `unsafe fn`이 됐지만 `WaveFormat::parse`는 `&WAVEFORMATEX`를 받아 그 뒤 22바이트를 더 읽는 안전 함수로 남아 있어(열린 이슈 #62는 24비트 폴백 문제라 별개) HEnquist/wasapi-rs#65로 보고했다(AI 도움으로 작성했음을 명시). 어댑터는 그대로 두 API를 쓰지 않는다.
 8. **기능 게이트.** 루트 `features.toml`에 모든 기능(IPC 메서드, 설정 필드, 파이프라인 스테이지, 출력물, 오디오 세션 동작)을 등록하고, `impulcifer-policy`의 게이트 테스트가 등록 누락과 검증 테스트 누락을 실패로 만든다. 구현된 기능에 검증 테스트가 하나라도 없으면 CI가 실패한다.
 9. **작업 분배.** unsafe 단(`impulcifer-sys-win`)과 오디오 백엔드는 Daybreak Blue 워커가, 나머지 크레이트는 ASTRA 워커가 작업서 단위로 구현한다. 아키텍처·작업서·검토·게이트·커밋은 Claude가 쥔다.
 10. **장치 문제는 실측한다.** `impulcifer-sys-win`의 `hardware_probe` 예제로 이 머신의 실제 장치에서 exclusive/shared, 44.1/48/96 kHz, 2/8/16채널을 재보고 결과를 문서에 남긴다.


### PR DESCRIPTION
## 요약

목표 5항의 조건을 다시 확인했습니다. wasapi-rs 유지보수자가 자기 PR(#57, #60, #61, #64)에 GitHub Copilot 자동 리뷰를 켜 두고 있어 AI 자동 리뷰를 받아들이는 분위기가 확인됐고, wasapi 0.24에서 `Device::from_raw`는 이미 `unsafe fn`이지만 `WaveFormat::parse`는 `&WAVEFORMATEX` 너머를 읽는 안전 함수로 남아 있어 HEnquist/wasapi-rs#65로 보고했습니다(열린 #62는 24비트 폴백 문제라 별개). ADR 0002 7항과 CLAUDE.md의 문장을 그 결정으로 갱신했습니다. 어댑터는 그대로 두 API를 쓰지 않습니다.

문서만 바꿨습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)