### PR TITLE
fix(ci): 스모크 드라이버 updates 단계를 실제 업데이트 확인 계약으로

### DIFF
--- a/tests/app_smoke/driver.js
+++ b/tests/app_smoke/driver.js
@@ -111,14 +111,26 @@
         });
         await step("updates", async () => {
           await navigate("info"); const start = observer.events.length; click("#btn-check-updates");
-          const expected = "INTERNAL_ERROR: check_for_updates not implemented";
-          await wait(() => node("#update-check-status").textContent === expected, "update error display");
+          // The button sets the "checking" line synchronously; the check itself is real since P20
+          // (GitHub releases): it settles as "up to date", as the update modal, or as an error
+          // line when the network is unavailable. Any of those passes; the envelope must be
+          // well-formed and the UI must leave the checking state.
+          const status = node("#update-check-status");
+          const checking = status.textContent;
+          await wait(() => responses("check_for_updates", start).length === 1, "update check response");
           const result = responses("check_for_updates", start);
           const actual = result[0]?.response;
-          assert(result.length === 1 && actual.ok === false && actual.error.code === "INTERNAL_ERROR"
-            && actual.error.message === "check_for_updates not implemented" && actual.error.retryable === false
-            && Object.keys(actual.error.details).length === 0, `update envelope: ${JSON.stringify(result)}`);
-          return { ui_text: expected, expected_envelope: result[0].response };
+          const okShape = !!actual && actual.ok === true && !!actual.data
+            && typeof actual.data.update_available === "boolean" && typeof actual.data.current_version === "string";
+          const errShape = !!actual && actual.ok === false && !!actual.error
+            && typeof actual.error.message === "string" && actual.error.message.length > 0;
+          assert(okShape || errShape, `update envelope: ${JSON.stringify(result)}`);
+          await wait(() => status.hidden || status.textContent !== checking
+            || !node("#update-modal").hidden, "update status settled");
+          const modal = !node("#update-modal").hidden;
+          assert(!okShape || actual.data.update_available === modal,
+            `update modal ${modal} does not match update_available ${actual.data && actual.data.update_available}`);
+          return { ui_text: modal ? "modal" : status.textContent, modal, envelope: actual };
         });
         if (params.hardware) await step("recording", async () => {
           await navigate("recorder"); const devices = {};

--- a/tests/app_smoke/in_app.py
+++ b/tests/app_smoke/in_app.py
@@ -8,7 +8,7 @@ import tempfile
 import time
 import traceback
 
-from smoke import ROOT, INPUTS, UPDATE_ERROR, Smoke, frozen_hashes, wav_info, write_json
+from smoke import ROOT, INPUTS, Smoke, frozen_hashes, real_update_check, wav_info, write_json
 from win32_capture import capture, accept_confirmation
 
 
@@ -109,7 +109,9 @@ class InAppSmoke(Smoke):
                 shutil.copy2(self.recording / "headphones.wav", self.output / "headphones.wav")
                 result["verified"] = info
             elif name == "updates":
-                assert record["details"]["expected_envelope"] == UPDATE_ERROR
+                envelope = record["details"]["envelope"]
+                assert real_update_check(envelope), envelope
+                result["verified"] = {"ok": envelope.get("ok"), "ui_text": record["details"].get("ui_text")}
         except Exception as error:
             result.update(ok=False, error=str(error), traceback=traceback.format_exc())
         if name == "recording-ready":
@@ -172,7 +174,7 @@ class InAppSmoke(Smoke):
         report.touch()
         params = {"demo": str(self.demo), "recovery": str(self.recovery),
                   "recording": str(self.recording), "hardware": self.hardware,
-                  "en": self.en, "update_error": UPDATE_ERROR,
+                  "en": self.en,
                   "labels": {code: json.loads((ROOT / f"i18n/locales/{code}.json").read_text(encoding="utf-8"))["label_select_language"] for code in ("ko", "en")}}
         param_file = self.output / "params.json"
         write_json(param_file, params)

--- a/tests/app_smoke/smoke.py
+++ b/tests/app_smoke/smoke.py
@@ -30,11 +30,18 @@ INPUTS = (
     "room-mic-calibration.txt", "eq.csv", "eq.txt", "eq-left.csv", "eq-left.txt",
     "eq-right.csv", "eq-right.txt",
 )
-UPDATE_ERROR = {
-    "ok": False,
-    "error": {"code": "INTERNAL_ERROR", "message": "check_for_updates not implemented",
-              "details": {}, "retryable": False},
-}
+
+
+def real_update_check(envelope):
+    """Since P20 check_for_updates is real (GitHub releases): a well-formed answer either
+    way passes, whether the runner has network (up to date / update available) or not."""
+    if not isinstance(envelope, dict):
+        return False
+    if envelope.get("ok") is True:
+        data = envelope.get("data") or {}
+        return isinstance(data.get("update_available"), bool) and isinstance(data.get("current_version"), str)
+    error = envelope.get("error") or {}
+    return envelope.get("ok") is False and isinstance(error.get("message"), str) and bool(error.get("message"))
 
 
 def write_json(path, value):
@@ -344,14 +351,19 @@ class Smoke:
         self.navigate("info")
         self.collect()
         event_start = len(self.events)
+        checking = self.page.locator("#update-check-status").text_content()
         self.page.locator("#btn-check-updates").click()
-        expected = "INTERNAL_ERROR: check_for_updates not implemented"
-        self.page.wait_for_function("expected => document.querySelector('#update-check-status').textContent === expected", arg=expected)
+        self.page.wait_for_function(
+            "checking => { const s = document.querySelector('#update-check-status');"
+            " return s.hidden || s.textContent !== checking || !document.querySelector('#update-modal').hidden; }",
+            arg=checking)
         self.collect()
         responses = [e["response"] for e in self.events[event_start:] if e["kind"] == "ipc-response"
                      and e["method"] == "check_for_updates"]
-        assert responses and all(r == UPDATE_ERROR for r in responses), responses
-        return {"ui_text": expected, "expected_envelope": responses[-1]}
+        assert len(responses) == 1 and real_update_check(responses[0]), responses
+        modal = self.page.evaluate("!document.querySelector('#update-modal').hidden")
+        text = "modal" if modal else self.page.locator("#update-check-status").text_content()
+        return {"ui_text": text, "modal": modal, "envelope": responses[0]}
 
     def recording(self):
         if not self.hardware:


### PR DESCRIPTION
## 요약

두 번째 수동 `release-3x.yml` 실행(34287262319)에서 PyPI 발행은 성공했고(`impulcifer-py313` 3.0.0a0, 사전 출시라 `pip install --pre`로만 받음), 업그레이드 검증 러너는 2.x 설치 → 3.x 적용·재시작 → first-run·bootstrap·BRIR·복구·설정(ko/en)까지 통과한 뒤 `updates` 단계에서 실패했습니다. 드라이버가 P20 이전의 `INTERNAL_ERROR: check_for_updates not implemented` 표시를 기대했는데, 지금 앱은 GitHub 릴리스를 실제로 조회해 `update_available: false`(최신 2.14.1)를 돌려주므로 15초 타임아웃이 났습니다.

- `driver.js`: 응답 하나가 오고 잘 짜인 봉투인지(ok+data.update_available/current_version, 또는 ok:false+error.message) 확인하고, 상태 줄이 checking 문구에서 벗어나거나 모달이 뜨면 정착으로 봅니다. 모달 여부가 `update_available`과 일치해야 합니다.
- `smoke.py`/`in_app.py`: `UPDATE_ERROR` 상수를 `real_update_check()` 형태 검사로 대체(CDP 모드도 동일).

`node --check`, ruff, `cargo test -p impulcifer-app --test smoke` 통과. 머지 후 릴리스 워크플로를 다시 실행합니다(PyPI는 skip-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)