### PR TITLE
fix(ci): 스모크 하네스 출력 UTF-8 (업그레이드 러너의 UnicodeEncodeError)

### DIFF
--- a/.github/workflows/release-3x.yml
+++ b/.github/workflows/release-3x.yml
@@ -143,6 +143,9 @@ jobs:
 
       - name: Install the newest 2.x release, apply the 3.x package, start the 3.x app
         shell: pwsh
+        env:
+          PYTHONUTF8: "1"
+          PYTHONIOENCODING: utf-8
         run: |
           $ErrorActionPreference = 'Stop'
           $root = Join-Path $env:LOCALAPPDATA 'Impulcifer'

--- a/tests/app_smoke/smoke.py
+++ b/tests/app_smoke/smoke.py
@@ -442,6 +442,11 @@ class Smoke:
 
 
 def main():
+    # The driver records carry the UI's own strings (ellipsis, Korean labels); a
+    # cp1252 console on the Windows runners must not turn that into a harness error.
+    for stream in (sys.stdout, sys.stderr):
+        if hasattr(stream, "reconfigure"):
+            stream.reconfigure(encoding="utf-8", errors="replace")
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--exe", type=Path, required=True)
     parser.add_argument("--hardware", action="store_true")


### PR DESCRIPTION
## 요약

첫 수동 `release-3x.yml` 실행에서 업그레이드 검증 잡이 실패했습니다. 실제 경로는 전부 통과했습니다. 2.x v2.14.1 설치, 3.x 패키지를 `Update.exe`로 적용해 앱이 다시 뜨고, 하네스가 붙어 first-run·bootstrap·BRIR(hesuvi.wav 1344080바이트)·복구 단계까지 확인했습니다. 실패는 그다음 단계의 드라이버 기록에 줄임표와 한글이 들어 있는데 러너의 콘솔이 cp1252라 `print(json.dumps(..., ensure_ascii=False))`가 `UnicodeEncodeError`를 내고 하네스가 중단된 것입니다.

- `tests/app_smoke/smoke.py`: 시작 시 stdout/stderr를 UTF-8(errors=replace)로 재설정.
- `release-3x.yml`: 업그레이드 잡 단계에 `PYTHONUTF8=1`, `PYTHONIOENCODING=utf-8`.

머지 후 릴리스 워크플로를 다시 실행합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)